### PR TITLE
CUI-7340 [Accessibility] Coral.Select should be tabbable after initialization

### DIFF
--- a/coral-base-overlay/src/scripts/BaseOverlay.js
+++ b/coral-base-overlay/src/scripts/BaseOverlay.js
@@ -893,7 +893,7 @@ const BaseOverlay = (superClass) => class extends superClass {
     }
   
     // If the element is not focusable,
-    if (element.offsetParent === null || !element.matches(commons.FOCUSABLE_ELEMENT_SELECTOR)) {
+    if (!element.matches(commons.FOCUSABLE_ELEMENT_SELECTOR)) {
       // add tabindex so that it is programmatically focusable.
       element.setAttribute('tabindex', -1);
     


### PR DESCRIPTION
When the coral-base-overlay initializes, but the element called with the `returnFocusTo` method is not yet in the DOM, the element will receive `tabindex="-1"` even if it would be focusable following initialization and render.

This can be seen on: https://opensource.adobe.com/coral-spectrum/dist/examples/coral-component-select.html, where the Select buttons are not tabbable after the page loads.

See: https://git.corp.adobe.com/Coral/coralui-mixin-overlay/commit/6e14b827c6ff163e65f24ee526cae2d0bb09b555#r161631, where tabindex="-1" is added after evaluating element.parentNode === null and https://github.com/adobe/coral-spectrum/blob/master/coral-base-overlay/src/scripts/BaseOverlay.js#L896

## Description
Remove `element.parentNode === null` test in `BaseOverlay.returnFocusTo()` method.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7340

## Motivation and Context
Coral.Select component will not be tabbable, when they initialize before being rendered.

## How Has This Been Tested?
The bug can be reproduced on: https://opensource.adobe.com/coral-spectrum/dist/examples/coral-component-select.html, where the Select buttons are not tabbable after the page loads.

But is fixed on: http://127.0.0.1:9001/examples/#select

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
