### PR TITLE
IE11 Polyfill for coral-select-list-item querySelector on DOM-less elements

### DIFF
--- a/coral-component-list/src/scripts/SelectListItem.js
+++ b/coral-component-list/src/scripts/SelectListItem.js
@@ -82,7 +82,18 @@ class SelectListItem extends BaseComponent(HTMLElement) {
   
         // Remove content icon before processing content zone
         const checkIcon = this._elements.checkIcon;
-        const contentIcon = content.querySelector('coral-icon:not(._coral-Menu-item-icon)');
+        let contentIcon;
+        // @polyfill ie11
+        // IE11 throws syntax error because of the "not()" in the selector if the element is not in the DOM.
+        if (navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.includes('Trident/')) {
+          const allContentIcons = Array.prototype.slice.call(content.querySelectorAll('coral-icon'));
+          const allContentMenuIcons = Array.prototype.slice.call(content.querySelectorAll('coral-icon._coral-Menu-item-icon'));
+          const contentIcons = allContentIcons.filter(icon => allContentMenuIcons.indexOf(icon) === -1);
+          contentIcon = contentIcons.length > 0 ? contentIcons[0] : undefined;
+        }
+        else {
+          contentIcon = content.querySelector('coral-icon:not(._coral-Menu-item-icon)');
+        }
         if (contentIcon && contentIcon.icon) {
           contentIcon.remove();
           this.icon = contentIcon.icon;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In IE11, when attempting to add a `coral-select-list-item` to a `coral-select-list`, if the `coral-select-list-item` is currently not within the DOM, then IE11 throws a SyntaxError on `content.querySelector('coral-icon:not(._coral-Menu-item-icon)')`. Specifically, it does not like the `:not` query selector for DOM-less elements, see https://github.com/FortAwesome/Font-Awesome/issues/12471.

This PR creates a polyfill for IE11, that ensures we can still remove the icons except `._coral-Menu-item-icon`s from the list item, without incurring a SyntaxError from IE11. This polyfill could have been extended to also check if the `content` is within the DOM, but I strongly suspect that tree-walking the DOM to find this element would be orders of magnitude slower than the array operations it does do.

## Related Issue
This relates to https://github.com/adobe/coral-spectrum/blob/master/coral-base-formfield/src/scripts/BaseFormField.js#L18 changes

## Motivation and Context
This is in relation to a conversation with @dhayes on slack in #coral-spectrum channel

## How Has This Been Tested?
Tested this in IE11 and Version 80.0.3987.132 (Official Build) (64-bit) (OSX). Replacing the coral.js in the affected application, with dist/coral.js from the result of `gulp build`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
