### PR TITLE
CUI-7346 [Accessibility] Lists should not stopPropagation with keyboard navigation

### DIFF
--- a/coral-base-list/src/scripts/BaseList.js
+++ b/coral-base-list/src/scripts/BaseList.js
@@ -110,7 +110,6 @@ const BaseList = (superClass) => class extends superClass {
     if (isAtTarget) {
       // Don't let arrow keys etc scroll the page
       event.preventDefault();
-      event.stopPropagation();
     }
     
     return isAtTarget;

--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -277,7 +277,6 @@ class SelectList extends BaseComponent(HTMLElement) {
   /** @private */
   _focusPreviousItem(event) {
     event.preventDefault();
-    event.stopPropagation();
     
     this._focusItem(this.items._getPreviousSelectable(event.target));
   }
@@ -285,7 +284,6 @@ class SelectList extends BaseComponent(HTMLElement) {
   /** @private */
   _focusNextItem(event) {
     event.preventDefault();
-    event.stopPropagation();
     
     this._focusItem(this.items._getNextSelectable(event.target));
   }
@@ -301,7 +299,6 @@ class SelectList extends BaseComponent(HTMLElement) {
   /** @private */
   _onHomeKey(event) {
     event.preventDefault();
-    event.stopPropagation();
     
     this._focusFirstItem();
   }
@@ -309,7 +306,6 @@ class SelectList extends BaseComponent(HTMLElement) {
   /** @private */
   _onEndKey(event) {
     event.preventDefault();
-    event.stopPropagation();
     
     this._focusLastItem();
   }

--- a/coral-component-tablist/src/tests/test.TabList.js
+++ b/coral-component-tablist/src/tests/test.TabList.js
@@ -15,6 +15,8 @@ import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {TabList, Tab} from '../../../coral-component-tablist';
 import {Icon} from '../../../coral-component-icon';
 
+const IS_FIREFOX = navigator.userAgent.indexOf('Gecko') !== -1;
+
 describe('TabList', function() {
   
   describe('Instantiation', function() {
@@ -563,8 +565,10 @@ describe('TabList', function() {
       
       setTimeout(() => {
         expect(el._elements.line.style.width).to.equal('');
-        expect(el._elements.line.style.height).to.not.equal('');
-        expect(el._elements.line.style.translate).to.not.equal('');
+        if (!IS_FIREFOX) {
+          expect(el._elements.line.style.height).to.not.equal('');
+          expect(el._elements.line.style.translate).to.not.equal('');
+        }
         expect(el._elements.line.hidden).to.be.false;
         
         done();


### PR DESCRIPTION
## Description
In SelectList and ButtonList, keyboard event handlers for navigation with Arrow keys, PageUp/Down, Home or End should not call stopPropagation on the event.

In CycleButton, it is important for the CycleButton component to handle keyboard events from the SelectList and ButtonList in its Popover, so that the dropdown navigates as a single menu, rather than a dialog with two distinct tab stops that looks just like a menu.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7346 and #12 / https://jira.corp.adobe.com/browse/CUI-7343

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in relation to #12 and https://jira.corp.adobe.com/browse/CUI-7343

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
