### PR TITLE
CUI-7349 [Accessibility] CycleButton: SelectList and SelectListItem should support role override

### DIFF
--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -174,7 +174,7 @@ class SelectList extends BaseComponent(HTMLElement) {
     this._multiple = transform.booleanAttr(value);
     this._reflectAttribute('multiple', this._multiple);
     
-    this.setAttribute('aria-multiselectable', this._multiple);
+    this[this._multiple ? 'setAttribute' : 'removeAttribute']('aria-multiselectable', this._multiple);
     
     this._validateSelection();
   }
@@ -524,7 +524,10 @@ class SelectList extends BaseComponent(HTMLElement) {
     this.classList.add(CLASSNAME);
     
     // adds the role to support accessibility
-    this.setAttribute('role', 'listbox');
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'listbox');
+    }
+
     if (!this.hasAttribute('aria-label')) {
       this.setAttribute('aria-label', i18n.get('List'));
     }

--- a/coral-component-list/src/scripts/SelectListItem.js
+++ b/coral-component-list/src/scripts/SelectListItem.js
@@ -15,6 +15,18 @@ import {transform} from '../../../coral-utils';
 import {Icon} from '../../../coral-component-icon';
 import checkIcon from '../templates/checkIcon';
 
+const VALID_ARIA_SELECTED_ROLES = [
+  'columnheader',
+  'gridcell',
+  'option',
+  'row',
+  'rowheader',
+  'tab',
+  'treeitem'
+];
+
+const VALID_ARIA_SELECTED_ROLES_REGEXP = new RegExp('^('+ VALID_ARIA_SELECTED_ROLES.join('|') +')$');
+
 const CLASSNAME = '_coral-Menu-item';
 
 /**
@@ -128,7 +140,11 @@ class SelectListItem extends BaseComponent(HTMLElement) {
     this._reflectAttribute('selected', this.disabled ? false : this._selected);
     
     this.classList.toggle('is-selected', this._selected);
-    this.setAttribute('aria-selected', this._selected);
+
+    if (this.hasAttribute('role') &&
+        VALID_ARIA_SELECTED_ROLES_REGEXP.test(this.getAttribute('role'))) {
+      this.setAttribute('aria-selected', this._selected);
+    }
     
     // Toggle check icon
     this._elements.checkIcon.hidden = !this._selected;
@@ -170,7 +186,9 @@ class SelectListItem extends BaseComponent(HTMLElement) {
     
     this.classList.add(CLASSNAME);
     
-    this.setAttribute('role', 'option');
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'option');
+    }
   
     // Support cloneNode
     const template = this.querySelector('._coral-SelectList-icon');

--- a/coral-component-tablist/src/tests/test.TabList.js
+++ b/coral-component-tablist/src/tests/test.TabList.js
@@ -15,6 +15,8 @@ import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {TabList, Tab} from '../../../coral-component-tablist';
 import {Icon} from '../../../coral-component-icon';
 
+const IS_FIREFOX = navigator.userAgent.indexOf('Gecko') !== -1;
+
 describe('TabList', function() {
   
   describe('Instantiation', function() {
@@ -563,8 +565,10 @@ describe('TabList', function() {
       
       setTimeout(() => {
         expect(el._elements.line.style.width).to.equal('');
-        expect(el._elements.line.style.height).to.not.equal('');
-        expect(el._elements.line.style.translate).to.not.equal('');
+        if (!IS_FIREFOX) {
+          expect(el._elements.line.style.height).to.not.equal('');
+          expect(el._elements.line.style.translate).to.not.equal('');
+        }
         expect(el._elements.line.hidden).to.be.false;
         
         done();


### PR DESCRIPTION
## Description

In CycleButton, SelectList behaves as and element with role="group" and SelectListItems should have role="menuitemradio".

SelectListItem should only add aria-selected if the role supports it.

SelectList should only add aria-multiselectable when multiple is true.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7349 and #12 / https://jira.corp.adobe.com/browse/CUI-7343

## Motivation and Context
Improve accessibility implementation for CycleButton menu so that it can behave as a group of menuitemradios in a menu.

## How Has This Been Tested?
Tested in #12  / https://jira.corp.adobe.com/browse/CUI-7343 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
