### PR TITLE
CUI-7345 [Accessibility] Icon alt text should not default to a non-localized icon name

### DIFF
--- a/coral-component-icon/src/scripts/Icon.js
+++ b/coral-component-icon/src/scripts/Icon.js
@@ -325,15 +325,12 @@ class Icon extends BaseComponent(HTMLElement) {
   _updateAltText(value) {
     const isImage = this.contains(this._elements.image);
     
-    let altText;
+    let altText = '';
     if (typeof value === 'string') {
       altText = value;
     }
     else if (isImage) {
       altText = '';
-    }
-    else {
-      altText = this.icon.replace(SPLIT_CAMELCASE_REGEX, '$1 $2');
     }
   
     // If no other role has been set, provide the appropriate

--- a/coral-component-icon/src/tests/test.Icon.js
+++ b/coral-component-icon/src/tests/test.Icon.js
@@ -367,12 +367,12 @@ describe('Icon', function() {
         expect(icon.getAttribute('aria-label')).to.equal('Add Item');
       });
   
-      it('should add an aria-label equal to the value of the icon property when not set and when no title attribute is present', function() {
+      it('should not add an aria-label equal to the value of the icon property when not set and when no title attribute is present', function() {
         var icon = helpers.build(new Icon());
     
         icon.icon = 'add';
     
-        expect(icon.getAttribute('aria-label')).to.equal('add');
+        expect(icon.hasAttribute('aria-label')).to.be.false;
       });
   
       it('should add an aria-label equal to the value of the title attribute property when not set and when a title attribute is present', function() {

--- a/coral-utils/src/tests/helpers/helpers.button.js
+++ b/coral-utils/src/tests/helpers/helpers.button.js
@@ -228,7 +228,7 @@ const testButton = function(Constructor, tagName, baseTagName) {
           expect(button._elements.icon).to.exist;
           expect(button._elements.icon.icon).to.equal('add');
           expect(button._elements.icon.alt).to.equal(null);
-          expect(button._elements.icon.getAttribute('aria-label')).to.equal('add');
+          expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
           expect(button.classList.contains('_coral-Button')).to.be.true;
         });
       
@@ -253,7 +253,7 @@ const testButton = function(Constructor, tagName, baseTagName) {
           expect(button._elements.icon).to.exist;
           expect(button._elements.icon.parentNode).not.to.be.null;
           expect(button._elements.icon.alt).to.equal(null);
-          expect(button._elements.icon.getAttribute('aria-label')).to.equal('add');
+          expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
         
           button.label.textContent = 'Add';
           // Wait for the MO to kick in
@@ -262,7 +262,7 @@ const testButton = function(Constructor, tagName, baseTagName) {
             expect(button.classList.contains('_coral-Button')).to.be.true;
             expect(button.icon).to.equal('add');
             expect(button._elements.icon.alt).to.equal('');
-            expect(button._elements.icon.getAttribute('aria-label')).to.be.null;
+            expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
             done();
           });
         });
@@ -282,7 +282,7 @@ const testButton = function(Constructor, tagName, baseTagName) {
             expect(button.classList.contains('_coral-Button')).to.be.true;
             expect(button.icon).to.equal('add');
             expect(button._elements.icon.alt).to.equal('');
-            expect(button._elements.icon.getAttribute('aria-label')).to.equal('add');
+            expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
             done();
           });
         });
@@ -303,7 +303,7 @@ const testButton = function(Constructor, tagName, baseTagName) {
             expect(button._getIconElement()).to.exist;
             expect(button._getIconElement().icon).to.equal('share');
             expect(button._elements.icon.alt).to.equal('');
-            expect(button._elements.icon.getAttribute('aria-label')).to.equal('share');
+            expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
             expect(button.classList.contains('_coral-Button')).to.be.true;
             done();
           });


### PR DESCRIPTION
## Description
Do not use the non-localized icon name as alternative text for accessibility.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7345 and #12 / https://jira.corp.adobe.com/browse/CUI-7343

## Motivation and Context
The original intent of using the icon name as alternative text for accessibility, was to localize the icon name to some meaningful string, so that if no aria-label were provided to an icon-only button, the button would still be identified in a meaningful way to assistive technology. The current implementation simply uses the non-localized name for the Icon, which populates the interface with strings like ''Chevron Right" or "Chevron Down", which aren't helpful, and are problematic without proper translation.

It is better to let icon-only buttons without an aria-label, remain unlabelled so that automated testing tools have an opportunity to identify the missing label.

## How Has This Been Tested?
Tested in relation to #12 and https://jira.corp.adobe.com/browse/CUI-7343

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
