### PR TITLE
select to respect when select item value is an empty string

### DIFF
--- a/coral-component-select/src/scripts/SelectItem.js
+++ b/coral-component-select/src/scripts/SelectItem.js
@@ -100,7 +100,7 @@ class SelectItem extends BaseComponent(HTMLElement) {
         val = this.textContent.replace(/\s{2,}/g, ' ').trim();
       }
       else {
-        val = this.getAttribute('value')
+        val = this.getAttribute('value');
       }
     }
 

--- a/coral-component-select/src/scripts/SelectItem.js
+++ b/coral-component-select/src/scripts/SelectItem.js
@@ -24,7 +24,7 @@ class SelectItem extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
-    
+
     this._observer = new MutationObserver(this._handleMutation.bind(this));
     this._observer.observe(this, {
       characterData: true,
@@ -32,7 +32,7 @@ class SelectItem extends BaseComponent(HTMLElement) {
       subtree: true
     });
   }
-  
+
   // @compat
   get content() {
     return this;
@@ -46,11 +46,11 @@ class SelectItem extends BaseComponent(HTMLElement) {
       }
     }
   }
-  
+
   /**
    Whether this item is disabled. When set to <code>true</code>, this will prevent every user interaction with the
    item. If disabled is set to <code>true</code> for a selected item it will be deselected.
-   
+
    @type {Boolean}
    @default false
    @htmlattribute disabled
@@ -62,13 +62,13 @@ class SelectItem extends BaseComponent(HTMLElement) {
   set disabled(value) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
-    
+
     this.trigger('coral-select-item:_disabledchanged');
   }
-  
+
   /**
    Whether the item is selected. Selected cannot be set to <code>true</code> if the item is disabled.
-   
+
    @type {Boolean}
    @default false
    @htmlattribute selected
@@ -80,31 +80,39 @@ class SelectItem extends BaseComponent(HTMLElement) {
   set selected(value) {
     this._selected = transform.booleanAttr(value);
     this._reflectAttribute('selected', this._selected);
-    
+
     this.trigger('coral-select-item:_selectedchanged');
   }
-  
+
   /**
    Value of the item. If not explicitly set, the value of <code>Node.textContent</code> is returned.
-   
+
    @type {String}
    @default ""
    @htmlattribute value
    @htmlattributereflected
    */
   get value() {
-    // keep spaces to only 1 max and trim to mimic native select option behavior
-    return typeof this._value === 'undefined' ?
-      this.getAttribute('value') || this.textContent.replace(/\s{2,}/g, ' ').trim() :
-      this._value;
+    let val = this._value;
+    if (typeof this._value === 'undefined') {
+      if (this.getAttribute('value') === null) {
+        // keep spaces to only 1 max and trim to mimic native select option behavior
+        val = this.textContent.replace(/\s{2,}/g, ' ').trim();
+      }
+      else {
+        val = this.getAttribute('value')
+      }
+    }
+
+    return val;
   }
   set value(value) {
     this._value = transform.string(value);
     this._reflectAttribute('value', this._value);
-    
+
     this.trigger('coral-select-item:_valuechanged');
   }
-  
+
   /**
    Inherited from {@link BaseComponent#trackingElement}.
    */
@@ -117,14 +125,14 @@ class SelectItem extends BaseComponent(HTMLElement) {
   set trackingElement(value) {
     super.trackingElement = value;
   }
-  
+
   /** @private */
   _handleMutation() {
     this.trigger('coral-select-item:_contentchanged', {
       content: this.textContent
     });
   }
-  
+
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat(['selected', 'disabled', 'value']);

--- a/coral-component-select/src/tests/test.Select.Item.js
+++ b/coral-component-select/src/tests/test.Select.Item.js
@@ -50,16 +50,25 @@ describe('Select.Item', function() {
     describe('#value', function() {
       it('should default empty string', function() {
         expect(el.value).to.equal('');
-        
+
         expect(el.hasAttribute('value')).to.be.false;
       });
 
-      it('should default to the content', function() {
+      it('should default to the content when value is null', function() {
         el.content.innerHTML = 'Switzerland';
 
         expect(el.content.innerHTML).to.equal('Switzerland');
         expect(el.value).to.equal('Switzerland');
         expect(el.hasAttribute('value')).to.be.false;
+      });
+
+      it('should default to the empty string when value is empty string', function() {
+        el.setAttribute('value', '');
+        el.content.innerHTML = 'Switzerland';
+
+        expect(el.content.innerHTML).to.equal('Switzerland');
+        expect(el.value).to.equal('');
+        expect(el.hasAttribute('value')).to.be.true;
       });
 
       it('should keep maximum 1 space from the content', function() {
@@ -86,7 +95,7 @@ describe('Select.Item', function() {
 
       it('should reflect the value', function() {
         el.value = 'crc';
-        
+
         expect(el.getAttribute('value')).to.equal('crc');
       });
     });
@@ -94,7 +103,7 @@ describe('Select.Item', function() {
     describe('#selected', function() {
       it('should be not be selected by default', function() {
         expect(el.selected).to.be.false;
-        
+
         expect(el.hasAttribute('selected')).to.be.false;
       });
 
@@ -138,7 +147,7 @@ describe('Select.Item', function() {
   describe('Markup', function() {
 
     describe('#content', function() {
-      
+
       it('should have content set to innerHTML if property not provided', function() {
         const el = helpers.build(window.__html__['Select.Item.base.html']);
         expect(el.content.innerHTML).to.equal('Costa Rica');
@@ -281,7 +290,7 @@ describe('Select.Item', function() {
     it('should always be hidden', function() {
       var el = helpers.build(new Select.Item());
       helpers.target.appendChild(el);
-      
+
       expect(el.offsetParent).to.equal(null);
     });
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
On first render, if default select item value is an empty string, since it is falsy, it defaulted too eagerly to element's text (as if it was not present at all) 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
