### PR TITLE
[Accessibilty] CUI-7342 Added tabindex for focus on calendar button

### DIFF
--- a/coral-component-datepicker/src/templates/base.html
+++ b/coral-component-datepicker/src/templates/base.html
@@ -1,7 +1,7 @@
 <coral-popover tracking="off" smart class="_coral-Datepicker-overlay" handle="overlay" id="{{data.commons.getUID()}}" breadthoffset="50%r - 50%p" placement="bottom"></coral-popover>
 <input type="hidden" handle="hiddenInput">
 <input tracking="off" is="coral-textfield" type="text" handle="input" class="_coral-InputGroup-field" role="textbox">
-<button tracking="off" is="coral-button" variant="_custom" class="_coral-InputGroup-button _coral-FieldButton" type="button" handle="toggle" aria-haspopup="true" aria-label="{{data.i18n.get('Calendar')}}" title="{{data.i18n.get('Calendar')}}">
+<button tracking="off" is="coral-button" variant="_custom" class="_coral-InputGroup-button _coral-FieldButton" tabindex="0" type="button" handle="toggle" aria-haspopup="true" aria-label="{{data.i18n.get('Calendar')}}" title="{{data.i18n.get('Calendar')}}">
   <coral-icon icon="calendar" iconsize="S" class="u-coral-noMargin" handle="icon"></coral-icon>
   <coral-button-label></coral-button-label>
 </button>

--- a/coral-component-datepicker/src/tests/test.Datepicker.js
+++ b/coral-component-datepicker/src/tests/test.Datepicker.js
@@ -311,7 +311,13 @@ describe('Datepicker', function() {
     
       describe('#required', function() {
       });
-    
+
+      describe('#toggleTabindex', function() {
+        it('should have default tabindex 0', function() {
+           expect(el._elements.toggle.getAttribute('tabindex')).to.equal('0');
+        });
+      });
+
       describe('#startDay', function() {
       });
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Issue is on opening datepicker focus should be on current date or selected date .
## Description
<!--- Describe your changes in detail -->
Added tabindex on calendar button on tabbing after input field focus will move to calendar button. This is done in respect to accessibility
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On tabbing after input field focus will move to calendar button. This is done in respect to accessibility
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I have run all test cases locally . Added test case to check tabindex is present or not.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
