### PR TITLE
[Accessibility] Table: restore setTimeout to liveRegion announcement

### DIFF
--- a/coral-component-table/src/templates/base.html
+++ b/coral-component-table/src/templates/base.html
@@ -1,4 +1,4 @@
-<div handle="liveRegion" class="u-coral-screenReaderOnly _coral-Table-liveRegion" aria-live="off" id="{{data.commons.getUID()}}"></div>
+<div handle="liveRegion" class="u-coral-screenReaderOnly _coral-Table-liveRegion" aria-hidden="true" aria-live="off" id="{{data.commons.getUID()}}"></div>
 <div handle="container" class="_coral-Table-wrapper-container" role="presentation" coral-table-scroll>
   <style handle="hiddenStyle"></style>
   <style handle="alignmentStyle"></style>

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -1565,6 +1565,7 @@ describe('Table', function() {
           expect(headerCell.getAttribute('sortabledirection')).to.equal(col.sortableDirection);
           expect(liveRegion.innerHTML).to.equal('sorted by column ' + headerCell.content.textContent + ' in ' + Table.Column.sortableDirection.ASCENDING + ' order');
           expect(liveRegion.getAttribute('aria-live')).to.equal('polite');
+          expect(liveRegion.hasAttribute('aria-hidden')).to.be.false;
           done();
         });
       });
@@ -1588,6 +1589,7 @@ describe('Table', function() {
           expect(headerCell.getAttribute('sortabledirection')).to.equal(col.sortableDirection);
           expect(liveRegion.innerHTML).to.equal('sorted by column ' + headerCell.content.textContent + ' in ' + Table.Column.sortableDirection.DESCENDING + ' order');
           expect(liveRegion.getAttribute('aria-live')).to.equal('polite');
+          expect(liveRegion.hasAttribute('aria-hidden')).to.be.false;
           done();
         });
       });
@@ -2150,6 +2152,7 @@ describe('Table', function() {
         const table = helpers.build(window.__html__['Table.sortable.html']);
         
         const liveRegion = table._elements.liveRegion;
+        expect(liveRegion.getAttribute('aria-hidden')).to.equal('true');
         expect(liveRegion.getAttribute('aria-live')).to.equal('off');
         expect(liveRegion.innerHTML).to.equal('');
       });
@@ -2651,6 +2654,7 @@ describe('Table', function() {
         
         expect(col.sortableDirection).to.equal(Table.Column.sortableDirection.DEFAULT);
         expect(liveRegion.innerHTML).to.equal('');
+        expect(liveRegion.getAttribute('aria-hidden')).to.equal('true');
         expect(liveRegion.getAttribute('aria-live')).to.equal('off');
       });
     


### PR DESCRIPTION
## Description
Per https://github.com/adobe/coral-spectrum/pull/39#discussion_r395187537

Live Region must have aria-live="polite" for 2500ms to give assistive technology time to pick up on update and announce the new sort order.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
