### PR TITLE
#28 Overflow class check only when there are alerts

### DIFF
--- a/coral-component-card/src/scripts/Card.js
+++ b/coral-component-card/src/scripts/Card.js
@@ -404,8 +404,9 @@ class Card extends BaseComponent(HTMLElement) {
     this.asset = asset;
     
     // In case a lot of alerts are added, they will not overflow the card
-    this.classList.toggle(`${CLASSNAME}--overflow`, this.info.scrollHeight > this.clientHeight);
-  }
+    // Also check whether any alerts are available
+    this.classList.toggle(`${CLASSNAME}--overflow`, this.info.childNodes.length && this.info.scrollHeight > this.clientHeight);
+   }
 }
 
 export default Card;


### PR DESCRIPTION
Overflow class toggle to also check if alerts are present.

## Description
<!--- Describe your changes in detail -->

## Related Issue
#28 

## Motivation and Context
In AEM Editor, when using button inside a coral-card for Chrome and the card has a decimal height, the button becomes non-clickable when no alerts are present. The overflow class is added irrespective of whether alerts are present or not and depend solely on the height checks.

## How Has This Been Tested?
Tested in relation to https://jira.corp.adobe.com/browse/CQ-4274556

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
