### PR TITLE
Adding alert icon to invalid Coral Spectrum Tabs

### DIFF
--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -130,7 +130,13 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     
     this.classList.toggle('is-invalid', this._invalid);
     this.setAttribute('aria-invalid', this._invalid);
-    this._setInvalidIcon(this._invalid);
+    //this._elements.invalidIcon.hidden = !this._invalid;
+    if (this._invalid) {
+      this._elements.invalidIcon.removeAttribute('hidden');
+    }
+    else {
+      this._elements.invalidIcon.setAttribute('hidden', 'true');
+    }
   }
   
   /**
@@ -268,31 +274,13 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     const iconElement = document.createElement('coral-icon');
     iconElement.icon = 'alert';
     iconElement.size=Icon.size.EXTRA_SMALL;
-    iconElement.classList.add('_coral-Tabs-item');
-    iconElement.classList.add('_coral-Tabs-item-invalid-icon');
+    //iconElement.classList.add('_coral-Tabs-item');
+    iconElement.classList.add('_coral-Tabs-itemInvalidIcon');
+    if (!this._invalid) {
+      iconElement.setAttribute('hidden', 'true');
+    }
     return iconElement;
   }
-
-  /**
-   Adds or remove an alert icon to mark an invalid tab.
-
-   @ignore
-   */
-  _setInvalidIcon(invalid) {
-    const iconElement = this._elements.invalidIcon;
-
-    // removes the icon element from the DOM.
-    if (!invalid) {
-      iconElement.remove();
-      this.trigger('coral-tab:_sizechanged');
-    }
-    // adds the icon back since it was blown away by textContent
-    else if (!iconElement.parentElement) {
-      this.appendChild(iconElement);
-      this.trigger('coral-tab:_sizechanged');
-    }
-  }
-
 
   get _contentZones() { return {'coral-tab-label': 'label'}; }
   
@@ -331,6 +319,10 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     if (this.icon) {
       frag.appendChild(this._elements.icon);
     }
+
+    // Create an invalid icon and hide it
+    this._elements.invalidIcon =  this._createInvalidIcon();
+    frag.append(this._elements.invalidIcon);
   
     const label = this._elements.label;
   

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -34,7 +34,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     // Templates
     this._elements = {
       label: this.querySelector('coral-tab-label') || document.createElement('coral-tab-label'),
-      invalidIcon: this.querySelector('coral-icon._coral-Tabs-itemInvalidIcon') || this._createInvalidIcon()
+      invalidIcon: this.querySelector('._coral-Tabs-itemInvalidIcon') || this._createInvalidIcon()
     };
     base.call(this._elements);
   

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -30,10 +30,11 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
-    
+
     // Templates
     this._elements = {
-      label: this.querySelector('coral-tab-label') || document.createElement('coral-tab-label')
+      label: this.querySelector('coral-tab-label') || document.createElement('coral-tab-label'),
+      invalidIcon: this.querySelector('coral-icon._coral-Tabs-item._coral-Tabs-item-invalid-icon') || this._createInvalidIcon()
     };
     base.call(this._elements);
   
@@ -129,6 +130,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     
     this.classList.toggle('is-invalid', this._invalid);
     this.setAttribute('aria-invalid', this._invalid);
+    this._setInvalidIcon(this._invalid);
   }
   
   /**
@@ -261,7 +263,37 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       }
     }
   }
-  
+
+  _createInvalidIcon() {
+    const iconElement = document.createElement('coral-icon');
+    iconElement.icon = 'alert';
+    iconElement.size=Icon.size.EXTRA_SMALL;
+    iconElement.classList.add('_coral-Tabs-item');
+    iconElement.classList.add('_coral-Tabs-item-invalid-icon');
+    return iconElement;
+  }
+
+  /**
+   Adds or remove an alert icon to mark an invalid tab.
+
+   @ignore
+   */
+  _setInvalidIcon(invalid) {
+    const iconElement = this._elements.invalidIcon;
+
+    // removes the icon element from the DOM.
+    if (!invalid) {
+      iconElement.remove();
+      this.trigger('coral-tab:_sizechanged');
+    }
+    // adds the icon back since it was blown away by textContent
+    else if (!iconElement.parentElement) {
+      this.appendChild(iconElement);
+      this.trigger('coral-tab:_sizechanged');
+    }
+  }
+
+
   get _contentZones() { return {'coral-tab-label': 'label'}; }
   
   /** @ignore */
@@ -318,10 +350,10 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
         this.removeChild(child);
       }
     }
-  
+
     // Add the frag to the component
     this.appendChild(frag);
-  
+
     // Assign the content zones, moving them into place in the process
     this.label = label;
   }

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -34,7 +34,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     // Templates
     this._elements = {
       label: this.querySelector('coral-tab-label') || document.createElement('coral-tab-label'),
-      invalidIcon: this.querySelector('coral-icon._coral-Tabs-item._coral-Tabs-item-invalid-icon') || this._createInvalidIcon()
+      invalidIcon: this.querySelector('coral-icon._coral-Tabs-itemInvalidIcon') || this._createInvalidIcon()
     };
     base.call(this._elements);
   
@@ -271,7 +271,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   }
 
   _createInvalidIcon() {
-    const iconElement = document.createElement('coral-icon');
+    let iconElement = document.createElement('coral-icon');
     iconElement.icon = 'alert';
     iconElement.size=Icon.size.EXTRA_SMALL;
     //iconElement.classList.add('_coral-Tabs-item');
@@ -320,9 +320,9 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       frag.appendChild(this._elements.icon);
     }
 
-    // Create an invalid icon and hide it
-    this._elements.invalidIcon =  this._createInvalidIcon();
-    frag.append(this._elements.invalidIcon);
+    if (this._elements.invalidIcon) {
+      frag.append(this._elements.invalidIcon);
+    }
   
     const label = this._elements.label;
   

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -130,7 +130,6 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     
     this.classList.toggle('is-invalid', this._invalid);
     this.setAttribute('aria-invalid', this._invalid);
-    //this._elements.invalidIcon.hidden = !this._invalid;
     if (this._invalid) {
       this._elements.invalidIcon.removeAttribute('hidden');
     }
@@ -273,8 +272,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   _createInvalidIcon() {
     let iconElement = document.createElement('coral-icon');
     iconElement.icon = 'alert';
-    iconElement.size=Icon.size.EXTRA_SMALL;
-    //iconElement.classList.add('_coral-Tabs-item');
+    iconElement.size = Icon.size.EXTRA_SMALL;
     iconElement.classList.add('_coral-Tabs-itemInvalidIcon');
     if (!this._invalid) {
       iconElement.setAttribute('hidden', 'true');

--- a/coral-component-tablist/src/styles/index.styl
+++ b/coral-component-tablist/src/styles/index.styl
@@ -26,6 +26,13 @@
   ._coral-Tabs-itemLabel:not(:empty) {
     display: inline;
   }
+
+  ._coral-Tabs-item-invalid-icon {
+    display: inline;
+    margin-right: 0;
+    margin-left: 5px;
+    float: right;
+  }
 }
 
 // @spectrum animation

--- a/coral-component-tablist/src/styles/index.styl
+++ b/coral-component-tablist/src/styles/index.styl
@@ -27,7 +27,7 @@
     display: inline;
   }
 
-  ._coral-Tabs-item-invalid-icon {
+  ._coral-Tabs-itemInvalidIcon {
     display: inline;
     margin-right: 0;
     margin-left: 5px;

--- a/coral-component-tablist/src/styles/light.styl
+++ b/coral-component-tablist/src/styles/light.styl
@@ -11,6 +11,7 @@
  */
 
 $tab-color-invalid = var(--spectrum-light-semantic-negative-color-text-small);
+$tab-normal-color = var(--spectrum-tabs-icon-color-key-focus);
 
 .coral--light {
   @import 'skin.styl'

--- a/coral-component-tablist/src/styles/skin.styl
+++ b/coral-component-tablist/src/styles/skin.styl
@@ -13,7 +13,7 @@
 ._coral-Tabs-item:not(.is-disabled).is-invalid {
   color: $tab-color-invalid;
 
-  ._coral-Tabs-itemLabel > ._coral-Icon._coral-Tabs-item-invalid-icon {
+  ._coral-Tabs-itemInvalidIcon ._coral-Icon {
     color: $tab-color-invalid;
   }
 

--- a/coral-component-tablist/src/styles/skin.styl
+++ b/coral-component-tablist/src/styles/skin.styl
@@ -12,4 +12,9 @@
 
 ._coral-Tabs-item:not(.is-disabled).is-invalid {
   color: $tab-color-invalid;
+
+  ._coral-Tabs-itemLabel > ._coral-Icon._coral-Tabs-item-invalid-icon {
+    color: $tab-color-invalid;
+  }
+
 }

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -149,7 +149,7 @@ describe('Tab', function() {
       it('should show an alert icon when invalid', function() {
         item.invalid = true;
         helpers.next(function() {
-          var invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+          let invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
           expect(invalidIcon).not.to.be.null;
           expect(invalidIcon.hasAttribute('hidden')).to.be.false;
           done();
@@ -161,7 +161,7 @@ describe('Tab', function() {
         helpers.next(function() {
           item.invalid = false;
           helpers.next(function() {
-            var invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+            let invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
             expect(invalidIcon).not.to.be.null;
             expect(invalidIcon.hasAttribute('hidden')).to.be.true;
             done();

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -145,6 +145,29 @@ describe('Tab', function() {
         expect(item.hasAttribute('invalid')).to.be.false;
         expect(item.classList.contains('is-invalid')).to.be.false;
       });
+
+      it('should show an alert icon when invalid', function() {
+        item.invalid = true;
+        helpers.next(function() {
+          var invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+          expect(invalidIcon).not.to.be.null;
+          expect(invalidIcon.hasAttribute('hidden')).to.be.false;
+          done();
+        });
+      });
+
+      it('should hide an alert icon when becomes valid', function() {
+        item.invalid = true;
+        helpers.next(function() {
+          item.invalid = false;
+          helpers.next(function() {
+            var invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+            expect(invalidIcon).not.to.be.null;
+            expect(invalidIcon.hasAttribute('hidden')).to.be.true;
+            done();
+          });
+        });
+      });
     });
 
     describe('#label', function() {

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -146,27 +146,19 @@ describe('Tab', function() {
         expect(item.classList.contains('is-invalid')).to.be.false;
       });
 
-      it('should show an alert icon when invalid', function() {
-        item.invalid = true;
-        helpers.next(function() {
-          let invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
-          expect(invalidIcon).not.to.be.null;
-          expect(invalidIcon.hasAttribute('hidden')).to.be.false;
-          done();
-        });
-      });
+      it('should show an alert icon when invalid and hide it when valid', function() {
+        // we need to call render so that the icons are attached to the tab
+        item.render();
 
-      it('should hide an alert icon when becomes valid', function() {
         item.invalid = true;
-        helpers.next(function() {
-          item.invalid = false;
-          helpers.next(function() {
-            let invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
-            expect(invalidIcon).not.to.be.null;
-            expect(invalidIcon.hasAttribute('hidden')).to.be.true;
-            done();
-          });
-        });
+        let invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+        expect(invalidIcon).not.to.be.null;
+        expect(invalidIcon.hasAttribute('hidden')).to.be.false;
+
+        item.invalid = false;
+        invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+        expect(invalidIcon).not.to.be.null;
+        expect(invalidIcon.hasAttribute('hidden')).to.be.true;
       });
     });
 


### PR DESCRIPTION
Adding an alert icon to invalid Coral Spectrum Tabs in order to improve accessibility.

## Description

When a Coral Spectrum Tab becomes invalid, it only uses the color red to signify that it's invalid. As Coral Spectrum may have users with impaired vision, there is need for a more robust approach. With this change, I'm adding a Coral Spectrum Icon that appears when the tab is invalid and hides when the tab becomes valid.
The icon is created during the Tab component render() method with the attribute `hidden` set. When the call to `setInvalid(value)` is made, the attribute is removed and the icon appears in the tab, depending on the value of `value`.

## Related Issue

https://github.com/adobe/coral-spectrum/issues/48

## Motivation and Context

This PR would improve Coral Spectrum accessibility by helping colour blind users to determine which tabs are invalid or not.

## How Has This Been Tested?

The testing of the issue has been done using the examples page of the Coral Spectrum Tablist component. A unit test has been provided.

## Screenshots (if appropriate):

Using Chromelens set to Achromatopsia:

![image](https://user-images.githubusercontent.com/53042848/78040741-86058580-7378-11ea-9b23-1fb571e7fb77.png)


## Types of changes

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
