### PR TITLE
[Accessibility]Focus should move to current date on Dialog/pop-up open

### DIFF
--- a/coral-component-calendar/src/scripts/Calendar.js
+++ b/coral-component-calendar/src/scripts/Calendar.js
@@ -994,7 +994,9 @@ class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
    sets focus to appropriate descendant
    */
   focus() {
-    if (!this.contains(document.activeElement) && !this.disabled) {
+      var el = this._elements.body.querySelector('.is-focused');
+      var flag = el === document.activeElement ;
+      if ( !flag && !this.disabled) { 
       this._setActiveDescendant();
       this._elements.body.focus();
     }

--- a/coral-component-calendar/src/tests/test.Calendar.js
+++ b/coral-component-calendar/src/tests/test.Calendar.js
@@ -432,8 +432,8 @@ describe('Calendar', function() {
           // set focus to element again
           el.focus();
       
-          // document focus should remain on prev button
-          expect(document.activeElement).to.equal(el._elements.prev);
+          // document focus should remain on body button
+          expect(document.activeElement).to.equal(el._elements.body);
         });
       });
       


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Datepicker component itself is made up of coral-calendar, coral popup component.  document.activeElement set to first tabbable element of popover which is "previous button" by popover component due to which "if " condition check failed and it never set focus to current date . I have changed document.activeElement by changing if condition.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In respect to accessibility , focus should be on current date on opening date picker.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
