### PR TITLE
Table: add aria-label and aria-labelledby

### DIFF
--- a/coral-component-table/examples/index.html
+++ b/coral-component-table/examples/index.html
@@ -34,6 +34,15 @@
     <link rel="stylesheet" href="../dist/css/coral.css">
     <script>
       document.addEventListener('DOMContentLoaded', function() {
+        var headings = document.getElementsByTagName('H2');
+        for (var i = 0; i < headings.length; i++) {
+          var heading = headings[i];
+          var table = heading.nextElementSibling;
+          if (table.tagName === 'TABLE') {
+            heading.id = Coral.commons.getUID();
+            table.setAttribute('labelledby', heading.id);
+          }
+        }
         const script = document.createElement('script');
         script.src = '../dist/js/coral.js';
         document.head.appendChild(script);

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -424,7 +424,39 @@ class Table extends BaseComponent(HTMLTableElement) {
     // a11y
     this._toggleFocusable();
   }
-  
+ 
+  /**
+    Specifies aria-labelledby value
+    @type {String}
+    @htmlattributereflected
+  */
+  set labelledby(value) {
+    if (value) {
+      this._labelledby = transform.string(value);
+      this._reflectAttribute('labelledby', this._labelledby);
+      this._elements.table.setAttribute('aria-labelledby', this._labelledby);
+    }
+    else {
+      this._elements.table.removeAttribute('aria-labelledby');
+    }
+  }
+
+  /**
+    Specifies aria-label value
+    @type {String}
+    @htmlattributereflected
+  */
+  set labelled(value) {
+    if (value) {
+      this._labelled = transform.string(value);
+      this._reflectAttribute('labelled', this._labelled);
+      this._elements.table.setAttribute('aria-label', this._labelled);
+    }
+    else {
+      this._elements.table.removeAttribute('aria-label');
+    }
+  }
+ 
   /**
    Returns an Array containing the selected items.
    
@@ -2445,7 +2477,7 @@ class Table extends BaseComponent(HTMLTableElement) {
   
   /** @ignore */
   static get observedAttributes() {
-    return super.observedAttributes.concat(['variant', 'selectable', 'orderable', 'multiple', 'lockable']);
+    return super.observedAttributes.concat(['variant', 'selectable', 'orderable', 'labelled', 'labelledby', 'multiple', 'lockable']);
   }
   
   /** @ignore */

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -347,7 +347,56 @@ describe('Table', function() {
         }, 100);
       });
     });
-  
+ 
+
+    describe('#labelled', function() {
+      it('should add aria-label to child table', function(done) {
+          var table = helpers.build(window.__html__['Table.base.html']);
+          table.labelled = 'my table';
+          helpers.next(() => {
+            expect(table._elements.table.getAttribute('aria-label')).to.equal('my table');
+            done();
+          });
+      });
+
+      it('should remove aria-label from child table when removed', function(done) {
+        var table = helpers.build(window.__html__['Table.base.html']);
+        table.labelled = 'my table';
+        helpers.next(() => {
+          expect(table._elements.table.getAttribute('aria-label')).to.equal('my table');
+          table.labelled = undefined;
+          helpers.next(() => {
+            expect(table._elements.table.hasAttribute('aria-label')).to.be.false;
+            done();
+          });
+        });
+      });
+    });
+
+    describe('#labelledby', function() {
+      it('should add aria-labelledby to child table', function(done) {
+        var table = helpers.build(window.__html__['Table.base.html']);
+        table.labelledby = 'foo bar';
+        helpers.next(() => {
+          expect(table._elements.table.getAttribute('aria-labelledby')).to.equal('foo bar');
+          done();
+        });
+      });
+
+      it('should remove aria-labelledby from child table when removed', function(done) {
+        var table = helpers.build(window.__html__['Table.base.html']);
+        table.labelledby = 'foo bar';
+        helpers.next(() => {
+          expect(table._elements.table.getAttribute('aria-labelledby')).to.equal('foo bar');
+          table.labelledby = undefined;
+          helpers.next(() => {
+            expect(table._elements.table.hasAttribute('aria-labelledby')).to.be.false;
+            done();
+          });
+        });
+      });
+    });
+ 
     describe('#multiple', function() {
       it('should only select the last selected row if multiple is false', function() {
         var table = helpers.build(window.__html__['Table.selectable.html']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added support for aria-label and aria-labelledby for table using properties labelled and labelledby respectively

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Missing aria-label and aria-labelledby support in table

## How Has This Been Tested?
I have run all test cases locally . Added new test cases to check new changes

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
