### PR TITLE
CUI-7343 [Accessibility] Coral.CycleButton dropdown should behave as a single menu

### DIFF
--- a/coral-component-cyclebutton/examples/index.html
+++ b/coral-component-cyclebutton/examples/index.html
@@ -51,17 +51,17 @@
 
       <h1 class="coral-Heading coral-Heading--1">CycleButton</h1>
 
-      <h2 class="coral-Heading coral-Heading--2">Default</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-0" for="cyclebutton-0-button">Default</label></h2>
       <div class="markup">
-        <coral-cyclebutton>
+        <coral-cyclebutton aria-labelledby="label-0" id="cyclebutton-0">
           <coral-cyclebutton-item icon="add">Add</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="remove">Remove</coral-cyclebutton-item>
         </coral-cyclebutton>
       </div>
 
-      <h2 class="coral-Heading coral-Heading--2">With content and pre-selected item</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-1" for="cyclebutton-1-button">With content and pre-selected item</label></h2>
       <div class="markup">
-        <coral-cyclebutton>
+        <coral-cyclebutton aria-labelledby="label-1" id="cyclebutton-1">
           <coral-cyclebutton-item icon="viewCard">Card View</coral-cyclebutton-item>
           <coral-cyclebutton-item>Grid looooooooooooooong View</coral-cyclebutton-item>
           <coral-cyclebutton-item selected icon="viewList">List View</coral-cyclebutton-item>
@@ -69,9 +69,9 @@
         </coral-cyclebutton>
       </div>
 
-      <h2 class="coral-Heading coral-Heading--2">With threshold=0</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-2" for="cyclebutton-2-button">With threshold=0</label></h2>
       <div class="markup">
-        <coral-cyclebutton threshold="0">
+        <coral-cyclebutton threshold="0" aria-labelledby="label-2" id="cyclebutton-2">
           <coral-cyclebutton-item icon="viewCard">Card View</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="viewGrid">Grid View</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="viewList">List View</coral-cyclebutton-item>
@@ -79,17 +79,17 @@
         </coral-cyclebutton>
       </div>
 
-      <h2 class="coral-Heading coral-Heading--2">With displayMode=icontext</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-3" for="cyclebutton-3-button">With displayMode=icontext</label></h2>
       <div class="markup">
-        <coral-cyclebutton displaymode="icontext">
+        <coral-cyclebutton displaymode="icontext" aria-labelledby="label-3" id="cyclebutton-3">
           <coral-cyclebutton-item icon="deviceRotatePortrait">Portrait</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="deviceRotateLandscape">Landscape</coral-cyclebutton-item>
         </coral-cyclebutton>
       </div>
 
-      <h2 class="coral-Heading coral-Heading--2">With additional actions</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-4" for="cyclebutton-4-button">With additional actions</label></h2>
       <div class="markup">
-        <coral-cyclebutton displaymode="icontext">
+        <coral-cyclebutton displaymode="icontext" aria-labelledby="label-4" id="cyclebutton-4">
           <coral-cyclebutton-item icon="viewCard">Card View</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="viewGrid">Grid View</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="viewList">List View</coral-cyclebutton-item>
@@ -99,9 +99,9 @@
         </coral-cyclebutton>
       </div>
 
-      <h2 class="coral-Heading coral-Heading--2">With multiple display modes</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-5" for="cyclebutton-5-button">With multiple display modes</label></h2>
       <div class="markup">
-        <coral-cyclebutton displayMode="icontext">
+        <coral-cyclebutton displayMode="icontext" aria-labelledby="label-5" id="cyclebutton-5">
           <coral-cyclebutton-item icon="viewCard" displayMode="icon">Card View</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="viewGrid">Grid View</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="viewList">List View</coral-cyclebutton-item>
@@ -109,9 +109,9 @@
         </coral-cyclebutton>
       </div>
 
-      <h2 class="coral-Heading coral-Heading--2">With a general icon</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-6" for="cyclebutton-6-button">With a general icon</label></h2>
       <div class="markup">
-        <coral-cyclebutton icon="apps">
+        <coral-cyclebutton icon="apps" aria-labelledby="label-6" id="cyclebutton-6">
           <coral-cyclebutton-item>Card View</coral-cyclebutton-item>
           <coral-cyclebutton-item>Grid View</coral-cyclebutton-item>
           <coral-cyclebutton-item icon="viewList">List View</coral-cyclebutton-item>
@@ -119,13 +119,25 @@
         </coral-cyclebutton>
       </div>
 
-      <h2 class="coral-Heading coral-Heading--2">Without any icons</h2>
+      <h2 class="coral-Heading coral-Heading--2"><label id="label-7" for="cyclebutton-7-button">Without any icons</label></h2>
       <div class="markup">
-        <coral-cyclebutton>
+        <coral-cyclebutton aria-labelledby="label-7" id="cyclebutton-7">
           <coral-cyclebutton-item>Card View</coral-cyclebutton-item>
           <coral-cyclebutton-item>Grid View</coral-cyclebutton-item>
           <coral-cyclebutton-item>List View</coral-cyclebutton-item>
           <coral-cyclebutton-item>Column View</coral-cyclebutton-item>
+        </coral-cyclebutton>
+      </div>
+
+      <h2 class="coral-Heading coral-Heading--2">Labelled using aria-label</h2>
+      <div class="markup">
+        <coral-cyclebutton displaymode="icontext" aria-label="Labelled using aria-label">
+          <coral-cyclebutton-item icon="viewCard">Card View</coral-cyclebutton-item>
+          <coral-cyclebutton-item icon="viewGrid">Grid View</coral-cyclebutton-item>
+          <coral-cyclebutton-item icon="viewList">List View</coral-cyclebutton-item>
+          <coral-cyclebutton-item icon="viewColumn">Column View</coral-cyclebutton-item>
+          <coral-cyclebutton-action icon="settings">View Settings</coral-cyclebutton-action>
+          <coral-cyclebutton-action icon="more">More Settings</coral-cyclebutton-action>
         </coral-cyclebutton>
       </div>
     </main>

--- a/coral-component-cyclebutton/src/scripts/CycleButton.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButton.js
@@ -63,13 +63,11 @@ class CycleButton extends BaseComponent(HTMLElement) {
   constructor() {
     super();
 
-    if (!this.id) {
-      this.id = commons.getUID();
-    } 
+    this._id = this.id || commons.getUID();
     
     // Templates
     this._elements = {};
-    base.call(this._elements, {Icon, commons, id: this.id});
+    base.call(this._elements, {Icon, commons, id: this._id});
     
     const events = {
       'click button[is="coral-button"]': '_onMouseDown',
@@ -505,6 +503,9 @@ class CycleButton extends BaseComponent(HTMLElement) {
       const ariaLabel = item.content.textContent.replace(WHITESPACE_REGEX, ' ');
       this._elements.button.setAttribute('aria-label', ariaLabel);
       this._elements.button.setAttribute('title', ariaLabel);
+      if (ariaLabel && effectiveIcon !== '' && this._elements.button._elements.icon) {
+        this._elements.button._elements.icon.setAttribute('aria-hidden', true);
+      }
     }
     else {
       // handle display modes that include text
@@ -513,6 +514,9 @@ class CycleButton extends BaseComponent(HTMLElement) {
       }
       if (effectiveDisplayMode === displayMode.ICON_TEXT) {
         this._elements.button.icon = effectiveIcon;
+        if (effectiveIcon !== '' && this._elements.button._elements.icon) {
+          this._elements.button._elements.icon.setAttribute('aria-hidden', true);
+        }
       }
       this._elements.button.label.innerHTML = item.content.innerHTML;
     
@@ -789,6 +793,7 @@ class CycleButton extends BaseComponent(HTMLElement) {
       selectListItem.icon = item.icon;
       selectListItem.role = item.role;
       selectListItem.setAttribute('aria-checked', item.selected);
+      selectListItem._elements.icon.setAttribute('aria-hidden', true);
 
       selectListItem.set({
         disabled: item.disabled,
@@ -807,6 +812,7 @@ class CycleButton extends BaseComponent(HTMLElement) {
         actionListItem.disabled = action.disabled;
         actionListItem.icon = action.icon;
         actionListItem.role = action.role;
+        actionListItem._elements.icon.setAttribute('aria-hidden', true);
 
         actionList.items.add(actionListItem);
       }
@@ -877,6 +883,10 @@ class CycleButton extends BaseComponent(HTMLElement) {
   /** @ignore */
   render() {
     super.render();
+
+    if (!this.id) {
+      this.id = this._id;
+    } 
     
     this.classList.add(CLASSNAME);
     

--- a/coral-component-cyclebutton/src/scripts/CycleButtonAction.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButtonAction.js
@@ -63,6 +63,20 @@ class CycleButtonAction extends BaseComponent(HTMLElement) {
   set trackingElement(value) {
     super.trackingElement = value;
   }
+
+  /** @ignore */
+  static get observedAttributes() {
+    return super.observedAttributes.concat(['icon']);
+  }
+
+  /** @ignore */
+  render() {
+    super.render();
+    
+    // adds the role to support accessibility
+    this.setAttribute('role', 'menuitem');
+    this.tabIndex =  -1;
+  }
 }
 
 export default CycleButtonAction;

--- a/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
@@ -120,7 +120,7 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
       this._reflectAttribute('selected', this.disabled ? false : this._selected);
       
       this.classList.toggle('is-selected', this._selected);
-      this.setAttribute('aria-selected', this._selected);
+      this.setAttribute('aria-checked', this._selected);
       
       this.trigger('coral-cyclebutton-item:_selectedchanged');
     }
@@ -185,7 +185,7 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
     super.render();
     
     // adds the role to support accessibility
-    this.setAttribute('role', 'option');
+    this.setAttribute('role', 'menuitemradio');
   
     // Default reflected attributes
     if (!this._displayMode) { this.displayMode = displayMode.INHERIT; }

--- a/coral-component-cyclebutton/src/templates/base.html
+++ b/coral-component-cyclebutton/src/templates/base.html
@@ -1,4 +1,8 @@
-<button tracking="off" id="{{data.commons.getUID()}}" handle="button" class="_coral-CycleSelect-button" is="coral-button" type="button" variant="quietaction" iconsize="S">
+<js>
+  data.buttonId = data.id + '-button';
+  data.menuId = data.id + '-menu';
+</js>
+<button tracking="off" id="{{data.buttonId}}" handle="button" class="_coral-CycleSelect-button" is="coral-button" type="button" variant="quietaction" iconsize="S">
   <coral-button-label class="_coral-ActionButton-label" handle="label"></coral-button-label>
 </button>
 <js>
@@ -7,7 +11,8 @@
   // Render chevron icon
   this.button.insertAdjacentHTML('afterbegin', data.Icon._renderSVG('spectrum-css-icon-ChevronDownMedium', ['_coral-CycleSelect-icon', '_coral-UIIcon-ChevronDownMedium']));
 </js>
-<coral-popover tracking="off" smart id="{{data.commons.getUID()}}" handle="overlay" focusonshow="coral-selectlist" placement="bottom">
-  <coral-selectlist tracking="off" class="_coral-CycleSelect-list" handle="selectList" id="{{data.commons.getUID()}}"></coral-selectlist>
-  <coral-buttonlist tracking="off" class="_coral-CycleSelect-buttonList" handle="actionList" hidden></coral-buttonlist>
+<coral-popover tracking="off" smart id="{{data.menuId}}" handle="overlay" focusonshow="coral-selectlist" placement="bottom" aria-live="off" role="menu">
+  <coral-selectlist role="group" tracking="off" class="_coral-CycleSelect-list" handle="selectList" id="{{data.commons.getUID()}}"></coral-selectlist>
+  <div role="separator" handle="separator" class="_coral-CycleButton-separator" style="height: 1px; margin-top: -1px" hidden></div>
+  <coral-buttonlist role="group" tracking="off" class="_coral-CycleSelect-buttonList" handle="actionList" hidden></coral-buttonlist>
 </coral-popover>

--- a/coral-component-cyclebutton/src/tests/test.CycleButton.js
+++ b/coral-component-cyclebutton/src/tests/test.CycleButton.js
@@ -612,8 +612,7 @@ describe('CycleButton', function() {
       var labelString = stripWhitespace(el.selectedItem.textContent);
       expect(el._elements.button.getAttribute('aria-haspopup')).to.equal('true', 'aria-haspopup attribute is not set to \'true\'');
       expect(el._elements.button.getAttribute('aria-expanded')).to.equal('false', 'aria-expanded attribute was not set to \'false\' when overlay is closed');
-      expect(el._elements.button.getAttribute('aria-owns')).to.equal(el._elements.selectList.id, 'aria-owns attribute was not set');
-      expect(el._elements.button.getAttribute('aria-controls')).to.equal(el._elements.selectList.id, 'aria-controls attribute was not set');
+      expect(el._elements.button.getAttribute('aria-controls')).to.equal(el._elements.overlay.id, 'aria-controls attribute was not set');
       if (el.icon) {
         expect(el._elements.button.getAttribute('aria-label')).to.equal(labelString, 'aria-label attribute on button does not match the selected item label');
         expect(el._elements.button.getAttribute('title')).to.equal(labelString, 'title attribute on button does not match the selected item label');
@@ -621,12 +620,11 @@ describe('CycleButton', function() {
       el.querySelector('#btn1').click();
       
       expect(el.selectedItem.id).to.equal('btn1');
-      expect(el._elements.button.getAttribute('aria-expanded')).to.equal('true', 'aria-expanded attribute was not set to \'true\' when overlay is closed');
       
       // Wait for list to be populated
       el.on('coral-overlay:open', () => {
+        expect(el._elements.button.getAttribute('aria-expanded')).to.equal('true', 'aria-expanded attribute was not set to \'true\' when overlay is opened');
         expect(el._elements.overlay.open).to.be.true;
-        
         done();
       });
     });
@@ -636,7 +634,8 @@ describe('CycleButton', function() {
       el._elements.button.querySelector('coral-icon').click();
       
       // Wait for the list to be populated
-      helpers.next(function() {
+      el.on('coral-overlay:open', () => {
+        expect(el._elements.button.getAttribute('aria-expanded')).to.equal('true', 'aria-expanded attribute was not set to \'true\' when overlay is opened');
         expect(el._elements.overlay.open).to.be.true;
         done();
       });
@@ -649,11 +648,13 @@ describe('CycleButton', function() {
       // Wait for the list to be populated
       el.on('coral-overlay:open', () => {
         el.querySelector('#btn1').click();
-  
-        expect(el.selectedItem.id).to.equal('btn1');
-        expect(el._elements.overlay.open).to.be.false;
-        expect(el._elements.button.getAttribute('aria-expanded')).to.equal('false', 'aria-expanded attribute was not set to \'false\'');
-        done();
+        
+        el.on('coral-overlay:close', () => {
+          expect(el.selectedItem.id).to.equal('btn1');
+          expect(el._elements.overlay.open).to.be.false;
+          expect(el._elements.button.getAttribute('aria-expanded')).to.equal('false', 'aria-expanded attribute was not set to \'false\'');
+          done();
+        });      
       });
     });
 
@@ -685,13 +686,14 @@ describe('CycleButton', function() {
       const el = helpers.build(SNIPPET_THREEITEMS);
       el.querySelector('#btn1').click();
       
-      // Wait for list to be populaited
-      helpers.next(function() {
+      // Wait for list to be populated
+      el.on('coral-overlay:open', () => {
+        el.on('coral-overlay:close', () => {
+          expect(el._elements.overlay.open).to.be.false;
+          expect(el._elements.button.getAttribute('aria-expanded')).to.equal('false', 'aria-expanded attribute was not set to \'false\'');
+          done();
+        });
         document.body.click();
-        
-        expect(el._elements.overlay.open).to.be.false;
-        expect(el._elements.button.getAttribute('aria-expanded')).to.equal('false', 'aria-expanded attribute was not set to \'false\'');
-        done();
       });
     });
 
@@ -727,7 +729,8 @@ describe('CycleButton', function() {
       expect(el.actions.length).to.equal(0);
       el.querySelector('#btn1').click();
       
-      expect(el._elements.actionList.getAttribute('hidden') === 'true').to.be.true;
+      expect(el._elements.actionList.hasAttribute('hidden')).to.be.true;
+      expect(el._elements.separator.hasAttribute('hidden')).to.be.true;
     });
 
     it('should show the actions selectList when there are actions', function() {
@@ -735,6 +738,8 @@ describe('CycleButton', function() {
       el.querySelector('#btn1').click();
       
       expect(el._elements.actionList.hasAttribute('hidden')).to.be.false;
+      expect(el._elements.separator.hasAttribute('hidden')).to.be.false;
+
     });
 
     it('should switch between inline/overlay selection when adding/removing nodes', function(done) {


### PR DESCRIPTION
## Description
Per: https://jira.corp.adobe.com/browse/GRANITE-28179

Coral.CycleButton currently opens a dropdown containing a listbox of coral-cyclebutton-items, and a coral-buttonlist of coral-cyclebutton-actions, which makes interaction difficult for a keyboard or screen reader user, because it is not clear that the dropdown, that looks like a menu, contains more than one tab stop.

The dropdown should behave as a single menu with coral-cyclebutton-items having role=menuitemradio and coral-cyclebutton-actions having role=menuitem.

Coral.CycleButton is difficult to label for accessibility, because the only label is the current selection

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7343

Sub-tasks: 
1. [CUI-7340](https://jira.corp.adobe.com/browse/CUI-7340)  [Accessibility] Coral.Select should be tabbable after initialization
2. [CUI-7344](https://jira.corp.adobe.com/browse/CUI-7344)  [Accessibility] Overlay tabCapture elements should have role=presentation
3. [CUI-7345](https://jira.corp.adobe.com/browse/CUI-7345) [Accessibility] Icon alt text should not default to a non-localized icon name.
4. [CUI-7346](https://jira.corp.adobe.com/browse/CUI-7346) [Accessibility] Lists should not stopPropagation with keyboard navigation
5. [CUI-7347](https://jira.corp.adobe.com/browse/CUI-7347) [Accessibility] Commons.FOCUSABLE_ELEMENT_SELECTOR must include any elements with tabIndex
6. [CUI-7348](https://jira.corp.adobe.com/browse/CUI-7348) [Accessibility] remove aria-disabled="false" when an element is not disabled
7. [CUI-7349](https://jira.corp.adobe.com/browse/CUI-7349) [Accessibility] CycleButton: SelectList and SelectListItem should support role override
8. [CUI-7350](https://jira.corp.adobe.com/browse/CUI-7350)  [Accessibility] CycleButton: Popover should support role override

## Motivation and Context
See GRANITE-28179 [Granite Collection-View-Switcher] "List view"/"Card view" toggle is not accessible in omni-search

## How Has This Been Tested?
Tested with Screen readers on: http://127.0.0.1:9001/examples/#cyclebutton

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
