### PR TITLE
CUI-7344 [Accessibility] Overlay tabCapture elements should have role=presentation

### DIFF
--- a/coral-base-overlay/src/scripts/BaseOverlay.js
+++ b/coral-base-overlay/src/scripts/BaseOverlay.js
@@ -210,6 +210,7 @@ function createDocumentTabCaptureEls() {
   if (!topTabCaptureEl) {
     topTabCaptureEl = document.createElement('div');
     topTabCaptureEl.setAttribute('coral-tabcapture', '');
+    topTabCaptureEl.setAttribute('role', 'presentation');
     topTabCaptureEl.tabIndex = 0;
     document.body.insertBefore(topTabCaptureEl, document.body.firstChild);
     topTabCaptureEl.addEventListener('focus', () => {
@@ -229,6 +230,7 @@ function createDocumentTabCaptureEls() {
     
     bottomTabCaptureEl = document.createElement('div');
     bottomTabCaptureEl.setAttribute('coral-tabcapture', '');
+    bottomTabCaptureEl.setAttribute('role', 'presentation');
     bottomTabCaptureEl.tabIndex = 0;
     document.body.appendChild(bottomTabCaptureEl);
     bottomTabCaptureEl.addEventListener('focus', () => {

--- a/coral-base-overlay/src/templates/base.html
+++ b/coral-base-overlay/src/templates/base.html
@@ -1,3 +1,3 @@
-<div handle="topTabCapture" coral-tabcapture="top" tabindex="0"></div>
-<div handle="intermediateTabCapture" coral-tabcapture="intermediate" tabindex="0"></div>
-<div handle="bottomTabCapture" coral-tabcapture="bottom" tabindex="0"></div>
+<div handle="topTabCapture" coral-tabcapture="top" tabindex="0" role="presentation"></div>
+<div handle="intermediateTabCapture" coral-tabcapture="intermediate" tabindex="0" role="presentation"></div>
+<div handle="bottomTabCapture" coral-tabcapture="bottom" tabindex="0" role="presentation"></div>


### PR DESCRIPTION
## Description
In Coral Spectrum, the tabCapture elements created by BaseOverlay, and in CoralUI, the tabCapture elements created by coralui-mixin-overlay should have role=presentation, so that assistive technology does not count them as children in components, like role="menu" or role="listbox", where child count is relevant.
 
## Related Issue
https://jira.corp.adobe.com/browse/CUI-7344 and 

## Motivation and Context
Helps prevent assistive technology from announcing the wrong number of children in a menu or listbox.

## How Has This Been Tested?
Tested in relation to #12 and https://jira.corp.adobe.com/browse/CUI-7343

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
