### PR TITLE
CUI-7348 [Accessibility] remove aria-disabled="false" when an element is not disabled

### DIFF
--- a/coral-base-list/src/scripts/BaseListItem.js
+++ b/coral-base-list/src/scripts/BaseListItem.js
@@ -67,7 +67,7 @@ const BaseListItem = (superClass) => class extends superClass {
     this._reflectAttribute('disabled', this._disabled);
   
     this.classList.toggle('is-disabled', this._disabled);
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
   }
   
   /**

--- a/coral-component-anchorbutton/src/scripts/AnchorButton.js
+++ b/coral-component-anchorbutton/src/scripts/AnchorButton.js
@@ -61,7 +61,7 @@ class AnchorButton extends BaseButton(BaseComponent(HTMLAnchorElement)) {
     
     this.classList.toggle('is-disabled', this._disabled);
     this.setAttribute('tabindex', this._disabled ? '-1' : '0');
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
   }
   
   /**
@@ -110,7 +110,7 @@ class AnchorButton extends BaseButton(BaseComponent(HTMLAnchorElement)) {
     if (!this.disabled) {
       // Force tabindex and aria-disabled attribute reflection
       this.setAttribute('tabindex', '0');
-      this.setAttribute('aria-disabled', 'false');
+      this.removeAttribute('aria-disabled');
     }
   }
 }

--- a/coral-component-anchorbutton/src/tests/test.AnchorButton.js
+++ b/coral-component-anchorbutton/src/tests/test.AnchorButton.js
@@ -32,7 +32,7 @@ describe('AnchorButton', function() {
       expect(button.hasAttribute('tabindex')).to.be.true;
       expect(button.getAttribute('role')).to.equal('button');
       expect(button.getAttribute('tabindex')).to.equal('0');
-      expect(button.getAttribute('aria-disabled')).to.equal('false');
+      expect(button.hasAttribute('aria-disabled')).to.be.false;
     });
 
     it('should have tabindex set to -1 while disabled', function() {

--- a/coral-component-autocomplete/src/scripts/Autocomplete.js
+++ b/coral-component-autocomplete/src/scripts/Autocomplete.js
@@ -538,7 +538,7 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this._elements.inputGroup.classList.toggle('is-disabled', this._disabled);
     
     this._elements.input.disabled = this._disabled;

--- a/coral-component-buttongroup/src/scripts/ButtonGroup.js
+++ b/coral-component-buttongroup/src/scripts/ButtonGroup.js
@@ -276,7 +276,7 @@ class ButtonGroup extends BaseFormField(BaseComponent(HTMLElement)) {
     this.items.getAll().forEach((item) => {
       item.disabled = isDisabled;
     });
-    this.setAttribute('aria-disabled', isDisabled);
+    this[isDisabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', isDisabled);
   }
   
   /**
@@ -297,12 +297,7 @@ class ButtonGroup extends BaseFormField(BaseComponent(HTMLElement)) {
     // Also update for all the items the disabled property so it matches the native select.
     this.items.getAll().forEach((item) => {
       item.disabled = this.disabled || this.readOnly && !item.hasAttribute('selected');
-      if (this.readOnly) {
-        item.setAttribute('aria-disabled', true);
-      }
-      else {
-        item.removeAttribute('aria-disabled');
-      }
+      item[this.readOnly ? 'setAttribute' : 'removeAttribute']('aria-disabled', true);
     });
     // aria-readonly is not permitted on elements with role="radiogroup" or role="group"
     this.removeAttribute('aria-readonly');
@@ -556,12 +551,7 @@ class ButtonGroup extends BaseFormField(BaseComponent(HTMLElement)) {
   
     item.disabled = this.disabled || this.readOnly && !item.hasAttribute('selected');
   
-    if (this.readOnly) {
-      item.setAttribute('aria-disabled', true);
-    }
-    else {
-      item.removeAttribute('aria-disabled');
-    }
+    item[this.readOnly ? 'setAttribute' : 'removeAttribute']('aria-disabled', true);
   
     this._addItemOption(item);
    

--- a/coral-component-calendar/src/scripts/Calendar.js
+++ b/coral-component-calendar/src/scripts/Calendar.js
@@ -443,7 +443,7 @@ class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
     this.classList.toggle('is-disabled', this._disabled);
     this._elements.prev.disabled = this._disabled;
     this._elements.next.disabled = this._disabled;
-    this._elements.body.setAttribute('aria-disabled', this._disabled);
+    this._elements.body[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this._elements.body[this._disabled ? 'removeAttribute' : 'setAttribute']('tabindex', '0');
   
     this._renderCalendar();

--- a/coral-component-checkbox/src/scripts/Checkbox.js
+++ b/coral-component-checkbox/src/scripts/Checkbox.js
@@ -166,7 +166,7 @@ class Checkbox extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     this._elements.input.disabled = this._disabled;
   }

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -206,7 +206,7 @@ class Clock extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     
     this._elements.hours.disabled = this._disabled;

--- a/coral-component-colorinput/src/scripts/ColorInput.js
+++ b/coral-component-colorinput/src/scripts/ColorInput.js
@@ -439,7 +439,7 @@ class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     
     this._elements.input.disabled = this.disabled;

--- a/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
@@ -90,7 +90,7 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
     this._reflectAttribute('disabled', this._disabled);
     
     this.classList.toggle('is-disabled', this.disabled);
-    this.setAttribute('aria-disabled', this.disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     
     if (this._disabled && this.selected) {
       this.selected = false;

--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -456,7 +456,7 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
   
     this._elements.input.disabled = this._disabled;

--- a/coral-component-drawer/src/scripts/Drawer.js
+++ b/coral-component-drawer/src/scripts/Drawer.js
@@ -78,7 +78,7 @@ class Drawer extends BaseComponent(HTMLElement) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
   
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this._elements.toggle.hidden = this._disabled;
   }
   

--- a/coral-component-list/src/scripts/SelectListItem.js
+++ b/coral-component-list/src/scripts/SelectListItem.js
@@ -152,7 +152,7 @@ class SelectListItem extends BaseComponent(HTMLElement) {
     this._reflectAttribute('disabled', this._disabled);
     
     this.classList.toggle('is-disabled', this._disabled);
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     
     this.selected = this.selected;
   }

--- a/coral-component-numberinput/src/scripts/NumberInput.js
+++ b/coral-component-numberinput/src/scripts/NumberInput.js
@@ -319,7 +319,7 @@ class NumberInput extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     this._elements.input.disabled = this._disabled;
     

--- a/coral-component-numberinput/src/tests/test.NumberInput.js
+++ b/coral-component-numberinput/src/tests/test.NumberInput.js
@@ -694,7 +694,7 @@ describe('NumberInput', function() {
         expect(el._elements.stepUp.disabled).to.be.false;
         expect(el._elements.stepDown.disabled).to.be.true;
         expect(el.getAttribute('disabled')).to.be.null;
-        expect(el.getAttribute('aria-disabled')).to.equal('false');
+        expect(el.hasAttribute('aria-disabled')).to.be.false;
 
         el.disabled = true;
         expect(el._elements.input.disabled).to.be.true;
@@ -708,7 +708,7 @@ describe('NumberInput', function() {
         expect(el._elements.stepUp.disabled).to.be.false;
         expect(el._elements.stepDown.disabled).to.be.true;
         expect(el.getAttribute('disabled')).to.be.null;
-        expect(el.getAttribute('aria-disabled')).to.equal('false');
+        expect(el.hasAttribute('aria-disabled')).to.be.false;
       });
 
       it('should handle manipulating disabled attribute', function() {

--- a/coral-component-radio/src/scripts/Radio.js
+++ b/coral-component-radio/src/scripts/Radio.js
@@ -144,7 +144,7 @@ class Radio extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     this._elements.input.disabled = this._disabled;
   }

--- a/coral-component-search/src/scripts/Search.js
+++ b/coral-component-search/src/scripts/Search.js
@@ -112,7 +112,7 @@ class Search extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     this._elements.input.disabled = this._disabled;
     this._elements.clearButton.disabled = this._disabled;

--- a/coral-component-select/src/scripts/Select.js
+++ b/coral-component-select/src/scripts/Select.js
@@ -421,7 +421,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     
     const isReadOnly = this.hasAttribute('readonly');

--- a/coral-component-slider/src/scripts/Slider.js
+++ b/coral-component-slider/src/scripts/Slider.js
@@ -335,7 +335,7 @@ class Slider extends BaseFormField(BaseComponent(HTMLElement)) {
     this._reflectAttribute('disabled', this._disabled);
     
     this.classList.toggle('is-disabled', this._disabled);
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this._elements.inputs.forEach((input) => {
       input.disabled = this._disabled;
     });

--- a/coral-component-status/src/scripts/Status.js
+++ b/coral-component-status/src/scripts/Status.js
@@ -117,7 +117,7 @@ class Status extends BaseComponent(HTMLElement) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
   }
   
   /**

--- a/coral-component-status/src/tests/test.Status.js
+++ b/coral-component-status/src/tests/test.Status.js
@@ -161,7 +161,7 @@ describe('Status', function() {
   
         el.disabled = false;
         expect(el.hasAttribute('disabled')).to.be.false;
-        expect(el.getAttribute('aria-disabled')).to.equal('false');
+        expect(el.hasAttribute('aria-disabled')).to.be.false;
       });
     });
   });

--- a/coral-component-switch/src/scripts/Switch.js
+++ b/coral-component-switch/src/scripts/Switch.js
@@ -142,7 +142,7 @@ class Switch extends BaseFormField(BaseComponent(HTMLElement)) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
     
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
     this._elements.input.disabled = this._disabled;
   }

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -141,8 +141,8 @@ class Tab extends BaseComponent(HTMLElement) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
   
-    this.classList.toggle('is-disabled', this.disabled);
-    this.setAttribute('aria-disabled', this.disabled);
+    this.classList.toggle('is-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     
     if (this._disabled && this.selected) {
       this.selected = false;

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -102,7 +102,7 @@ describe('Tab', function() {
         expect(item.disabled).to.be.false;
         expect(item.hasAttribute('disabled')).to.be.false;
         expect(item.classList.contains('is-disabled')).to.be.false;
-        expect(item.getAttribute('aria-disabled')).to.equal('false');
+        expect(item.hasAttribute('aria-disabled')).to.be.false;
       });
   
       it('disabled items cannot be selected', function() {

--- a/coral-component-tablist/src/tests/test.TabList.js
+++ b/coral-component-tablist/src/tests/test.TabList.js
@@ -15,6 +15,8 @@ import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {TabList, Tab} from '../../../coral-component-tablist';
 import {Icon} from '../../../coral-component-icon';
 
+const IS_FIREFOX = navigator.userAgent.indexOf('Gecko') !== -1;
+
 describe('TabList', function() {
   
   describe('Instantiation', function() {
@@ -563,8 +565,10 @@ describe('TabList', function() {
       
       setTimeout(() => {
         expect(el._elements.line.style.width).to.equal('');
-        expect(el._elements.line.style.height).to.not.equal('');
-        expect(el._elements.line.style.translate).to.not.equal('');
+        if (!IS_FIREFOX) {
+          expect(el._elements.line.style.height).to.not.equal('');
+          expect(el._elements.line.style.translate).to.not.equal('');
+        }
         expect(el._elements.line.hidden).to.be.false;
         
         done();

--- a/coral-component-taglist/src/scripts/TagList.js
+++ b/coral-component-taglist/src/scripts/TagList.js
@@ -189,7 +189,7 @@ class TagList extends BaseFormField(BaseComponent(HTMLElement)) {
     });
     
     // a11y
-    this.setAttribute('aria-disabled', this._disabled);
+    this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
   }
   
   // JSDoc inherited

--- a/coral-component-tree/src/scripts/TreeItem.js
+++ b/coral-component-tree/src/scripts/TreeItem.js
@@ -280,7 +280,7 @@ class TreeItem extends BaseComponent(HTMLElement) {
     this._reflectAttribute('disabled', this._disabled);
   
     this._elements.header.classList.toggle('is-disabled', this._disabled);
-    this._elements.header.setAttribute('aria-disabled', this._disabled);
+    this._elements.header[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     
     this.trigger('coral-tree-item:_disabledchanged');
   }

--- a/examples/compat/Coral.Element.js
+++ b/examples/compat/Coral.Element.js
@@ -63,7 +63,7 @@
         transform: Coral.transform.boolean,
         attributeTransform: Coral.transform.booleanAttr,
         sync: function() {
-          this.setAttribute('aria-disabled', this.disabled);
+          this[this.disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this.disabled);
           this.classList.toggle('is-disabled', this.disabled);
           this._elements.toggle.disabled = this.disabled;
         }


### PR DESCRIPTION
## Description
When an element is not disabled, it does not require nor should it have the aria-disabled="false" property.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7348 and #12 / https://jira.corp.adobe.com/browse/CUI-7343

## Motivation and Context
Simplify rendering of elements when they are not disabled.

## How Has This Been Tested?
Tested in context of #12 / https://jira.corp.adobe.com/browse/CUI-7343

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
