### PR TITLE
CUI-7338 [CoralUI-Calender, CoralUI-DatePicker] NO visible labels for…

### DIFF
--- a/coral-component-clock/src/styles/index.styl
+++ b/coral-component-clock/src/styles/index.styl
@@ -37,6 +37,7 @@
   text-align: center;
   width: 16px;
   vertical-align: middle;
+  padding-top: 16px;
 }
 
 ._coral-Clock ._coral-Clock-period {

--- a/coral-component-clock/src/templates/base.html
+++ b/coral-component-clock/src/templates/base.html
@@ -1,9 +1,9 @@
 <input type="hidden" name="" handle="input">
 <time handle="valueAsText" id="{{data.commons.getUID()}}" hidden></time>
-<label for="_coral-Clock-hour" class="coral-Form-fieldlabel">{{Coral.i18n.get('Hours')}}</label>
+<label for="_coral-Clock-hour" class="coral-Form-fieldlabel">{{data.i18n.get('Hours')}}</label>
 <input is="coral-textfield" id="{{data.commons.getUID()}}" type="number" min="0" max="23" class="_coral-Clock-hour" handle="hours" id="_coral-Clock-hour" aria-label="{{data.i18n.get('Hours')}}">
 <span class="_coral-Clock-divider" handle="divider">:</span>
-<label for="_coral-Clock-minute"  class="coral-Form-fieldlabel">{{Coral.i18n.get('Minutes')}}</label>
+<label for="_coral-Clock-minute"  class="coral-Form-fieldlabel">{{data.i18n.get('Minutes')}}</label>
 <input is="coral-textfield" type="number" min="0" max="59" class="_coral-Clock-minute" handle="minutes" id="_coral-Clock-minute" aria-label="{{data.i18n.get('Minutes')}}">
 <coral-select handle="period" class="_coral-Clock-period" hidden aria-label="{{data.i18n.get('AM/PM')}}">
   <coral-select-item value="am"></coral-select-item>

--- a/coral-component-clock/src/templates/base.html
+++ b/coral-component-clock/src/templates/base.html
@@ -1,8 +1,10 @@
 <input type="hidden" name="" handle="input">
 <time handle="valueAsText" id="{{data.commons.getUID()}}" hidden></time>
-<input is="coral-textfield" id="{{data.commons.getUID()}}" type="number" min="0" max="23" class="_coral-Clock-hour" handle="hours" aria-label="{{data.i18n.get('Hours')}}">
+<label for="_coral-Clock-hour" class="coral-Form-fieldlabel">{{Coral.i18n.get('Hours')}}</label>
+<input is="coral-textfield" id="{{data.commons.getUID()}}" type="number" min="0" max="23" class="_coral-Clock-hour" handle="hours" id="_coral-Clock-hour" aria-label="{{data.i18n.get('Hours')}}">
 <span class="_coral-Clock-divider" handle="divider">:</span>
-<input is="coral-textfield" type="number" min="0" max="59" class="_coral-Clock-minute" handle="minutes" aria-label="{{data.i18n.get('Minutes')}}">
+<label for="_coral-Clock-minute"  class="coral-Form-fieldlabel">{{Coral.i18n.get('Minutes')}}</label>
+<input is="coral-textfield" type="number" min="0" max="59" class="_coral-Clock-minute" handle="minutes" id="_coral-Clock-minute" aria-label="{{data.i18n.get('Minutes')}}">
 <coral-select handle="period" class="_coral-Clock-period" hidden aria-label="{{data.i18n.get('AM/PM')}}">
   <coral-select-item value="am"></coral-select-item>
   <coral-select-item value="pm"></coral-select-item>


### PR DESCRIPTION
… Hour and Minute input fields in coral calendar

Added Labels for hours and minutes in clock component.

## Description
labels for hours and minutes have been added to base.html for coral-component-clock

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [`x`] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [`x` ] I have read the **CONTRIBUTING** document.
