### PR TITLE
Enable manual aria-label handling, deprecating aria-label generation

### DIFF
--- a/coral-component-icon/src/scripts/Icon.js
+++ b/coral-component-icon/src/scripts/Icon.js
@@ -73,7 +73,7 @@ const SPLIT_CAMELCASE_REGEX = /([a-z0-9])([A-Z])/g;
 /**
  * Parameter for toggling aria-label handling by coral.
  */
-const DISABLE_AUTO_ARIA_LABEL = 'disable-auto-aria-label';
+const CORAL_HANDLE_ARIA = 'coral-aria-label';
 
 /**
  Returns capitalized string. This is used to map the icons with their SVG counterpart.
@@ -322,7 +322,7 @@ class Icon extends BaseComponent(HTMLElement) {
   /**
    Autogenerating aria-label is being deprecated
    Please provide your own contextual proper aria-label[ledby] information
-   Please use disable-auto-aria-label boolean attribute, the flag removes aria-label handling and will be default behaviour in the future.
+   Please use coral-aria-label='false', the flag removes aria-label handling and will be default behaviour in the future.
 
    Updates the aria-label or img alt attribute depending on value of alt, title or icon.
 
@@ -331,10 +331,11 @@ class Icon extends BaseComponent(HTMLElement) {
    to explicitly override the default behavior, or when we remove an alt attribute
    thus restoring the default behavior, we make sure to update the alt text.
    @private
+   @deprecated
    */
   _updateAltText(value) {
     const isImage = this.contains(this._elements.image);
-    const shouldHandleAriaLabel = !this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
+    const shouldHandleAriaLabel = this.getAttribute(CORAL_HANDLE_ARIA, 'true') !== 'false';
 
     let altText;
     if (typeof value === 'string') {
@@ -367,9 +368,6 @@ class Icon extends BaseComponent(HTMLElement) {
     }
   }
 
-  /**
-   * @deprecated
-   */
   _updateAriaLabel(altText, isImage) {
     if (isImage) {
       this.removeAttribute('aria-label');

--- a/coral-component-icon/src/scripts/Icon.js
+++ b/coral-component-icon/src/scripts/Icon.js
@@ -73,7 +73,7 @@ const SPLIT_CAMELCASE_REGEX = /([a-z0-9])([A-Z])/g;
 /**
  * Parameter for toggling aria-label handling by coral.
  */
-const CORAL_HANDLE_ARIA = 'coral-aria-label';
+const AUTO_ARIA_LABEL = 'autoAriaLabel';
 
 /**
  Returns capitalized string. This is used to map the icons with their SVG counterpart.
@@ -322,7 +322,7 @@ class Icon extends BaseComponent(HTMLElement) {
   /**
    Autogenerating aria-label is being deprecated
    Please provide your own contextual proper aria-label[ledby] information
-   Please use coral-aria-label='false', the flag removes aria-label handling and will be default behaviour in the future.
+   Please use autoAriaLabel='off', the flag removes aria-label handling and will be default behaviour in the future.
 
    Updates the aria-label or img alt attribute depending on value of alt, title or icon.
 
@@ -331,11 +331,10 @@ class Icon extends BaseComponent(HTMLElement) {
    to explicitly override the default behavior, or when we remove an alt attribute
    thus restoring the default behavior, we make sure to update the alt text.
    @private
-   @deprecated
    */
   _updateAltText(value) {
     const isImage = this.contains(this._elements.image);
-    const shouldHandleAriaLabel = this.getAttribute(CORAL_HANDLE_ARIA, 'true') !== 'false';
+    const shouldHandleAriaLabel = this.getAttribute(AUTO_ARIA_LABEL, 'on') !== 'off';
 
     let altText;
     if (typeof value === 'string') {
@@ -368,6 +367,9 @@ class Icon extends BaseComponent(HTMLElement) {
     }
   }
 
+  /**
+   @deprecated
+   */
   _updateAriaLabel(altText, isImage) {
     if (isImage) {
       this.removeAttribute('aria-label');

--- a/coral-component-icon/src/scripts/Icon.js
+++ b/coral-component-icon/src/scripts/Icon.js
@@ -73,7 +73,7 @@ const SPLIT_CAMELCASE_REGEX = /([a-z0-9])([A-Z])/g;
 /**
  * Parameter for toggling aria-label handling by coral.
  */
-const CORAL_HANDLE_ARIA = 'coral-aria-label';
+const DISABLE_AUTO_ARIA_LABEL = 'disable-auto-aria-label';
 
 /**
  Returns capitalized string. This is used to map the icons with their SVG counterpart.
@@ -322,7 +322,7 @@ class Icon extends BaseComponent(HTMLElement) {
   /**
    Autogenerating aria-label is being deprecated
    Please provide your own contextual proper aria-label[ledby] information
-   Please use coral-aria-label='false', the flag removes aria-label handling and will be default behaviour in the future.
+   Please use disable-auto-aria-label boolean attribute, the flag removes aria-label handling and will be default behaviour in the future.
 
    Updates the aria-label or img alt attribute depending on value of alt, title or icon.
 
@@ -331,11 +331,10 @@ class Icon extends BaseComponent(HTMLElement) {
    to explicitly override the default behavior, or when we remove an alt attribute
    thus restoring the default behavior, we make sure to update the alt text.
    @private
-   @deprecated
    */
   _updateAltText(value) {
     const isImage = this.contains(this._elements.image);
-    const shouldHandleAriaLabel = this.getAttribute(CORAL_HANDLE_ARIA, 'true') !== 'false';
+    const shouldHandleAriaLabel = !this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
 
     let altText;
     if (typeof value === 'string') {
@@ -368,6 +367,9 @@ class Icon extends BaseComponent(HTMLElement) {
     }
   }
 
+  /**
+   * @deprecated
+   */
   _updateAriaLabel(altText, isImage) {
     if (isImage) {
       this.removeAttribute('aria-label');

--- a/coral-component-icon/src/tests/test.Icon.js
+++ b/coral-component-icon/src/tests/test.Icon.js
@@ -394,10 +394,10 @@ describe('Icon', function() {
         expect(icon.hasAttribute('aria-label')).to.be.false;
       });
 
-      it('shouldnt set aria-label when coral-aria-label is false', function (done) {
+      it('shouldnt set aria-label when autoAriaLabel is false', function (done) {
         var icon = helpers.build(new Icon());
 
-        icon.setAttribute('coral-aria-label', 'false');
+        icon.setAttribute('autoAriaLabel', 'off');
         icon.icon = 'add';
 
         helpers.next(function () {
@@ -406,10 +406,10 @@ describe('Icon', function() {
         });
       });
 
-      it('should set default aria-label when coral-aria-label is anything else than false', function (done) {
+      it('should set default aria-label when autoAriaLabel is anything else than false', function (done) {
         var icon = helpers.build(new Icon());
 
-        icon.setAttribute('coral-aria-label', 'asdf');
+        icon.setAttribute('autoAriaLabel', 'asdf');
         icon.icon = 'add';
 
         helpers.next(function () {

--- a/coral-component-icon/src/tests/test.Icon.js
+++ b/coral-component-icon/src/tests/test.Icon.js
@@ -394,10 +394,10 @@ describe('Icon', function() {
         expect(icon.hasAttribute('aria-label')).to.be.false;
       });
 
-      it('shouldnt set aria-label when disable-auto-aria-label is set to empty string', function (done) {
+      it('shouldnt set aria-label when coral-aria-label is false', function (done) {
         var icon = helpers.build(new Icon());
 
-        icon.setAttribute('disable-auto-aria-label', '');
+        icon.setAttribute('coral-aria-label', 'false');
         icon.icon = 'add';
 
         helpers.next(function () {
@@ -406,33 +406,10 @@ describe('Icon', function() {
         });
       });
 
-      it('shouldnt set aria-label when disable-auto-aria-label is set to it\'s canonical name', function (done) {
+      it('should set default aria-label when coral-aria-label is anything else than false', function (done) {
         var icon = helpers.build(new Icon());
 
-        icon.setAttribute('disable-auto-aria-label', 'disable-auto-aria-label');
-        icon.icon = 'add';
-
-        helpers.next(function () {
-          expect(icon.hasAttribute('aria-label')).to.be.false;
-          done();
-        });
-      });
-
-      it('shouldnt set aria-label when disable-auto-aria-label is set', function (done) {
-        var icon = helpers.build(new Icon());
-
-        icon.setAttribute('disable-auto-aria-label');
-        icon.icon = 'add';
-
-        helpers.next(function () {
-          expect(icon.hasAttribute('aria-label')).to.be.false;
-          done();
-        });
-      });
-
-      it('should set default aria-label when disable-auto-aria-label not set', function (done) {
-        var icon = helpers.build(new Icon());
-
+        icon.setAttribute('coral-aria-label', 'asdf');
         icon.icon = 'add';
 
         helpers.next(function () {

--- a/coral-component-icon/src/tests/test.Icon.js
+++ b/coral-component-icon/src/tests/test.Icon.js
@@ -394,10 +394,10 @@ describe('Icon', function() {
         expect(icon.hasAttribute('aria-label')).to.be.false;
       });
 
-      it('shouldnt set aria-label when coral-aria-label is false', function (done) {
+      it('shouldnt set aria-label when disable-auto-aria-label is set to empty string', function (done) {
         var icon = helpers.build(new Icon());
 
-        icon.setAttribute('coral-aria-label', 'false');
+        icon.setAttribute('disable-auto-aria-label', '');
         icon.icon = 'add';
 
         helpers.next(function () {
@@ -406,10 +406,33 @@ describe('Icon', function() {
         });
       });
 
-      it('should set default aria-label when coral-aria-label is anything else than false', function (done) {
+      it('shouldnt set aria-label when disable-auto-aria-label is set to it\'s canonical name', function (done) {
         var icon = helpers.build(new Icon());
 
-        icon.setAttribute('coral-aria-label', 'asdf');
+        icon.setAttribute('disable-auto-aria-label', 'disable-auto-aria-label');
+        icon.icon = 'add';
+
+        helpers.next(function () {
+          expect(icon.hasAttribute('aria-label')).to.be.false;
+          done();
+        });
+      });
+
+      it('shouldnt set aria-label when disable-auto-aria-label is set', function (done) {
+        var icon = helpers.build(new Icon());
+
+        icon.setAttribute('disable-auto-aria-label');
+        icon.icon = 'add';
+
+        helpers.next(function () {
+          expect(icon.hasAttribute('aria-label')).to.be.false;
+          done();
+        });
+      });
+
+      it('should set default aria-label when disable-auto-aria-label not set', function (done) {
+        var icon = helpers.build(new Icon());
+
         icon.icon = 'add';
 
         helpers.next(function () {

--- a/coral-component-icon/src/tests/test.Icon.js
+++ b/coral-component-icon/src/tests/test.Icon.js
@@ -7,15 +7,15 @@ Icon._iconsExternal = () => 'off';
 describe('Icon', function() {
   const hasSVGIcon = (el, icon, ignoreCapitalize) => {
     const capitalize = s => s.charAt(0).toUpperCase() + s.slice(1);
-    
+
     if (el._elements.svg && el.contains(el._elements.svg)) {
       const iconName = ignoreCapitalize ? icon : capitalize(icon);
       return el._elements.svg.querySelector('use').href.baseVal.endsWith(iconName);
     }
-    
+
     return false;
   };
-  
+
   describe('Namespace', function() {
     it('should define the sizes in an enum', function() {
       expect(Icon.size).to.exist;
@@ -29,7 +29,7 @@ describe('Icon', function() {
       expect(Object.keys(Icon.size).length).to.equal(7);
     });
   });
-  
+
   describe('Instantiation', function() {
     it('should be possible using new', function() {
       var icon = helpers.build(new Icon());
@@ -48,17 +48,17 @@ describe('Icon', function() {
       expect(icon.classList.contains('_coral-Icon')).to.be.true;
       expect(icon.classList.contains('_coral-Icon--sizeS')).to.be.true;
     });
-    
+
     helpers.cloneComponent(
       'should be possible to clone using markup',
       '<coral-icon icon="add" size="L"></coral-icon>'
     );
-  
+
     helpers.cloneComponent(
       'should be possible to clone an image icon using markup',
       '<coral-icon icon="http://via.placeholder.com/150x150" size="L"></coral-icon>'
     );
-  
+
     helpers.cloneComponent(
       'should be possible to clone using js',
       new Icon().set({
@@ -159,11 +159,11 @@ describe('Icon', function() {
     beforeEach(() => {
       icon = helpers.build(new Icon());
     });
-  
+
     afterEach(() => {
       icon = null;
     });
-    
+
     describe('#icon', function() {
       it('should default to null', function() {
         expect(icon.icon).to.equal('');
@@ -185,13 +185,13 @@ describe('Icon', function() {
         expect(icon.hasAttribute('icon')).to.be.true;
         expect(hasSVGIcon(icon, 'add')).to.be.true;
       });
-      
+
       it('should not render the same icon', function() {
         icon.icon = 'add';
-        
+
         icon.querySelector('svg').id = 'add';
         icon.icon = 'add';
-        
+
         expect(icon.querySelector('svg').id).to.equal('add');
       });
 
@@ -217,14 +217,14 @@ describe('Icon', function() {
       it('should not set multiple SVG icons', function() {
         icon.icon = 'adobeSocial';
         icon.icon = 'add';
-  
+
         expect(hasSVGIcon(icon, 'add')).to.be.true;
         expect(icon.querySelectorAll('svg').length).to.equal(1);
       });
 
       it('should remove the icon with null', function() {
         icon.icon = 'add';
-  
+
         expect(hasSVGIcon(icon, 'add')).to.be.true;
 
         icon.icon = null;
@@ -235,7 +235,7 @@ describe('Icon', function() {
 
       it('should remove the icon with undefined', function() {
         icon.icon = 'add';
-  
+
         expect(hasSVGIcon(icon, 'add')).to.be.true;
 
         icon.icon = undefined;
@@ -246,7 +246,7 @@ describe('Icon', function() {
 
       it('should remove the icon with empty string', function() {
         icon.icon = 'add';
-  
+
         expect(hasSVGIcon(icon, 'add')).to.be.true;
 
         icon.icon = '';
@@ -266,20 +266,20 @@ describe('Icon', function() {
         expect(icon.icon).to.equal('');
         expect(hasSVGIcon(icon, 'add')).to.be.false;
       });
-      
+
       it('should support SVG icon Id', function() {
         icon.icon = 'spectrum-css-icon-SearchClear';
         expect(icon.icon).to.equal('spectrum-css-icon-SearchClear');
         expect(hasSVGIcon(icon, 'spectrum-css-icon-SearchClear')).to.be.false;
       });
-      
+
       it('should support external SVG file reference', () => {
         Icon._iconsExternal = () => 'on';
         icon.icon = 'add';
         expect(icon._elements.svg.querySelector('use').href.baseVal.includes('spectrum-icons.svg')).to.be.true;
         Icon._iconsExternal = () => 'off';
       });
-      
+
       it('should not use external SVG file for colored icons', () => {
         Icon._iconsExternal = () => 'on';
         icon.icon = 'AdobeAudienceManagerColor';
@@ -307,7 +307,7 @@ describe('Icon', function() {
 
         expect(icon.classList.contains('_coral-Icon--sizeL')).to.be.true;
       });
-      
+
       it('should be set with an attribute', function() {
         icon.setAttribute('size', Icon.size.LARGE);
         expect(icon.size).to.equal(Icon.size.LARGE);
@@ -343,120 +343,144 @@ describe('Icon', function() {
         expect(icon.classList.contains('_coral-Icon--sizeXS')).to.be.true;
         expect(icon.classList.contains('_coral-Icon--sizeME')).to.be.true;
       });
-      
+
       it('should update the icon if the size changed', function() {
         icon.icon = 'add';
         expect(icon._elements.svg.querySelector('use').href.baseVal.indexOf('18') !== -1).to.be.true;
-  
+
         icon.size = 'XXL';
-  
+
         expect(icon._elements.svg.querySelector('use').href.baseVal.indexOf('24') !== -1).to.be.true;
       });
     });
   });
-  
+
   describe('Implementation details', function() {
     describe('alt', function() {
       it('should add an aria-label equal to the value of the alt property', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'add';
         icon.alt = 'Add Item';
-    
+
         expect(icon.alt).to.equal('Add Item');
         expect(icon.getAttribute('aria-label')).to.equal('Add Item');
       });
-  
+
       it('should add an aria-label equal to the value of the icon property when not set and when no title attribute is present', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'add';
-    
+
         expect(icon.getAttribute('aria-label')).to.equal('add');
       });
-  
+
       it('should add an aria-label equal to the value of the title attribute property when not set and when a title attribute is present', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'add';
         icon.title = 'Add Item';
-    
+
         expect(icon.getAttribute('aria-label')).to.equal('Add Item');
       });
-  
+
       it('should have no aria-label attribute when explicitly set to an empty string', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'add';
         icon.title = 'Add Item';
         icon.alt = '';
-    
+
         expect(icon.hasAttribute('aria-label')).to.be.false;
       });
-  
+
+      it('shouldnt set aria-label when coral-aria-label is false', function (done) {
+        var icon = helpers.build(new Icon());
+
+        icon.setAttribute('coral-aria-label', 'false');
+        icon.icon = 'add';
+
+        helpers.next(function () {
+          expect(icon.hasAttribute('aria-label')).to.be.false;
+          done();
+        });
+      });
+
+      it('should set default aria-label when coral-aria-label is anything else than false', function (done) {
+        var icon = helpers.build(new Icon());
+
+        icon.setAttribute('coral-aria-label', 'asdf');
+        icon.icon = 'add';
+
+        helpers.next(function () {
+          expect(icon.getAttribute('aria-label')).to.equal('add');
+          done();
+        });
+      });
+
       it('should have role="img" when icon property is not a URL', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'add';
         icon.alt = 'Add Item';
-    
+
         expect(icon.getAttribute('role')).to.equal('img');
       });
-  
+
       it('should have role="presentation" when icon property is a URL', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'image.png';
-    
+
         expect(icon.getAttribute('role')).to.equal('presentation');
         expect(icon._elements.image.getAttribute('alt')).to.equal('');
       });
-  
+
       it('should update alt text on child image when icon property is a URL', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'image.png';
         icon.alt = 'Add Item';
-    
+
         expect(icon.getAttribute('role')).to.equal('presentation');
         expect(icon._elements.image.getAttribute('alt')).to.equal('Add Item');
       });
-  
+
       it('should set alt text on child image to value of title attribute empty string when icon property is a URL and alt is null', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'image.png';
         icon.title = 'Add Item';
-    
+
         expect(icon.getAttribute('role')).to.equal('presentation');
         expect(icon._elements.image.getAttribute('alt')).to.equal(icon.title);
       });
-  
+
       it('should set alt text on child image to an empty string when icon property is a URL and alt is an empty string', function() {
         var icon = helpers.build(new Icon());
-    
+
         icon.icon = 'image.png';
         icon.title = 'Add Item';
-    
+
         expect(icon.getAttribute('role')).to.equal('presentation');
         expect(icon._elements.image.getAttribute('alt')).to.equal(icon.title);
-    
+
         // By setting alt = '' explicitly, we override the default behavior and instead use an empty string for alt text.
         icon.alt = '';
         expect(icon._elements.image.getAttribute('alt')).to.equal('');
       });
     });
-    
+
     describe('SVG', function() {
       it('should render the SVG markup', function() {
         helpers.target.innerHTML = Icon._renderSVG('testId', ['testClass']);
-        
+
         const svg = helpers.target.querySelector('svg');
         expect(svg.classList.contains('testClass')).to.be.true;
         expect(svg.querySelector('use').href.baseVal.indexOf('testId') !== -1).to.be.true;
       });
     });
-    
+
     describe('IMG', function() {
       it('should use the existing img', function() {
         const el = helpers.build('<coral-icon><img id="img" src="image.jpg"/></coral-icon>');
@@ -466,84 +490,84 @@ describe('Icon', function() {
         expect(img.getAttribute('alt')).to.equal('');
       });
     });
-    
+
     describe('Template', function() {
       it('should ignore unresolved templates', function() {
         const el = helpers.build('<coral-icon icon="image-{{index}}.jpg"></coral-icon>');
         expect(el.querySelector('img')).to.equal(null);
       });
     });
-    
+
     describe('Compat', function() {
       let warn;
       let called = 0;
-      
+
       beforeEach(() => {
         warn = console.warn;
-        
+
         console.warn = function() {
           called++;
         };
       });
-      
+
       afterEach(() => {
         console.warn = warn;
         called = 0;
       });
-      
+
       it('should capitalize the icon name to match to the new icon name', function() {
         const el = helpers.build(new Icon());
         el.icon = 'add';
         expect(hasSVGIcon(el, 'Add', true)).to.be.true;
         expect(called).to.equal(0);
       });
-      
+
       it('should map the old icon name to the new icon name', function() {
         const el = helpers.build(new Icon());
         el.icon = 'adobe';
         expect(hasSVGIcon(el, 'AdobeLogo', true)).to.be.true;
         expect(called).to.equal(1);
       });
-  
+
       it('should map to the new icon name based on the light theme', function() {
         const container = document.createElement('div');
         const el = new Icon();
         container.appendChild(el);
-        
+
         container.classList.add('coral--light');
-  
+
         helpers.target.appendChild(container);
-  
+
         el.icon = 'userCircleColor';
-  
+
         expect(hasSVGIcon(el, 'UserCircleColor_Light', true)).to.be.true;
         expect(called).to.equal(1);
       });
-  
+
       it('should map to the new icon name based on the dark theme', function() {
         const container = document.createElement('div');
         const el = new Icon();
         container.appendChild(el);
-    
+
         container.classList.add('coral--dark');
-  
+
         helpers.target.appendChild(container);
-        
+
         el.icon = 'userCircleColor';
-    
+
         expect(hasSVGIcon(el, 'UserCircleColor_Dark', true)).to.be.true;
         expect(called).to.equal(1);
       });
-  
+
       it('should map to the new light icon by default if no theme specified', function() {
         const container = document.createElement('div');
         const el = new Icon();
         container.appendChild(el);
-        
+
         helpers.target.appendChild(container);
-  
+
         el.icon = 'userCircleColor';
-    
+
         expect(hasSVGIcon(el, 'UserCircleColor_Light', true)).to.be.true;
         expect(called).to.equal(1);
       });

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -21,7 +21,7 @@ const CLASSNAME = '_coral-Tabs-item';
 /**
  * Parameter for toggling aria-label handling by coral.
  */
-const CORAL_HANDLE_ARIA = 'coral-aria-label';
+const DISABLE_AUTO_ARIA_LABEL = 'disable-auto-aria-label';
 
 /**
  @class Coral.Tab
@@ -92,9 +92,9 @@ class Tab extends BaseComponent(HTMLElement) {
     return iconElement ? iconElement.icon : '';
   }
   set icon(value) {
-    const shouldHandleAriaLabel = this.getAttribute(CORAL_HANDLE_ARIA);
+    const shouldHandleAriaLabel = this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
     if (shouldHandleAriaLabel) {
-      this._elements.icon.setAttribute(CORAL_HANDLE_ARIA, this.getAttribute(CORAL_HANDLE_ARIA));
+      this._elements.icon.setAttribute(DISABLE_AUTO_ARIA_LABEL, '');
     }
     const iconElement = this._elements.icon;
     iconElement.icon = value;

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -21,7 +21,7 @@ const CLASSNAME = '_coral-Tabs-item';
 /**
  * Parameter for toggling aria-label handling by coral.
  */
-const DISABLE_AUTO_ARIA_LABEL = 'disable-auto-aria-label';
+const AUTO_ARIA_LABEL = 'autoAriaLabel';
 
 /**
  @class Coral.Tab
@@ -92,9 +92,9 @@ class Tab extends BaseComponent(HTMLElement) {
     return iconElement ? iconElement.icon : '';
   }
   set icon(value) {
-    const shouldHandleAriaLabel = this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
+    const shouldHandleAriaLabel = this.getAttribute(AUTO_ARIA_LABEL);
     if (shouldHandleAriaLabel) {
-      this._elements.icon.setAttribute(DISABLE_AUTO_ARIA_LABEL, '');
+      this._elements.icon.setAttribute(AUTO_ARIA_LABEL, this.getAttribute(AUTO_ARIA_LABEL));
     }
     const iconElement = this._elements.icon;
     iconElement.icon = value;

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -92,8 +92,8 @@ class Tab extends BaseComponent(HTMLElement) {
     return iconElement ? iconElement.icon : '';
   }
   set icon(value) {
-    const disableAutoAriaLabel = this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
-    if (disableAutoAriaLabel) {
+    const shouldHandleAriaLabel = this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
+    if (shouldHandleAriaLabel) {
       this._elements.icon.setAttribute(DISABLE_AUTO_ARIA_LABEL, '');
     }
     const iconElement = this._elements.icon;

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -92,8 +92,8 @@ class Tab extends BaseComponent(HTMLElement) {
     return iconElement ? iconElement.icon : '';
   }
   set icon(value) {
-    const shouldHandleAriaLabel = this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
-    if (shouldHandleAriaLabel) {
+    const disableAutoAriaLabel = this.hasAttribute(DISABLE_AUTO_ARIA_LABEL);
+    if (disableAutoAriaLabel) {
       this._elements.icon.setAttribute(DISABLE_AUTO_ARIA_LABEL, '');
     }
     const iconElement = this._elements.icon;

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -92,9 +92,9 @@ class Tab extends BaseComponent(HTMLElement) {
     return iconElement ? iconElement.icon : '';
   }
   set icon(value) {
-    const shouldHandleAriaLabel = this.getAttribute(AUTO_ARIA_LABEL);
+    const shouldHandleAriaLabel = this.hasAttribute('aria-label');
     if (shouldHandleAriaLabel) {
-      this._elements.icon.setAttribute(AUTO_ARIA_LABEL, this.getAttribute(AUTO_ARIA_LABEL));
+      this._elements.icon.setAttribute(AUTO_ARIA_LABEL, 'off');
     }
     const iconElement = this._elements.icon;
     iconElement.icon = value;

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -92,8 +92,8 @@ class Tab extends BaseComponent(HTMLElement) {
     return iconElement ? iconElement.icon : '';
   }
   set icon(value) {
-    const shouldHandleAriaLabel = this.hasAttribute('aria-label');
-    if (shouldHandleAriaLabel) {
+    const shouldDisableAutoAriaLabel = this.hasAttribute('aria-label');
+    if (shouldDisableAutoAriaLabel) {
       this._elements.icon.setAttribute(AUTO_ARIA_LABEL, 'off');
     }
     const iconElement = this._elements.icon;

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -157,19 +157,19 @@ describe('Tab', function() {
     describe('#icon', function() {
       var item;
 
-      it('should propagate disable-auto-aria-label flag to tab\'s icon', function() {
+      it('should propagate coral-aria-label flag to tab\'s icon', function() {
         item = new Tab();
-        item.setAttribute('disable-auto-aria-label', '');
+        item.setAttribute('coral-aria-label', 'test123');
         item.setAttribute('icon', 'Add');
 
-        expect(item._elements.icon.hasAttribute('disable-auto-aria-label')).to.be.true;
+        expect(item._elements.icon.getAttribute('coral-aria-label')).to.equal('test123');
       });
 
-      it('should not propagate disable-auto-aria-label flag to tab\'s icon if not set.', function() {
+      it('should not propagate coral-aria-label flag to tab\'s icon if not set.', function() {
         item = new Tab();
         item.setAttribute('icon', 'Add');
 
-        expect(item._elements.icon.hasAttribute('disable-auto-aria-label')).to.be.false;
+        expect(item._elements.icon.getAttribute('coral-aria-label')).to.be.a('null');
       });
     });
   });

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -157,19 +157,19 @@ describe('Tab', function() {
     describe('#icon', function() {
       var item;
 
-      it('should propagate coral-aria-label flag to tab\'s icon', function() {
+      it('should propagate autoAriaLabel flag to tab\'s icon', function() {
         item = new Tab();
-        item.setAttribute('coral-aria-label', 'test123');
+        item.setAttribute('autoAriaLabel', 'test123');
         item.setAttribute('icon', 'Add');
 
-        expect(item._elements.icon.getAttribute('coral-aria-label')).to.equal('test123');
+        expect(item._elements.icon.getAttribute('autoAriaLabel')).to.equal('test123');
       });
 
-      it('should not propagate coral-aria-label flag to tab\'s icon if not set.', function() {
+      it('should not propagate autoAriaLabel flag to tab\'s icon if not set.', function() {
         item = new Tab();
         item.setAttribute('icon', 'Add');
 
-        expect(item._elements.icon.getAttribute('coral-aria-label')).to.be.a('null');
+        expect(item._elements.icon.getAttribute('autoAriaLabel')).to.be.a('null');
       });
     });
   });

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -157,19 +157,19 @@ describe('Tab', function() {
     describe('#icon', function() {
       var item;
 
-      it('should propagate coral-aria-label flag to tab\'s icon', function() {
+      it('should propagate disable-auto-aria-label flag to tab\'s icon', function() {
         item = new Tab();
-        item.setAttribute('coral-aria-label', 'test123');
+        item.setAttribute('disable-auto-aria-label', '');
         item.setAttribute('icon', 'Add');
 
-        expect(item._elements.icon.getAttribute('coral-aria-label')).to.equal('test123');
+        expect(item._elements.icon.hasAttribute('disable-auto-aria-label')).to.be.true;
       });
 
-      it('should not propagate coral-aria-label flag to tab\'s icon if not set.', function() {
+      it('should not propagate disable-auto-aria-label flag to tab\'s icon if not set.', function() {
         item = new Tab();
         item.setAttribute('icon', 'Add');
 
-        expect(item._elements.icon.getAttribute('coral-aria-label')).to.be.a('null');
+        expect(item._elements.icon.hasAttribute('disable-auto-aria-label')).to.be.false;
       });
     });
   });

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -25,17 +25,17 @@ describe('Tab', function() {
       'should be possible via clone using markup',
       '<coral-tab>Tab One</coral-tab>'
     );
-  
+
     helpers.cloneComponent(
       'should be possible via clone using markup with textContent',
       '<coral-tab><coral-tab-label>Tab One</coral-tab-label></coral-tab>'
     );
-  
+
     helpers.cloneComponent(
       'should be possible via clone using markup with icon',
       '<coral-tab icon="add"><coral-tab-label>Tab One</coral-tab-label></coral-tab>'
     );
-  
+
     helpers.cloneComponent(
       'should be possible via clone using js',
       new Tab()
@@ -58,88 +58,88 @@ describe('Tab', function() {
     afterEach(function() {
       el = item = item2 = null;
     });
-    
+
     describe('#selected', function() {
       it('should default to false', function() {
         expect(item2.selected).to.be.false;
         expect(item2.hasAttribute('selected')).to.be.false;
       });
-  
+
       it('should be settable to truthy', function() {
         item2.selected = true;
-        
+
         expect(item2.selected).to.be.true;
         expect(item2.hasAttribute('selected')).to.be.true;
         expect(item2.classList.contains('is-selected')).to.be.true;
         expect(item2.getAttribute('tabindex')).to.equal('0');
       });
-  
+
       it('selecting a disabled item should make it unselected', function() {
         item.disabled = true;
         item.selected = true;
-    
+
         expect(item.disabled).to.be.true;
         expect(item.hasAttribute('disabled')).to.be.true;
         expect(item.selected).to.be.false;
         expect(item.hasAttribute('selected')).to.be.false;
       });
     });
-    
+
     describe('#disabled', function() {
       it('should default to false', function() {
         expect(item.disabled).to.be.false;
         expect(item.hasAttribute('disabled')).to.be.false;
       });
-  
+
       it('should be settable to truthy/falsy', function() {
         item.disabled = true;
         expect(item.disabled).to.be.true;
         expect(item.hasAttribute('disabled')).to.be.true;
         expect(item.classList.contains('is-disabled')).to.be.true;
         expect(item.getAttribute('aria-disabled')).to.equal('true');
-    
+
         item.disabled = false;
         expect(item.disabled).to.be.false;
         expect(item.hasAttribute('disabled')).to.be.false;
         expect(item.classList.contains('is-disabled')).to.be.false;
         expect(item.hasAttribute('aria-disabled')).to.be.false;
       });
-  
+
       it('disabled items cannot be selected', function() {
         item.disabled = true;
         expect(item.disabled).to.be.true;
         expect(item.hasAttribute('disabled')).to.be.true;
-    
+
         expect(item.selected).to.be.false;
-    
+
         item.selected = true;
-    
+
         expect(item.selected).to.be.false;
       });
-  
+
       it('disabling should make it unselected', function() {
         item.selected = true;
         item.disabled = true;
-    
+
         expect(item.disabled).to.be.true;
         expect(item.hasAttribute('disabled')).to.be.true;
         expect(item.selected).to.be.false;
         expect(item.hasAttribute('selected')).to.be.false;
       });
     });
-    
+
     describe('#invalid', function() {
       it('should default to false', function() {
         expect(item.invalid).to.be.false;
         expect(item.hasAttribute('invalid')).to.be.false;
       });
-  
+
       it('should be settable to truthy/falsy', function() {
         item.invalid = true;
         expect(item.invalid).to.be.true;
         expect(item.hasAttribute('invalid')).to.be.true;
         expect(item.classList.contains('is-invalid')).to.be.true;
-    
+
         item.invalid = false;
         expect(item.invalid).to.be.false;
         expect(item.hasAttribute('invalid')).to.be.false;
@@ -151,6 +151,25 @@ describe('Tab', function() {
       it('should be settable', function() {
         item.label.textContent = 'Item 1';
         expect(item.label.textContent).to.equal('Item 1');
+      });
+    });
+
+    describe('#icon', function() {
+      var item;
+
+      it('should propagate coral-aria-label flag to tab\'s icon', function() {
+        item = new Tab();
+        item.setAttribute('coral-aria-label', 'test123');
+        item.setAttribute('icon', 'Add');
+
+        expect(item._elements.icon.getAttribute('coral-aria-label')).to.equal('test123');
+      });
+
+      it('should not propagate coral-aria-label flag to tab\'s icon if not set.', function() {
+        item = new Tab();
+        item.setAttribute('icon', 'Add');
+
+        expect(item._elements.icon.getAttribute('coral-aria-label')).to.be.a('null');
       });
     });
   });

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -157,12 +157,12 @@ describe('Tab', function() {
     describe('#icon', function() {
       var item;
 
-      it('should propagate autoAriaLabel flag to tab\'s icon', function() {
+      it('should set autoAriaLabel flag to tab\'s icon when tab has aria-label on it\'s own', function() {
         item = new Tab();
-        item.setAttribute('autoAriaLabel', 'test123');
+        item.setAttribute('aria-label', 'test123');
         item.setAttribute('icon', 'Add');
 
-        expect(item._elements.icon.getAttribute('autoAriaLabel')).to.equal('test123');
+        expect(item._elements.icon.getAttribute('autoAriaLabel')).to.equal('off');
       });
 
       it('should not propagate autoAriaLabel flag to tab\'s icon if not set.', function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Developer can setup aria-label or aria-labelledby to anything in an Icon.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/coral-spectrum/issues/23

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
aria-label and aria-labelledby should be always handled by end user of spectrum. Spectrum, even though it would be nice, cannot guess the need for aria-label/labelledby and contextual text associated with it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Automated tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
