### PR TITLE
CUI-7350 [Accessibility] CycleButton: Popover should support role override

### DIFF
--- a/coral-component-popover/src/scripts/Popover.js
+++ b/coral-component-popover/src/scripts/Popover.js
@@ -246,7 +246,9 @@ class Popover extends Overlay {
       
       if (this._variant === variant.DEFAULT) {
         // ARIA
-        this.setAttribute('role', 'dialog');
+        if (!this.hasAttribute('role')) {
+          this.setAttribute('role', 'dialog');
+        }
       }
       else {
         // Set new variant class
@@ -485,9 +487,12 @@ class Popover extends Overlay {
     this.classList.add(CLASSNAME);
     
     // ARIA
-    this.setAttribute('role', 'dialog');
-    // This helped announcements in certain screen readers
-    this.setAttribute('aria-live', 'assertive');
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'dialog');
+      
+      // This helped announcements in certain screen readers
+      this.setAttribute('aria-live', 'assertive');
+    }
     
     // Default reflected attributes
     if (!this._variant) { this.variant = variant.DEFAULT; }

--- a/coral-component-popover/src/templates/base.html
+++ b/coral-component-popover/src/templates/base.html
@@ -1,3 +1,3 @@
-<div class="_coral-Dialog-header" handle="headerWrapper"></div>
-<button tracking="off" handle="closeButton" class="_coral-Dialog-closeButton _coral-ClearButton" type="button" is="coral-button" variant="_custom" icon="close" title="{{data.i18n.get('Close')}}" tabindex="-1" coral-close></button>
-<div class="_coral-Popover-tip" handle="tip"></div>
+<div class="_coral-Dialog-header" handle="headerWrapper" role="presentation"></div>
+<button tracking="off" handle="closeButton" class="_coral-Dialog-closeButton _coral-ClearButton" type="button" is="coral-button" variant="_custom" icon="close" aria-label="{{data.i18n.get('Close')}}" title="{{data.i18n.get('Close')}}" tabindex="-1" coral-close></button>
+<div class="_coral-Popover-tip" handle="tip" aria-hidden="true"></div>

--- a/coral-component-tablist/src/tests/test.TabList.js
+++ b/coral-component-tablist/src/tests/test.TabList.js
@@ -15,6 +15,8 @@ import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {TabList, Tab} from '../../../coral-component-tablist';
 import {Icon} from '../../../coral-component-icon';
 
+const IS_FIREFOX = navigator.userAgent.indexOf('Gecko') !== -1;
+
 describe('TabList', function() {
   
   describe('Instantiation', function() {
@@ -563,8 +565,10 @@ describe('TabList', function() {
       
       setTimeout(() => {
         expect(el._elements.line.style.width).to.equal('');
-        expect(el._elements.line.style.height).to.not.equal('');
-        expect(el._elements.line.style.translate).to.not.equal('');
+        if (!IS_FIREFOX) {
+          expect(el._elements.line.style.height).to.not.equal('');
+          expect(el._elements.line.style.translate).to.not.equal('');
+        }
         expect(el._elements.line.hidden).to.be.false;
         
         done();


### PR DESCRIPTION
## Description

For CycleButton, it should be possible to set the Popover role="menu" .

When role is not dialog, Popover should not have aria-live.

Popover headerWrapper should have role="presentation"

Close button should have aria-label as well as title.

Popover tip should be hidden for accessibility

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7350 and #12 / https://jira.corp.adobe.com/browse/CUI-7343

## Motivation and Context
Allows Popover to behave as a menu rather than as a dialog in CycleButton.

## How Has This Been Tested?
Tested in relation to #12 / https://jira.corp.adobe.com/browse/CUI-7343

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
