### PR TITLE
CUI-7170 Coral.ColumnView: single selection loads next

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -219,11 +219,8 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
       const isSelected = item.hasAttribute('selected');
       
       if (!isSelected) {
-        if (this._selectionMode === selectionMode.SINGLE) {
-          item.setAttribute('active', '');
-        }
         // Handle multi-selection with shiftKey
-        else if (event.shiftKey && this._selectionMode === selectionMode.MULTIPLE) {
+         if (event.shiftKey && this._selectionMode === selectionMode.MULTIPLE) {
           const lastSelectedItem = this._lastSelectedItems[this._lastSelectedItems.length - 1];
     
           if (lastSelectedItem) {
@@ -251,10 +248,6 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
             });
           }
         }
-      }
-      
-      if (!isSelected && this._selectionMode === selectionMode.SINGLE) {
-        item.setAttribute('active', '');
       }
       
       item[isSelected ? 'removeAttribute' : 'setAttribute']('selected', '');

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -489,10 +489,7 @@ describe('ColumnView', function() {
 
           var columns = el.columns.getAll();
           var firstColumn = columns[0];
-
           var secondColumn = columns[1];
-
-
           // selects the an item in the first column
           var selectedItem = firstColumn.items.first();
           selectedItem.selected = true;

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -484,6 +484,25 @@ describe('ColumnView', function() {
         expect(columnActiveChangeSpy.calledBefore(changeSpy)).to.be.true;
       });
 
+      it('should not active when column is selected ', function() {
+        helpers.build(window.__html__['ColumnView.full.html'], function(el) {
+
+          var columns = el.columns.getAll();
+          var firstColumn = columns[0];
+
+          var secondColumn = columns[1];
+
+
+          // selects the an item in the first column
+          var selectedItem = firstColumn.items.first();
+          selectedItem.selected = true;
+          expect(secondColumn.activeItem).to.be.null;
+          expect(secondColumn.selectedItem).to.be.null;
+
+//done();
+        });
+      });
+
       it('should trigger an event when a selected item is removed', function(done) {
         const el = helpers.build(window.__html__['ColumnView.full.html']);
         // no initial events

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -498,8 +498,6 @@ describe('ColumnView', function() {
           selectedItem.selected = true;
           expect(secondColumn.activeItem).to.be.null;
           expect(secondColumn.selectedItem).to.be.null;
-
-//done();
         });
       });
 

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -485,17 +485,16 @@ describe('ColumnView', function() {
       });
 
       it('should not active when column is selected ', function() {
-        helpers.build(window.__html__['ColumnView.full.html'], function(el) {
-
+          const el = helpers.build(window.__html__['ColumnView.full.html']);
           var columns = el.columns.getAll();
           var firstColumn = columns[0];
-          var secondColumn = columns[1];
-          // selects the an item in the first column
           var selectedItem = firstColumn.items.first();
-          selectedItem.selected = true;
-          expect(secondColumn.activeItem).to.be.null;
-          expect(secondColumn.selectedItem).to.be.null;
-        });
+          var secondColumn = columns[1];
+          selectedItem.setAttribute("selected",true);
+          var selectedActiveColumn = selectedItem.getAttribute("active");
+          var secondColumnActive = secondColumn.getAttribute("active");
+          expect(secondColumnActive).to.be.null;
+          expect(selectedActiveColumn).to.be.null;
       });
 
       it('should trigger an event when a selected item is removed', function(done) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The actual issue is that on selecting the item(clicking on thumbnail) in a column view(selectionMode : Single), it loads the next column.
The root cause is the code triggers the activate event of next column when an item is selected. AFAIU Setting an item as active results in loads item data , which is the folder content.
This is not the expected behaviour. In 6.3 , next column is not loaded on selecting asset thumbnail .
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Have run Gulp build and verified everything run fines .
CQ Issue also got resolved after applying this fix.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
