### PR TITLE
CUI-7341 : Accessibility improvements for ActionBar

### DIFF
--- a/coral-component-actionbar/src/scripts/ActionBar.js
+++ b/coral-component-actionbar/src/scripts/ActionBar.js
@@ -467,6 +467,7 @@ class ActionBar extends BaseComponent(HTMLElement) {
     else if (!item.hasAttribute('coral-actionbar-offscreen')) {
       // actually just move element offscreen to be able to measure the size while calculating the layout
       item.setAttribute('coral-actionbar-offscreen', '');
+      item.setAttribute('aria-hidden', true);
       // if I do not force a browser redraw webkit has layouting problems
       this._forceWebkitRedraw(item);
     }
@@ -480,6 +481,7 @@ class ActionBar extends BaseComponent(HTMLElement) {
     else if (item.hasAttribute('coral-actionbar-offscreen')) {
       // actually just move element onscreen again (see _hideItem)
       item.removeAttribute('coral-actionbar-offscreen');
+      item.removeAttribute('aria-hidden');
       // if I do not force a browser redraw webkit has layouting problems
       this._forceWebkitRedraw(item);
     }

--- a/coral-component-actionbar/src/scripts/ActionBar.js
+++ b/coral-component-actionbar/src/scripts/ActionBar.js
@@ -467,7 +467,7 @@ class ActionBar extends BaseComponent(HTMLElement) {
     else if (!item.hasAttribute('coral-actionbar-offscreen')) {
       // actually just move element offscreen to be able to measure the size while calculating the layout
       item.setAttribute('coral-actionbar-offscreen', '');
-      item.setAttribute('aria-hidden', true);
+      item.style.visibility = 'hidden';
       // if I do not force a browser redraw webkit has layouting problems
       this._forceWebkitRedraw(item);
     }
@@ -481,7 +481,7 @@ class ActionBar extends BaseComponent(HTMLElement) {
     else if (item.hasAttribute('coral-actionbar-offscreen')) {
       // actually just move element onscreen again (see _hideItem)
       item.removeAttribute('coral-actionbar-offscreen');
-      item.removeAttribute('aria-hidden');
+      item.style.visibility = '';
       // if I do not force a browser redraw webkit has layouting problems
       this._forceWebkitRedraw(item);
     }

--- a/coral-component-actionbar/src/scripts/ActionBarPrimary.js
+++ b/coral-component-actionbar/src/scripts/ActionBarPrimary.js
@@ -31,6 +31,8 @@ class ActionBarPrimary extends ActionBarContainer(BaseComponent(HTMLElement)) {
     
     for (let i = 0; i < this._itemsInPopover.length; i++) {
       item = this._itemsInPopover[i];
+
+      item.setAttribute('aria-hidden', true);
       
       // remove tabindex again
       wrappedItem = getFirstSelectableWrappedItem(item);

--- a/coral-component-actionbar/src/scripts/ActionBarPrimary.js
+++ b/coral-component-actionbar/src/scripts/ActionBarPrimary.js
@@ -32,7 +32,7 @@ class ActionBarPrimary extends ActionBarContainer(BaseComponent(HTMLElement)) {
     for (let i = 0; i < this._itemsInPopover.length; i++) {
       item = this._itemsInPopover[i];
 
-      item.setAttribute('aria-hidden', true);
+      item.style.visibility = 'hidden';
       
       // remove tabindex again
       wrappedItem = getFirstSelectableWrappedItem(item);

--- a/coral-component-actionbar/src/scripts/ActionBarSecondary.js
+++ b/coral-component-actionbar/src/scripts/ActionBarSecondary.js
@@ -31,6 +31,8 @@ class ActionBarSecondary extends ActionBarContainer(BaseComponent(HTMLElement)) 
     
     for (let i = 0; i < this._itemsInPopover.length; i++) {
       item = this._itemsInPopover[i];
+
+      item.setAttribute('aria-hidden', true);
   
       // remove tabindex again
       wrappedItem = getFirstSelectableWrappedItem(item);

--- a/coral-component-actionbar/src/scripts/ActionBarSecondary.js
+++ b/coral-component-actionbar/src/scripts/ActionBarSecondary.js
@@ -31,8 +31,8 @@ class ActionBarSecondary extends ActionBarContainer(BaseComponent(HTMLElement)) 
     
     for (let i = 0; i < this._itemsInPopover.length; i++) {
       item = this._itemsInPopover[i];
-
-      item.setAttribute('aria-hidden', true);
+  
+      item.style.visibility = 'hidden';
   
       // remove tabindex again
       wrappedItem = getFirstSelectableWrappedItem(item);

--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -177,6 +177,10 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
     if (this._itemsInPopover.length < 1) {
       return;
     }
+
+    this._itemsInPopover.forEach(function(item) {
+      item.removeAttribute('aria-hidden');
+    });
   
     // Store the button and popover on the item
     this._itemsInPopover.forEach((item) => {

--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -179,7 +179,7 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
     }
 
     this._itemsInPopover.forEach(function(item) {
-      item.removeAttribute('aria-hidden');
+      item.style.visibility = '';
     });
   
     // Store the button and popover on the item

--- a/coral-component-actionbar/src/scripts/getFirstSelectableWrappedItem.js
+++ b/coral-component-actionbar/src/scripts/getFirstSelectableWrappedItem.js
@@ -33,6 +33,18 @@ export default function getFirstSelectableWrappedItem(wrapperItem) {
       return child;
     }
   }
+
+  // search at 2nd level, some elements like coral-fileupload has selectable items inside them
+  for (let i = 0; i < wrapperItem.children.length; i++) {
+    child = wrapperItem.children[i];
+    for(let j = 0; j<child.children.length; j++) {
+      let subChild = child.children[j];
+      // maybe filter even more elements? (opacity, display='none', position='absolute' ...)
+      if(subChild.offsetParent && subChild.matches(Coral.commons.FOCUSABLE_ELEMENT_SELECTOR)) {
+        return subChild;
+      }
+    }
+  }
   
   return null;
 }

--- a/coral-component-actionbar/src/scripts/getFirstSelectableWrappedItem.js
+++ b/coral-component-actionbar/src/scripts/getFirstSelectableWrappedItem.js
@@ -40,7 +40,7 @@ export default function getFirstSelectableWrappedItem(wrapperItem) {
     for(let j = 0; j<child.children.length; j++) {
       let subChild = child.children[j];
       // maybe filter even more elements? (opacity, display='none', position='absolute' ...)
-      if(subChild.offsetParent && subChild.matches(Coral.commons.FOCUSABLE_ELEMENT_SELECTOR)) {
+      if(subChild.offsetParent && subChild.matches(commons.FOCUSABLE_ELEMENT_SELECTOR)) {
         return subChild;
       }
     }

--- a/coral-component-actionbar/src/tests/snippets/ActionBar.hiddenitems.html
+++ b/coral-component-actionbar/src/tests/snippets/ActionBar.hiddenitems.html
@@ -1,5 +1,5 @@
 <coral-actionbar id="bar">
-    <coral-actionbar-primary threshold="1" morebuttontext="More Left">
+    <coral-actionbar-primary threshold="3" morebuttontext="More Left">
         <coral-actionbar-item>
             <button is="coral-button" style="display:none;" icon="viewCard">View Card</button>
         </coral-actionbar-item>
@@ -18,7 +18,7 @@
             <button is="coral-button" variant="quiet">1 selected</button>
         </coral-actionbar-item>
     </coral-actionbar-primary>
-    <coral-actionbar-secondary threshold="2" morebuttontext="More Right">
+    <coral-actionbar-secondary threshold="3" morebuttontext="More Right">
         <coral-actionbar-item>
             <button is="coral-button" style="display:none;" icon="search">Search</button>
         </coral-actionbar-item>

--- a/coral-component-actionbar/src/tests/snippets/ActionBar.hiddenitems.html
+++ b/coral-component-actionbar/src/tests/snippets/ActionBar.hiddenitems.html
@@ -1,0 +1,32 @@
+<coral-actionbar id="bar">
+    <coral-actionbar-primary threshold="1" morebuttontext="More Left">
+        <coral-actionbar-item>
+            <button is="coral-button" style="display:none;" icon="viewCard">View Card</button>
+        </coral-actionbar-item>
+        <coral-actionbar-item>
+            <button is="coral-button" icon="viewList">View List</button>
+        </coral-actionbar-item>
+        <coral-actionbar-item>
+            <coral-fileupload>
+                <button is="coral-button" icon="upload">Upload Files</button>
+            </coral-fileupload>
+        </coral-actionbar-item>
+        <coral-actionbar-item>
+            <button is="coral-button" icon="viewColumn">View Column</button>
+        </coral-actionbar-item>
+        <coral-actionbar-item>
+            <button is="coral-button" variant="quiet">1 selected</button>
+        </coral-actionbar-item>
+    </coral-actionbar-primary>
+    <coral-actionbar-secondary threshold="2" morebuttontext="More Right">
+        <coral-actionbar-item>
+            <button is="coral-button" style="display:none;" icon="search">Search</button>
+        </coral-actionbar-item>
+        <coral-actionbar-item>
+            <button is="coral-button" icon="clock">Timeline</button>
+        </coral-actionbar-item>
+        <coral-actionbar-item>
+            <button is="coral-button" icon="unmerge">References</button>
+        </coral-actionbar-item>
+    </coral-actionbar-secondary>
+</coral-actionbar>

--- a/coral-component-actionbar/src/tests/snippets/ActionBar.hiddenitems.html
+++ b/coral-component-actionbar/src/tests/snippets/ActionBar.hiddenitems.html
@@ -1,32 +1,47 @@
 <coral-actionbar id="bar">
-    <coral-actionbar-primary threshold="3" morebuttontext="More Left">
-        <coral-actionbar-item>
-            <button is="coral-button" style="display:none;" icon="viewCard">View Card</button>
-        </coral-actionbar-item>
-        <coral-actionbar-item>
-            <button is="coral-button" icon="viewList">View List</button>
-        </coral-actionbar-item>
-        <coral-actionbar-item>
-            <coral-fileupload>
-                <button is="coral-button" icon="upload">Upload Files</button>
-            </coral-fileupload>
-        </coral-actionbar-item>
-        <coral-actionbar-item>
-            <button is="coral-button" icon="viewColumn">View Column</button>
-        </coral-actionbar-item>
-        <coral-actionbar-item>
-            <button is="coral-button" variant="quiet">1 selected</button>
-        </coral-actionbar-item>
-    </coral-actionbar-primary>
-    <coral-actionbar-secondary threshold="3" morebuttontext="More Right">
-        <coral-actionbar-item>
-            <button is="coral-button" style="display:none;" icon="search">Search</button>
-        </coral-actionbar-item>
-        <coral-actionbar-item>
-            <button is="coral-button" icon="clock">Timeline</button>
-        </coral-actionbar-item>
-        <coral-actionbar-item>
-            <button is="coral-button" icon="unmerge">References</button>
-        </coral-actionbar-item>
-    </coral-actionbar-secondary>
+  <coral-actionbar-primary threshold="3" morebuttontext="More Left">
+    <coral-actionbar-item>
+      <button is="coral-button" style="display:none;" icon="viewCard">View Card</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="viewList">View List</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <coral-fileupload>
+        <button is="coral-button" icon="upload">Upload Files</button>
+      </coral-fileupload>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="viewColumn">View Column</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" variant="quiet">1 selected</button>
+    </coral-actionbar-item>
+  </coral-actionbar-primary>
+  <coral-actionbar-secondary threshold="2" morebuttontext="More Right">
+    <coral-actionbar-item>
+      <button is="coral-button" style="display:none;" icon="search">Search</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="clock">Timeline</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="infoCircle">View Properties</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="copy">Copy</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="move">Move</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="globe">Publish</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="globeRemove">Unpublish</button>
+    </coral-actionbar-item>
+    <coral-actionbar-item>
+      <button is="coral-button" icon="delete">Delete</button>
+    </coral-actionbar-item>
+  </coral-actionbar-secondary>
 </coral-actionbar>

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -565,59 +565,46 @@ describe('ActionBar', function() {
     });
   
     it('should allow tab navigation to actionbar item, if first item is not selectable then next selectable item should be tab-able. e.g. first item is hidden', function (done) {
-      helpers.build(window.__html__['Coral.ActionBar.hiddenitems.html'], function (bar) {
-        helpers.next(function () {
-          expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
-        
-          let leftActionBarItems = bar.primary.items.getAll();
-          let rightActionBarItems = bar.secondary.items.getAll();
-        
-          // simulate a tab press on first item in actionbar simply by setting focus as I can't trigger a real one ..
-          let firstLeftButton = leftActionBarItems[0].querySelector('button');
-          firstLeftButton.focus();
-        
-          expect(document.activeElement).to.not.equal(firstLeftButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
-        
-          let secondLeftButton = leftActionBarItems[1].querySelector('button');
-          expect(document.activeElement).to.not.equal(secondLeftButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
-          expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tabable');
-          expect(bar.primary._elements.moreButton.getAttribute('tabindex')).to.equal('-1', 'more should not be tabable');
-        
-          let i = 0;
-          for (i = 1; i < leftActionBarItems.length; i++) {
-            expect(leftActionBarItems[i].querySelector('button').getAttribute('tabindex')).to.equal('-1', 'all other items should not be tabable("' + i + '" failed"');
-          }
-        
-          let firstRightButton = rightActionBarItems[0].querySelector('button');
-          firstRightButton.focus();
-        
-          expect(document.activeElement).to.not.equal(firstRightButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
-        
-          let secondRightButton = rightActionBarItems[1].querySelector('button');
-          expect(document.activeElement).to.not.equal(secondRightButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
-          expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tabable');
-        
-          for (i = 1; i < rightActionBarItems.length; i++) {
-            expect(rightActionBarItems[i].querySelector('button').getAttribute('tabindex')).to.equal('-1', 'all other items should not be tabable("' + i + '" failed"');
-          }
-        
-          done();
-        });
-      });
+      let bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
+      expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
+    
+      let leftActionBarItems = bar.primary.items.getAll();
+      let rightActionBarItems = bar.secondary.items.getAll();
+    
+      // Wait for resize listener
+      window.setTimeout(function () {
+        let firstLeftButton = leftActionBarItems[0].querySelector('button');
+        firstLeftButton.focus();
+        expect(document.activeElement).to.not.equal(firstLeftButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
+      
+        let secondLeftButton = leftActionBarItems[1].querySelector('button');
+        secondLeftButton.focus();
+        expect(document.activeElement).to.equal(secondLeftButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
+        expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tab-able');
+        expect(bar.primary._elements.moreButton.getAttribute('tabindex')).to.equal('-1', 'more should not be tab-able');
+      
+        let firstRightButton = rightActionBarItems[0].querySelector('button');
+        firstRightButton.focus();
+        expect(document.activeElement).to.not.equal(firstRightButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
+      
+        let secondRightButton = rightActionBarItems[1].querySelector('button');
+        secondRightButton.focus();
+        expect(document.activeElement).to.equal(secondRightButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
+      
+    //    expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tab-able');
+      
+        done();
+      }, 200);
     });
   
     it('selectable items at 2nd level inside coral-actionbar-item in tree should be tab-able', function (done) {
-      helpers.build(window.__html__['Coral.ActionBar.hiddenitems.html'], function (bar) {
-        helpers.next(function () {
-          expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
-        
-          let leftActionBarItems = bar.primary.items.getAll();
-          let uploadButton = leftActionBarItems[2].querySelector('coral-fileupload>button');
-        
-          expect(uploadButton.getAttribute('tabindex')).to.equal('-1', 'more should not be tabable');
-          done();
-        });
-      });
+      let bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
+      expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
+    
+      let leftActionBarItems = bar.primary.items.getAll();
+      let uploadButton = leftActionBarItems[2].querySelector('coral-fileupload>button');
+      expect(uploadButton.getAttribute('tabindex')).to.equal('-1', 'upload button should not be tabable');
+      done();
     });
   
     describe('Smart Overlay', () => {

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -564,6 +564,62 @@ describe('ActionBar', function() {
       }, 200);
     });
   
+    it('should allow tab navigation to actionbar item, if first item is not selectable then next selectable item should be tab-able. e.g. first item is hidden', function (done) {
+      helpers.build(window.__html__['Coral.ActionBar.hiddenitems.html'], function (bar) {
+        helpers.next(function () {
+          expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
+        
+          let leftActionBarItems = bar.primary.items.getAll();
+          let rightActionBarItems = bar.secondary.items.getAll();
+        
+          // simulate a tab press on first item in actionbar simply by setting focus as I can't trigger a real one ..
+          let firstLeftButton = leftActionBarItems[0].querySelector('button');
+          firstLeftButton.focus();
+        
+          expect(document.activeElement).to.not.equal(firstLeftButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
+        
+          let secondLeftButton = leftActionBarItems[1].querySelector('button');
+          expect(document.activeElement).to.not.equal(secondLeftButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
+          expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tabable');
+          expect(bar.primary._elements.moreButton.getAttribute('tabindex')).to.equal('-1', 'more should not be tabable');
+        
+          let i = 0;
+          for (i = 1; i < leftActionBarItems.length; i++) {
+            expect(leftActionBarItems[i].querySelector('button').getAttribute('tabindex')).to.equal('-1', 'all other items should not be tabable("' + i + '" failed"');
+          }
+        
+          let firstRightButton = rightActionBarItems[0].querySelector('button');
+          firstRightButton.focus();
+        
+          expect(document.activeElement).to.not.equal(firstRightButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
+        
+          let secondRightButton = rightActionBarItems[1].querySelector('button');
+          expect(document.activeElement).to.not.equal(secondRightButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
+          expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tabable');
+        
+          for (i = 1; i < rightActionBarItems.length; i++) {
+            expect(rightActionBarItems[i].querySelector('button').getAttribute('tabindex')).to.equal('-1', 'all other items should not be tabable("' + i + '" failed"');
+          }
+        
+          done();
+        });
+      });
+    });
+  
+    it('selectable items at 2nd level inside coral-actionbar-item in tree should be tab-able', function (done) {
+      helpers.build(window.__html__['Coral.ActionBar.hiddenitems.html'], function (bar) {
+        helpers.next(function () {
+          expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
+        
+          let leftActionBarItems = bar.primary.items.getAll();
+          let uploadButton = leftActionBarItems[2].querySelector('coral-fileupload>button');
+        
+          expect(uploadButton.getAttribute('tabindex')).to.equal('-1', 'more should not be tabable');
+          done();
+        });
+      });
+    });
+  
     describe('Smart Overlay', () => {
       helpers.testSmartOverlay('coral-actionbar-primary');
       helpers.testSmartOverlay('coral-actionbar-secondary');

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -565,7 +565,7 @@ describe('ActionBar', function() {
     });
   
     it('should allow tab navigation to actionbar item, if first item is not selectable then next selectable item should be tab-able. e.g. first item is hidden', function (done) {
-      let bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
+      const bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
       expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
     
       let leftActionBarItems = bar.primary.items.getAll();
@@ -590,20 +590,42 @@ describe('ActionBar', function() {
         let secondRightButton = rightActionBarItems[1].querySelector('button');
         secondRightButton.focus();
         expect(document.activeElement).to.equal(secondRightButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
-      
-    //    expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tab-able');
+        expect(bar.secondary._elements.moreButton.getAttribute('tabindex')).to.not.equal('-1', 'more should be tab-able');
       
         done();
       }, 200);
     });
   
     it('selectable items at 2nd level inside coral-actionbar-item in tree should be tab-able', function (done) {
-      let bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
+      const bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
       expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
     
       let leftActionBarItems = bar.primary.items.getAll();
       let uploadButton = leftActionBarItems[2].querySelector('coral-fileupload>button');
       expect(uploadButton.getAttribute('tabindex')).to.equal('-1', 'upload button should not be tabable');
+      done();
+    });
+  
+    it('offscreen items should not be accessible', function (done) {
+      const bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
+      expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
+      let leftActionBarItems = bar.primary.items.getAll();
+      let rightActionBarItems = bar.secondary.items.getAll();
+    
+    
+      let i = 0;
+      for (i = 1; i < leftActionBarItems.length; i++) {
+        if (leftActionBarItems[i].hasAttribute('coral-actionbar-offscreen')) {
+          expect(leftActionBarItems[i].getAttribute('aria-hidden')).to.equal('true', 'offscreen items should not be accessible("' + i + '" failed"');
+        
+        }
+      }
+      for (i = 1; i < rightActionBarItems.length; i++) {
+        if (rightActionBarItems[i].hasAttribute('coral-actionbar-offscreen')) {
+          expect(rightActionBarItems[i].getAttribute('aria-hidden')).to.equal('true', 'offscreen items should not be accessible("' + i + '" failed"');
+        
+        }
+      }
       done();
     });
   

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -569,7 +569,6 @@ describe('ActionBar', function() {
       expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
     
       let leftActionBarItems = bar.primary.items.getAll();
-      let rightActionBarItems = bar.secondary.items.getAll();
     
       // Wait for resize listener
       window.setTimeout(function () {
@@ -582,16 +581,8 @@ describe('ActionBar', function() {
         expect(document.activeElement).to.equal(secondLeftButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
         expect(document.activeElement.getAttribute('tabindex')).to.not.equal('-1', 'this element should be tab-able');
         expect(bar.primary._elements.moreButton.getAttribute('tabindex')).to.equal('-1', 'more should not be tab-able');
-      
-        let firstRightButton = rightActionBarItems[0].querySelector('button');
-        firstRightButton.focus();
-        expect(document.activeElement).to.not.equal(firstRightButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
-      
-        let secondRightButton = rightActionBarItems[1].querySelector('button');
-        secondRightButton.focus();
-        expect(document.activeElement).to.equal(secondRightButton, 'activeElement should now be the second wrapped item (here button) inside the actionbar');
+        
         expect(bar.secondary._elements.moreButton.getAttribute('tabindex')).to.not.equal('-1', 'more should be tab-able');
-      
         done();
       }, 200);
     });
@@ -606,7 +597,7 @@ describe('ActionBar', function() {
       done();
     });
   
-    it('offscreen items should not be accessible', function (done) {
+    it('offscreen items should not be visible', function (done) {
       const bar = helpers.build(window.__html__['ActionBar.hiddenitems.html']);
       expect(document.activeElement.tagName.toLowerCase()).to.not.equal('button', 'activeElement should not be an one of the buttons inside the actionbar');
       let leftActionBarItems = bar.primary.items.getAll();
@@ -614,16 +605,34 @@ describe('ActionBar', function() {
     
     
       let i = 0;
-      for (i = 1; i < leftActionBarItems.length; i++) {
+      for (; i < leftActionBarItems.length; i++) {
         if (leftActionBarItems[i].hasAttribute('coral-actionbar-offscreen')) {
-          expect(leftActionBarItems[i].getAttribute('aria-hidden')).to.equal('true', 'offscreen items should not be accessible("' + i + '" failed"');
-        
+          expect(leftActionBarItems[i].style.visibility).to.equal('hidden', 'offscreen items should not be accessible("' + i + '" failed"');
         }
       }
-      for (i = 1; i < rightActionBarItems.length; i++) {
+      for (i = 0; i < rightActionBarItems.length; i++) {
         if (rightActionBarItems[i].hasAttribute('coral-actionbar-offscreen')) {
-          expect(rightActionBarItems[i].getAttribute('aria-hidden')).to.equal('true', 'offscreen items should not be accessible("' + i + '" failed"');
-        
+          expect(rightActionBarItems[i].style.visibility).to.equal('hidden', 'offscreen items should not be accessible("' + i + '" failed"');
+        }
+      }
+  
+      bar.primary._elements.moreButton.click();
+      expect(bar.primary._elements.overlay.open).to.equal(true, 'left popover should be opened');
+      let leftPopOverItems =  bar.primary._itemsInPopover;
+      
+      for (i = 0; i < leftPopOverItems.length; i++) {
+        if (leftPopOverItems[i].hasAttribute('coral-actionbar-offscreen')) {
+          expect(leftPopOverItems[i].style.visibility).to.equal('', 'offscreen items should be accessible("' + i + '" failed"');
+        }
+      }
+  
+      bar.secondary._elements.moreButton.click();
+      expect(bar.secondary._elements.overlay.open).to.equal(true, 'right popover should be opened');
+  
+      let rightPopOverItems =  bar.secondary._itemsInPopover;
+      for (i = 0; i < rightPopOverItems.length; i++) {
+        if (rightPopOverItems[i].hasAttribute('coral-actionbar-offscreen')) {
+          expect(rightPopOverItems[i].style.visibility).to.equal('', 'offscreen items should be accessible("' + i + '" failed"');
         }
       }
       done();


### PR DESCRIPTION
The changes fixes 2 issues :
1. ActionBar items which has selectable elements at 2nd level e.g. coral-fileupload are not selectable.
2. Offscreen ActionBar items are accessible.

## Description
1. Added code to find selectable elements in an ActionBar item if no selectable element found at first level.
2. Added code to set aria-hidden="true" to hide offscreen items from being read by screen-reader.

## Related Issue - CUI-7341
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Manually tested with keyboard navigation.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
