### PR TITLE
[Accessibility] remove role="rowgroup" from BaseTableSection

### DIFF
--- a/coral-component-table/src/scripts/BaseTableSection.js
+++ b/coral-component-table/src/scripts/BaseTableSection.js
@@ -93,9 +93,6 @@ const BaseTableSection = (superClass) => class extends superClass {
   render() {
     super.render();
     
-    // a11y
-    this.setAttribute('role', 'rowgroup');
-    
     // Default reflected attributes
     if (!this._divider) { this.divider = divider.ROW; }
   }

--- a/coral-component-table/src/tests/test.Table.Body.js
+++ b/coral-component-table/src/tests/test.Table.Body.js
@@ -91,7 +91,8 @@ describe('Table.Body', function() {
   describe('Implementation Details', function() {
     it('should set a11y attribute', function() {
       const el = helpers.build(new Table.Body());
-      expect(el.getAttribute('role')).to.equal('rowgroup');
+      expect(el.tagName).to.equal('TBODY');
+      expect(el.hasAttribute('role')).to.be.false;
     });
   });
 });

--- a/coral-component-table/src/tests/test.Table.Foot.js
+++ b/coral-component-table/src/tests/test.Table.Foot.js
@@ -67,7 +67,8 @@ describe('Table.Foot', function() {
   describe('Implementation Details', function() {
     it('should set a11y attribute', function() {
       const el = helpers.build(new Table.Foot());
-      expect(el.getAttribute('role')).to.equal('rowgroup');
+      expect(el.tagName).to.equal('TFOOT');
+      expect(el.hasAttribute('role')).to.be.false;
     });
   });
 });

--- a/coral-component-table/src/tests/test.Table.Head.js
+++ b/coral-component-table/src/tests/test.Table.Head.js
@@ -139,7 +139,8 @@ describe('Table.Head', function() {
   describe('Implementation Details', function() {
     it('should set a11y attribute', function() {
       var row = helpers.build(new Table.Head());
-      expect(row.getAttribute('role')).to.equal('rowgroup');
+      expect(row.tagName).to.equal('THEAD');
+      expect(row.hasAttribute('role')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Description
role=rowgroup causes VoiceOver to announce table as "empty"

## Motivation and Context
VoiceOver screen reader announces tables that use `role="rowgroup"` on `thead`, `tbody` or `tfoot` as empty, failing to communicate the number of rows or columns in the table.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
