### PR TITLE
🐛fix #6/CORAL-158 SideNav on Examples page is not keyboard accessible

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -20,7 +20,8 @@
       padding-left: 24px;
       overflow: scroll;
       background-color: rgb(250, 250, 250);
-      transition: transform 160ms ease-in-out;
+      visibility: visible;
+      transition: visibility 0ms linear 160ms, transform 160ms ease-in-out;
       position: relative;
       z-index: 10;
     }
@@ -86,12 +87,11 @@
     }
 
     .nav-toggle-header .toggle-icon {
-      height: 22px;
-      width: 22px !important;
+      height: 36px;
+      width: 36px;
       fill: currentColor;
       color: rgb(110, 110, 110);
-      padding: 16px;
-      left: 0;
+      left: 4px;
       position: absolute;
       cursor: pointer;
     }
@@ -150,10 +150,13 @@
 
       .example-List {
         transform: translateX(-100%);
+        visibility: hidden;
       }
 
       .example-List.is-open {
         transform: translateX(0);
+        transition-delay: 0;
+        visibility: visible;
       }
 
       .example-List coral-search {
@@ -165,28 +168,21 @@
 </head>
 <body class="coral--lightest">
   <div class="nav-toggle-overlay" id="nav-toggle-overlay"></div>
-  <div class="nav-toggle-header">
-    <svg id="nav-toggle-action" class="toggle-icon" viewBox="0 0 36 36" focusable="false" aria-hidden="true" role="img" class="spectrum-Icon spectrum-Icon--sizeS">
-      <rect height="4" rx="1" ry="1" width="28" x="4" y="16"></rect>
-      <rect height="4" rx="1" ry="1" width="28" x="4" y="6"></rect>
-      <rect height="4" rx="1" ry="1" width="28" x="4" y="26"></rect>
-    </svg>
-
+  <div class="nav-toggle-header" role="banner">
     <a href="../documentation">
-      <svg class="adobe-icon" viewBox="0 0 30 26" focusable="false"
-           aria-hidden="true" aria-label="Adobe logo">
+      <svg class="adobe-icon" viewBox="0 0 30 26" focusable="false" aria-label="Adobe" role="img">
         <polygon points="19,0 30,0 30,26"></polygon>
         <polygon points="11.1,0 0,0 0,26"></polygon>
         <polygon points="15,9.6 22.1,26 17.5,26 15.4,20.8 10.2,20.8"></polygon>
       </svg>
       <h1>Coral Spectrum</h1>
     </a>
+    <button is="coral-button" variant="quietaction" icon="spectrum-css-icon-TripleGripper" id="nav-toggle-action" class="toggle-icon" aria-label="Show Navigation Menu"></button>
   </div>
 
-  <div id="side-nav" class="example-List">
+  <div id="side-nav" class="example-List" role="complementary">
     <a class="example-Logo" href="../documentation">
-      <svg viewBox="0 0 30 26" focusable="false"
-           aria-hidden="true" aria-label="Adobe logo">
+      <svg viewBox="0 0 30 26" focusable="false" aria-label="Adobe" role="img">
         <polygon points="19,0 30,0 30,26"></polygon>
         <polygon points="11.1,0 0,0 0,26"></polygon>
         <polygon points="15,9.6 22.1,26 17.5,26 15.4,20.8 10.2,20.8"></polygon>
@@ -195,11 +191,14 @@
       <h1>Coral Spectrum</h1>
     </a>
 
-    <coral-search id="example-search" placeholder="Search"></coral-search>
+    <label id="example-search-label" class="u-coral-screenReaderOnly">Search</label>
+    <coral-search id="example-search" placeholder="Search" role="search" labelledBy="example-search-label"></coral-search>
 
     <nav is="coral-sidenav" id="example-list"></nav>
   </div>
-  <iframe class="example-Preview" id="example-preview"></iframe>
+  <main id="example-main">
+    <iframe class="example-Preview" id="example-preview" title="Example Preview"></iframe>
+  </main>
 
   <script>
     const sideNav = document.getElementById('side-nav');
@@ -209,11 +208,15 @@
     navToggleAction.addEventListener('click', function() {
       sideNav.classList.toggle('is-open', !sideNav.classList.contains('is-open'));
       navToggleOverlay.classList.toggle('is-open', !navToggleOverlay.classList.contains('is-open'));
+      navToggleAction.setAttribute('aria-expanded', sideNav.classList.contains('is-open'));
+      navToggleAction.selected = sideNav.classList.contains('is-open');
     });
 
     navToggleOverlay.addEventListener('click', function() {
       sideNav.classList.toggle('is-open', !sideNav.classList.contains('is-open'));
       navToggleOverlay.classList.toggle('is-open', !navToggleOverlay.classList.contains('is-open'));
+      navToggleAction.setAttribute('aria-expanded', sideNav.classList.contains('is-open'));
+      navToggleAction.selected = sideNav.classList.contains('is-open');
     });
 
     const components = [
@@ -273,6 +276,7 @@
     ];
 
     const list = document.getElementById('example-list');
+    const main = document.getElementById('example-main');
     const preview = document.getElementById('example-preview');
     const search = document.getElementById('example-search');
 
@@ -296,13 +300,19 @@
 
     components.forEach(function(component) {
       const name = component.split('-').pop();
+      const selected = location.hash.slice(1) === name;
       const item = list.items.add({
         content: {
           textContent: name
         },
-        selected: location.hash.slice(1) === name
+        selected: selected,
+        href: '../' + component + '/examples/index.html',
+        ariaCurrent: (selected ? 'page' : undefined)
       });
-      item.setAttribute('src', '../' + component + '/examples/index.html');
+      selected && item.setAttribute('aria-current', 'page');
+      item.on('click', function(event) {
+        event.preventDefault()
+      });
     });
 
     list.on('coral-sidenav:change', function(event) {
@@ -313,13 +323,26 @@
           location.hash = event.detail.selection.textContent.trim();
 
           requestAnimationFrame(function() {
-            sideNav.classList.remove('is-open');
-            navToggleOverlay.classList.remove('is-open');
+            if (sideNav.classList.contains('is-open')) {
+              sideNav.classList.remove('is-open');
+              navToggleOverlay.classList.remove('is-open');
+              navToggleAction.setAttribute('aria-expanded', false);
+              navToggleAction.selected = false;
+              navToggleAction.focus();
+            }
           });
         }
       };
 
-      XMLHttpRequest.open('GET', event.detail.selection.getAttribute('src'), true);
+      // update aria-current to reflect current page.
+      let currentItem = event.currentTarget.querySelector('[aria-current]');
+      currentItem && currentItem.removeAttribute('aria-current');
+      event.detail.selection.setAttribute('aria-current', 'page');
+
+      // update the main region to give it a unique label
+      main.setAttribute('aria-label', event.detail.selection.textContent);
+
+      XMLHttpRequest.open('GET', event.detail.selection.getAttribute('href'), true);
       XMLHttpRequest.send();
     });
   </script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -20,8 +20,7 @@
       padding-left: 24px;
       overflow: scroll;
       background-color: rgb(250, 250, 250);
-      visibility: visible;
-      transition: visibility 0ms linear 160ms, transform 160ms ease-in-out;
+      transition: transform 160ms ease-in-out;
       position: relative;
       z-index: 10;
     }
@@ -149,14 +148,25 @@
       }
 
       .example-List {
+        overflow: hidden;
         transform: translateX(-100%);
-        visibility: hidden;
       }
 
       .example-List.is-open {
+        overflow: auto;
         transform: translateX(0);
-        transition-delay: 0;
+      }
+
+      .example-List > * {
+        transition: visibility 0ms linear 500ms;
+        visibility: hidden;
+
+      }
+
+      .example-List.is-open > * {
+        transition-delay: 0ms;
         visibility: visible;
+
       }
 
       .example-List coral-search {
@@ -180,7 +190,7 @@
     <button is="coral-button" variant="quietaction" icon="spectrum-css-icon-TripleGripper" id="nav-toggle-action" class="toggle-icon" aria-label="Show Navigation Menu"></button>
   </div>
 
-  <div id="side-nav" class="example-List" role="complementary">
+  <div id="side-nav" class="example-List" role="navigation" aria-label="Navigation Menu">
     <a class="example-Logo" href="../documentation">
       <svg viewBox="0 0 30 26" focusable="false" aria-label="Adobe" role="img">
         <polygon points="19,0 30,0 30,26"></polygon>
@@ -201,150 +211,148 @@
   </main>
 
   <script>
-    const sideNav = document.getElementById('side-nav');
-    const navToggleAction = document.getElementById('nav-toggle-action');
-    const navToggleOverlay = document.getElementById('nav-toggle-overlay');
+    (function(window, document) {
+      const sideNav = document.getElementById('side-nav');
+      const navToggleAction = document.getElementById('nav-toggle-action');
+      const navToggleOverlay = document.getElementById('nav-toggle-overlay');
 
-    navToggleAction.addEventListener('click', function() {
-      sideNav.classList.toggle('is-open', !sideNav.classList.contains('is-open'));
-      navToggleOverlay.classList.toggle('is-open', !navToggleOverlay.classList.contains('is-open'));
-      navToggleAction.setAttribute('aria-expanded', sideNav.classList.contains('is-open'));
-      navToggleAction.selected = sideNav.classList.contains('is-open');
-    });
+      function toggleSideNav() {
+        sideNav.classList.toggle('is-open', !sideNav.classList.contains('is-open'));
+        navToggleOverlay.classList.toggle('is-open', !navToggleOverlay.classList.contains('is-open'));
+        navToggleAction.setAttribute('aria-expanded', sideNav.classList.contains('is-open'));
+        navToggleAction.selected = sideNav.classList.contains('is-open');
+      }
 
-    navToggleOverlay.addEventListener('click', function() {
-      sideNav.classList.toggle('is-open', !sideNav.classList.contains('is-open'));
-      navToggleOverlay.classList.toggle('is-open', !navToggleOverlay.classList.contains('is-open'));
-      navToggleAction.setAttribute('aria-expanded', sideNav.classList.contains('is-open'));
-      navToggleAction.selected = sideNav.classList.contains('is-open');
-    });
+      navToggleAction.addEventListener('click', toggleSideNav);
+      navToggleOverlay.addEventListener('click', toggleSideNav);
 
-    const components = [
-      'coral-component-accordion',
-      'coral-component-actionbar',
-      'coral-component-alert',
-      'coral-component-anchorbutton',
-      'coral-component-autocomplete',
-      'coral-component-banner',
-      'coral-component-button',
-      'coral-component-buttongroup',
-      'coral-component-calendar',
-      'coral-component-card',
-      'coral-component-charactercount',
-      'coral-component-checkbox',
-      'coral-component-clock',
-      'coral-component-coachmark',
-      'coral-component-colorinput',
-      'coral-component-columnview',
-      'coral-component-cyclebutton',
-      'coral-component-datepicker',
-      'coral-component-dialog',
-      'coral-component-drawer',
-      'coral-component-fileupload',
-      'coral-component-icon',
-      'coral-component-list',
-      'coral-component-masonry',
-      'coral-component-multifield',
-      'coral-component-numberinput',
-      'coral-component-overlay',
-      'coral-component-panelstack',
-      'coral-component-popover',
-      'coral-component-progress',
-      'coral-component-quickactions',
-      'coral-component-radio',
-      'coral-component-search',
-      'coral-component-select',
-      'coral-component-sidenav',
-      'coral-component-shell',
-      'coral-component-slider',
-      'coral-component-splitbutton',
-      'coral-component-status',
-      'coral-component-steplist',
-      'coral-component-switch',
-      'coral-component-table',
-      'coral-component-tablist',
-      'coral-component-tabview',
-      'coral-component-taglist',
-      'coral-component-textarea',
-      'coral-component-textfield',
-      'coral-component-toast',
-      'coral-component-tooltip',
-      'coral-component-tree',
-      'coral-component-wait',
-      'coral-component-wizardview',
-      'coral-dragaction'
-    ];
+      const components = [
+        'coral-component-accordion',
+        'coral-component-actionbar',
+        'coral-component-alert',
+        'coral-component-anchorbutton',
+        'coral-component-autocomplete',
+        'coral-component-banner',
+        'coral-component-button',
+        'coral-component-buttongroup',
+        'coral-component-calendar',
+        'coral-component-card',
+        'coral-component-charactercount',
+        'coral-component-checkbox',
+        'coral-component-clock',
+        'coral-component-coachmark',
+        'coral-component-colorinput',
+        'coral-component-columnview',
+        'coral-component-cyclebutton',
+        'coral-component-datepicker',
+        'coral-component-dialog',
+        'coral-component-drawer',
+        'coral-component-fileupload',
+        'coral-component-icon',
+        'coral-component-list',
+        'coral-component-masonry',
+        'coral-component-multifield',
+        'coral-component-numberinput',
+        'coral-component-overlay',
+        'coral-component-panelstack',
+        'coral-component-popover',
+        'coral-component-progress',
+        'coral-component-quickactions',
+        'coral-component-radio',
+        'coral-component-search',
+        'coral-component-select',
+        'coral-component-sidenav',
+        'coral-component-shell',
+        'coral-component-slider',
+        'coral-component-splitbutton',
+        'coral-component-status',
+        'coral-component-steplist',
+        'coral-component-switch',
+        'coral-component-table',
+        'coral-component-tablist',
+        'coral-component-tabview',
+        'coral-component-taglist',
+        'coral-component-textarea',
+        'coral-component-textfield',
+        'coral-component-toast',
+        'coral-component-tooltip',
+        'coral-component-tree',
+        'coral-component-wait',
+        'coral-component-wizardview',
+        'coral-dragaction'
+      ];
 
-    const list = document.getElementById('example-list');
-    const main = document.getElementById('example-main');
-    const preview = document.getElementById('example-preview');
-    const search = document.getElementById('example-search');
+      const list = document.getElementById('example-list');
+      const main = document.getElementById('example-main');
+      const preview = document.getElementById('example-preview');
+      const search = document.getElementById('example-search');
 
-    search.on('coral-search:input', function(event) {
-      const value = event.target.value.trim();
-      list.items.getAll().forEach(function(item) {
-        if (item.content.textContent.trim().indexOf(value) !== 0) {
-          item.hidden = true;
-        }
-        else {
+      search.on('coral-search:input', function(event) {
+        const value = event.target.value.trim();
+        list.items.getAll().forEach(function(item) {
+          if (item.content.textContent.trim().indexOf(value) !== 0) {
+            item.hidden = true;
+          }
+          else {
+            item.hidden = false;
+          }
+        });
+      });
+
+      search.on('coral-search:clear', function() {
+        list.items.getAll().forEach(function(item) {
           item.hidden = false;
-        }
+        });
       });
-    });
 
-    search.on('coral-search:clear', function() {
-      list.items.getAll().forEach(function(item) {
-        item.hidden = false;
+      components.forEach(function(component) {
+        const name = component.split('-').pop();
+        const selected = location.hash.slice(1) === name;
+        const item = list.items.add({
+          content: {
+            textContent: name
+          },
+          selected: selected,
+          href: '../' + component + '/examples/index.html',
+          ariaCurrent: (selected ? 'page' : undefined)
+        });
+        selected && item.setAttribute('aria-current', 'page');
+        item.on('click', function(event) {
+          event.preventDefault()
+        });
       });
-    });
 
-    components.forEach(function(component) {
-      const name = component.split('-').pop();
-      const selected = location.hash.slice(1) === name;
-      const item = list.items.add({
-        content: {
-          textContent: name
-        },
-        selected: selected,
-        href: '../' + component + '/examples/index.html',
-        ariaCurrent: (selected ? 'page' : undefined)
+      list.on('coral-sidenav:change', function(event) {
+        const XMLHttpRequest = new window.XMLHttpRequest();
+        XMLHttpRequest.onreadystatechange = function() {
+          if (XMLHttpRequest.readyState == 4 && XMLHttpRequest.status == 200) {
+            preview.srcdoc = this.responseText;
+            location.hash = event.detail.selection.textContent.trim();
+
+            requestAnimationFrame(function() {
+              if (sideNav.classList.contains('is-open')) {
+                sideNav.classList.remove('is-open');
+                navToggleOverlay.classList.remove('is-open');
+                navToggleAction.setAttribute('aria-expanded', false);
+                navToggleAction.selected = false;
+                navToggleAction.focus();
+              }
+            });
+          }
+        };
+
+        // update aria-current to reflect current page.
+        let currentItem = event.currentTarget.querySelector('[aria-current]');
+        currentItem && currentItem.removeAttribute('aria-current');
+        event.detail.selection.setAttribute('aria-current', 'page');
+
+        // update the main region to give it a unique label
+        main.setAttribute('aria-label', event.detail.selection.textContent);
+
+        XMLHttpRequest.open('GET', event.detail.selection.getAttribute('href'), true);
+        XMLHttpRequest.send();
       });
-      selected && item.setAttribute('aria-current', 'page');
-      item.on('click', function(event) {
-        event.preventDefault()
-      });
-    });
-
-    list.on('coral-sidenav:change', function(event) {
-      const XMLHttpRequest = new window.XMLHttpRequest();
-      XMLHttpRequest.onreadystatechange = function() {
-        if (XMLHttpRequest.readyState == 4 && XMLHttpRequest.status == 200) {
-          preview.srcdoc = this.responseText;
-          location.hash = event.detail.selection.textContent.trim();
-
-          requestAnimationFrame(function() {
-            if (sideNav.classList.contains('is-open')) {
-              sideNav.classList.remove('is-open');
-              navToggleOverlay.classList.remove('is-open');
-              navToggleAction.setAttribute('aria-expanded', false);
-              navToggleAction.selected = false;
-              navToggleAction.focus();
-            }
-          });
-        }
-      };
-
-      // update aria-current to reflect current page.
-      let currentItem = event.currentTarget.querySelector('[aria-current]');
-      currentItem && currentItem.removeAttribute('aria-current');
-      event.detail.selection.setAttribute('aria-current', 'page');
-
-      // update the main region to give it a unique label
-      main.setAttribute('aria-label', event.detail.selection.textContent);
-
-      XMLHttpRequest.open('GET', event.detail.selection.getAttribute('href'), true);
-      XMLHttpRequest.send();
-    });
+    })(window, document);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Description

### Expected Behavior

User should be able to navigate through SideNav items using the Tab key, and SideNav items should be identified a links using assistive technology.

### Actual Behavior

SideNav items are skipped entirely. Using a screen reader the SideNav items are identified as static text.

Note: this commit includes a few other small accessibility fixes to:

1. Control visibility of sidenav when it is collapsed in responsive mode. A user should not be able to tab to items in a collapses side nav.
2. Use an actual button that communicates state for the navigation toggle button
3. Improve labelling of Search control
4. Improve labelling of Adobe logo
5. Add landmark regions

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
#6 / [CORAL-158](https://jira.corp.adobe.com/browse/CORAL-158)

## Motivation and Context
Example documentation for Coral Spectrum components should be accessible.

## How Has This Been Tested?
These changes apply to the Component example documentation which has been evaluated using aXe browser extension for Chrome and manually tested using VoiceOver in Chrome and Safari on macOS.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
