### PR TITLE
issue/58 tooltip to open when focused

### DIFF
--- a/coral-base-overlay/src/scripts/BaseOverlay.js
+++ b/coral-base-overlay/src/scripts/BaseOverlay.js
@@ -72,7 +72,7 @@ function hideEverythingBut(instance) {
   const children = document.body.children;
   for (let i = 0; i < children.length; i++) {
     const child = children[i];
-    
+
     // If it's not a parent of or not the instance itself, it needs to be hidden
     if (child !== instance && child.contains && !child.contains(instance)) {
       const currentAriaHidden = child.getAttribute('aria-hidden');
@@ -89,12 +89,12 @@ function hideEverythingBut(instance) {
         // Nothing is hidden by default, store that
         child._previousAriaHidden = 'false';
       }
-      
+
       // Hide it
       child.setAttribute('aria-hidden', 'true');
     }
   }
-  
+
   // Always show ourselves
   instance.setAttribute('aria-hidden', 'false');
 }
@@ -105,7 +105,7 @@ function hideEverythingBut(instance) {
 function doRepositionBackdrop() {
   // Position under the topmost overlay
   const top = OverlayManager.top();
-  
+
   if (top) {
     // The backdrop, if shown, should be positioned under the topmost overlay that does have a backdrop
     for (let i = overlayStack.length - 1; i > -1; i--) {
@@ -114,7 +114,7 @@ function doRepositionBackdrop() {
         break;
       }
     }
-    
+
     // ARIA: Set hidden properly
     hideEverythingBut(top.instance);
   }
@@ -124,35 +124,35 @@ OverlayManager = {
   pop(instance) {
     // Get overlay index
     const index = this.indexOf(instance);
-    
+
     if (index === -1) {
       return null;
     }
-    
+
     // Get the overlay
     const overlay = overlayStack[index];
-    
+
     // Remove from the stack
     overlayStack.splice(index, 1);
-    
+
     // Return the passed overlay or the found overlay
     return overlay;
   },
-  
+
   push(instance) {
     // Pop overlay
     const overlay = this.pop(instance) || {instance};
-    
+
     // Get the new highest zIndex
     const zIndex = this.getHighestZIndex() + 10;
-    
+
     // Store the zIndex
     overlay.zIndex = zIndex;
     instance.style.zIndex = zIndex;
-    
+
     // Push it
     overlayStack.push(overlay);
-    
+
     if (overlay.backdrop) {
       // If the backdrop is shown, we'll need to reposition it
       // Generally, a component will not call _pushOverlay unnecessarily
@@ -160,10 +160,10 @@ OverlayManager = {
       // so _pushOverlay will be called when shown and when attached
       doRepositionBackdrop();
     }
-    
+
     return overlay;
   },
-  
+
   indexOf(instance) {
     // Loop over stack
     // Find overlay
@@ -175,29 +175,29 @@ OverlayManager = {
     }
     return -1;
   },
-  
+
   get(instance) {
     // Get overlay index
     const index = this.indexOf(instance);
-    
+
     // Return overlay
     return index === -1 ? null : overlayStack[index];
   },
-  
+
   top() {
     const length = overlayStack.length;
     return length === 0 ? null : overlayStack[length - 1];
   },
-  
+
   getHighestZIndex() {
     const overlay = this.top();
     return overlay ? overlay.zIndex : startZIndex;
   },
-  
+
   some(...args) {
     return overlayStack.some(...args);
   },
-  
+
   forEach(...args) {
     return overlayStack.forEach(...args);
   }
@@ -222,12 +222,12 @@ function createDocumentTabCaptureEls() {
             item.focus(preventScroll(top));
             return true;
           }
-          
+
           return false;
         });
       }
     });
-    
+
     bottomTabCaptureEl = document.createElement('div');
     bottomTabCaptureEl.setAttribute('coral-tabcapture', '');
     bottomTabCaptureEl.setAttribute('role', 'presentation');
@@ -237,7 +237,7 @@ function createDocumentTabCaptureEls() {
       const top = OverlayManager.top();
       if (top && top.instance.trapFocus === trapFocus.ON) {
         const tabbableElement = Array.prototype.filter.call(top.instance.querySelectorAll(commons.TABBABLE_ELEMENT_SELECTOR), (item) => item.offsetParent !== null && !item.hasAttribute('coral-tabcapture')).pop();
-        
+
         // Focus on the last tabbable element of the top overlay
         if (tabbableElement) {
           tabbableElement.focus(preventScroll(top));
@@ -250,13 +250,13 @@ function createDocumentTabCaptureEls() {
       // Make sure we stay at the very top
       document.body.insertBefore(topTabCaptureEl, document.body.firstChild);
     }
-    
+
     if (document.body.lastElementChild !== bottomTabCaptureEl) {
       // Make sure we stay at the very bottom
       document.body.appendChild(bottomTabCaptureEl);
     }
   }
-  
+
   // Make sure the tab capture elemenst are shown
   topTabCaptureEl.style.display = 'inline';
   bottomTabCaptureEl.style.display = 'inline';
@@ -290,20 +290,20 @@ function showEverything() {
  */
 function doBackdropHide() {
   document.body.classList.remove('u-coral-noscroll');
-  
+
   // Start animation
   window.requestAnimationFrame(() => {
     backdropEl.classList.remove('is-open');
-    
+
     cancelBackdropHide();
     fadeTimeout = window.setTimeout(() => {
       backdropEl.style.display = 'none';
     }, FADETIME);
   });
-  
+
   // Set flag for testing
   backdropEl._isOpen = false;
-  
+
   // Wait for animation to complete
   showEverything();
 }
@@ -316,13 +316,13 @@ function hideOrRepositionBackdrop() {
     // Do nothing if the backdrop isn't shown
     return;
   }
-  
+
   // Loop over all overlays
   const keepBackdrop = OverlayManager.some((overlay) => {
     // Check for backdrop usage
     return !!overlay.backdrop;
   });
-  
+
   if (!keepBackdrop) {
     // Hide the backdrop
     doBackdropHide();
@@ -331,7 +331,7 @@ function hideOrRepositionBackdrop() {
     // Reposition the backdrop
     doRepositionBackdrop();
   }
-  
+
   // Hide/create the document-level tab capture element as necessary
   // This only applies to modal overlays (those that have backdrops)
   const top = OverlayManager.top();
@@ -359,32 +359,32 @@ function handleBackdropClick(event) {
  */
 function doBackdropShow(zIndex, instance) {
   document.body.classList.add('u-coral-noscroll');
-  
+
   if (!backdropEl) {
     backdropEl = document.createElement('div');
     backdropEl.className = '_coral-Underlay';
     document.body.appendChild(backdropEl);
-    
+
     backdropEl.addEventListener('click', handleBackdropClick);
   }
-  
+
   // Show just under the provided zIndex
   // Since we always increment by 10, this will never collide
   backdropEl.style.zIndex = zIndex - 1;
-  
+
   // Set flag for testing
   backdropEl._isOpen = true;
-  
+
   // Start animation
   backdropEl.style.display = '';
   window.requestAnimationFrame(() => {
     // Add the class on the next animation frame so backdrop has time to exist
     // Otherwise, the animation for opacity will not work.
     backdropEl.classList.add('is-open');
-    
+
     cancelBackdropHide();
   });
-  
+
   hideEverythingBut(instance);
 }
 
@@ -396,15 +396,15 @@ const BaseOverlay = (superClass) => class extends superClass {
   /** @ignore */
   constructor() {
     super();
-    
+
     // Templates
     this._elements = {};
     base.call(this._elements);
   }
-  
+
   /**
    Whether to trap tabs and keep them within the overlay. See {@link OverlayTrapFocusEnum}.
-   
+
    @type {String}
    @default OverlayTrapFocusEnum.OFF
    @htmlattribute trapfocus
@@ -415,19 +415,19 @@ const BaseOverlay = (superClass) => class extends superClass {
   set trapFocus(value) {
     value = transform.string(value).toLowerCase();
     this._trapFocus = validate.enumeration(trapFocus)(value) && value || trapFocus.OFF;
-    
+
     if (this._trapFocus === trapFocus.ON) {
       // Give ourselves tabIndex if we are not focusable
       if (this.tabIndex < 0) {
         /** @ignore */
         this.tabIndex = 0;
       }
-      
+
       // Insert elements
       this.insertBefore(this._elements.topTabCapture, this.firstElementChild);
       this.appendChild(this._elements.intermediateTabCapture);
       this.appendChild(this._elements.bottomTabCapture);
-      
+
       // Add listeners
       this._handleTabCaptureFocus = this._handleTabCaptureFocus.bind(this);
       this._handleRootKeypress = this._handleRootKeypress.bind(this);
@@ -439,16 +439,16 @@ const BaseOverlay = (superClass) => class extends superClass {
       this._elements.topTabCapture && this._elements.topTabCapture.remove();
       this._elements.intermediateTabCapture && this._elements.intermediateTabCapture.remove();
       this._elements.bottomTabCapture && this._elements.bottomTabCapture.remove();
-  
+
       // Remove listeners
       this._vent.off('keydown', this._handleRootKeypress);
       this._vent.off('focus', '[coral-tabcapture]', this._handleTabCaptureFocus);
     }
   }
-  
+
   /**
    Whether to return focus to the previously focused element when closed. See {@link OverlayReturnFocusEnum}.
-   
+
    @type {String}
    @default OverlayReturnFocusEnum.OFF
    @htmlattribute returnfocus
@@ -460,10 +460,10 @@ const BaseOverlay = (superClass) => class extends superClass {
     value = transform.string(value).toLowerCase();
     this._returnFocus = validate.enumeration(returnFocus)(value) && value || returnFocus.OFF;
   }
-  
+
   /**
    Whether the browser should scroll the document to bring the newly-focused element into view. See {@link OverlayScrollOnFocusEnum}.
-   
+
    @type {String}
    @default OverlayScrollOnFocusEnum.ON
    @htmlattribute scrollonfocus
@@ -475,13 +475,13 @@ const BaseOverlay = (superClass) => class extends superClass {
     value = transform.string(value).toLowerCase();
     this._scrollOnFocus = validate.enumeration(scrollOnFocus)(value) && value || scrollOnFocus.ON;
   }
-  
+
   /**
    Whether to focus the overlay, when opened or not. By default the overlay itself will get the focus. It also accepts
    an instance of HTMLElement or a selector like ':first-child' or 'button:last-of-type'. If the selector returns
    multiple elements, it will focus the first element inside the overlay that matches the selector.
    See {@link OverlayFocusOnShowEnum}.
-   
+
    @type {HTMLElement|String}
    @default OverlayFocusOnShowEnum.ON
    @htmlattribute focusonshow
@@ -494,10 +494,10 @@ const BaseOverlay = (superClass) => class extends superClass {
       this._focusOnShow = value;
     }
   }
-  
+
   /**
    Whether this overlay is open or not.
-   
+
    @type {Boolean}
    @default false
    @htmlattribute open
@@ -512,23 +512,23 @@ const BaseOverlay = (superClass) => class extends superClass {
   }
   set open(value) {
     const silenced = this._silenced;
-    
+
     value = transform.booleanAttr(value);
-  
+
     // Used for global animations
     this.trigger('coral-overlay:_animate');
-    
+
     const beforeEvent = this.trigger(value ? 'coral-overlay:beforeopen' : 'coral-overlay:beforeclose');
-    
+
     if (!beforeEvent.defaultPrevented) {
       const open = this._open = value;
       this._reflectAttribute('open', open);
-  
+
       // Set aria-hidden false before we show
       // Otherwise, screen readers will not announce
       // Doesn't matter when we set aria-hidden true (nothing being announced)
       this.setAttribute('aria-hidden', !open);
-  
+
       // Don't do anything if we're not in the DOM yet
       // This prevents errors related to allocating a zIndex we don't need
       if (this.parentNode) {
@@ -536,7 +536,7 @@ const BaseOverlay = (superClass) => class extends superClass {
         if (open) {
           // Set z-index
           this._pushOverlay();
-      
+
           if (this.returnFocus === returnFocus.ON) {
             this._elementToFocusWhenHidden =
               // cached element
@@ -552,12 +552,12 @@ const BaseOverlay = (superClass) => class extends superClass {
           this._popOverlay();
         }
       }
-      
+
       // Don't force reflow
       window.requestAnimationFrame(() => {
         // Keep it silenced
         this._silenced = silenced;
-        
+
         if (open) {
           if (this.trapFocus === trapFocus.ON) {
             // Make sure tab capture elements are positioned correctly
@@ -573,28 +573,28 @@ const BaseOverlay = (superClass) => class extends superClass {
               this.appendChild(this._elements.bottomTabCapture);
             }
           }
-    
+
           // The default style should be display: none for overlays
           // Show ourselves first for centering calculations etc
           this.style.display = '';
-  
+
           // Do it in the next frame to make the animation happen
           window.requestAnimationFrame(() => {
             this.classList.add('is-open');
           });
-  
+
           const openComplete = () => {
             if (this.open) {
               this._debounce(() => {
                 // handles the focus behavior based on accessibility recommendations
                 this._handleFocus();
-  
+
                 this.trigger('coral-overlay:open');
                 this._silenced = false;
               });
             }
           };
-  
+
           if (this._overlayAnimationTime) {
             // Wait for animation to complete
             commons.transitionEnd(this, openComplete);
@@ -607,25 +607,25 @@ const BaseOverlay = (superClass) => class extends superClass {
         else {
           // Fade out
           this.classList.remove('is-open');
-    
+
           const closeComplete = () => {
             if (!this.open) {
               // Hide self
               this.style.display = 'none';
-  
+
               // makes sure the focus is returned per accessibility recommendations
               this._handleReturnFocus();
-  
+
               this._debounce(() => {
                 // Inform child overlays that we're closing
                 this._closeChildOverlays();
-  
+
                 this.trigger('coral-overlay:close');
                 this._silenced = false;
               });
             }
           };
-    
+
           if (this._overlayAnimationTime) {
             // Wait for animation to complete
             commons.transitionEnd(this, closeComplete);
@@ -638,14 +638,14 @@ const BaseOverlay = (superClass) => class extends superClass {
       });
     }
   }
-  
+
   _closeChildOverlays() {
     const components = this.querySelectorAll(COMPONENTS_WITH_OVERLAY);
-    
+
     // Close all children overlays and components with overlays
     for (let i = 0; i < components.length; i++) {
       const component = components[i];
-      
+
       // Overlay component
       if (component.hasAttribute('open')) {
         component.removeAttribute('open');
@@ -656,7 +656,7 @@ const BaseOverlay = (superClass) => class extends superClass {
       }
     }
   }
-  
+
   /** @private */
   _debounce(f) {
     // Used to avoid triggering open/close event continuously
@@ -665,104 +665,104 @@ const BaseOverlay = (superClass) => class extends superClass {
       f();
     }, 10);
   }
-  
+
   /**
    Check if this overlay is the topmost.
-   
+
    @protected
    */
   _isTopOverlay() {
     const top = OverlayManager.top();
     return top && top.instance === this;
   }
-  
+
   /**
    Push the overlay to the top of the stack.
-   
+
    @protected
    */
   _pushOverlay() {
     OverlayManager.push(this);
   }
-  
+
   /**
    Remove the overlay from the stack.
-   
+
    @protected
    */
   _popOverlay() {
     OverlayManager.pop(this);
-    
+
     // Automatically hide the backdrop if required
     hideOrRepositionBackdrop();
   }
-  
+
   /**
    Show the backdrop.
-   
+
    @protected
    */
   _showBackdrop() {
     const overlay = OverlayManager.get(this);
-    
+
     // Overlay is not tracked unless the component is in the DOM
     // Hence, we need to check
     if (overlay) {
       overlay.backdrop = true;
       doBackdropShow(overlay.zIndex, this);
     }
-    
+
     // Mark on the instance that the backdrop has been requested for this overlay
     this._requestedBackdrop = true;
-    
+
     // Mark that the backdrop was requested when not attached to the DOM
     // This allows us to know whether to push the overlay when the component is attached
     if (!this.parentNode) {
       this._showBackdropOnAttached = true;
     }
-    
+
     if (this.trapFocus === trapFocus.ON) {
       createDocumentTabCaptureEls();
     }
   }
-  
+
   /**
    Show the backdrop.
-   
+
    @protected
    */
   _hideBackdrop() {
     const overlay = OverlayManager.get(this);
-    
+
     if (overlay) {
       overlay.backdrop = false;
-      
+
       // If that was the last overlay using the backdrop, hide it
       hideOrRepositionBackdrop();
     }
-    
+
     // Mark on the instance that the backdrop is no longer needed
     this._requestedBackdrop = false;
   }
-  
+
   /**
    Handles keypresses on the root of the overlay and marshalls focus accordingly.
-   
+
    @protected
    */
   _handleRootKeypress(event) {
     if (event.target === this && event.keyCode === TAB_KEY) {
       // Skip the top tabcapture and focus on the first focusable element
       this._focusOn('first');
-      
+
       // Stop the normal tab behavior
       event.preventDefault();
     }
   }
-  
+
   /**
    Handles focus events on tab capture elements.
-   
+
    @protected
    */
   _handleTabCaptureFocus(event) {
@@ -771,18 +771,18 @@ const BaseOverlay = (superClass) => class extends superClass {
       this._ignoreTabCapture = false;
       return;
     }
-    
+
     // Focus on the correct tabbable element
     const target = event.target;
     const which = target === this._elements.intermediateTabCapture ? 'first' : 'last';
-    
+
     this._focusOn(which);
   }
-  
+
   /**
    Handles the focus behavior. When "on" is specified it would try to find the first tababble descendent in the
    content and if there are no valid candidates it will focus the element itself.
-   
+
    @protected
    */
   _handleFocus() {
@@ -796,7 +796,7 @@ const BaseOverlay = (superClass) => class extends superClass {
     else if (typeof this.focusOnShow === 'string' && this.focusOnShow !== focusOnShow.OFF) {
       // we need to add :not([coral-tabcapture]) to avoid selecting the tab captures
       const selectedElement = this.querySelector(`${this.focusOnShow}:not([coral-tabcapture])`);
-      
+
       if (selectedElement) {
         selectedElement.focus(preventScroll(this));
       }
@@ -806,7 +806,7 @@ const BaseOverlay = (superClass) => class extends superClass {
       }
     }
   }
-  
+
   /**
    @protected
    */
@@ -816,27 +816,27 @@ const BaseOverlay = (superClass) => class extends superClass {
         // Don't return focus if the user focused outside of the overlay
         return;
       }
-      
+
       // Return focus, ignoring tab capture if it is an overlay
       this._elementToFocusWhenHidden._ignoreTabCapture = true;
       this._elementToFocusWhenHidden.focus(preventScroll(this));
       this._elementToFocusWhenHidden._ignoreTabCapture = false;
-      
+
       // Drop the reference to avoid memory leaks
       this._elementToFocusWhenHidden = null;
     }
   }
-  
+
   /**
    Focus on the first or last element.
-   
+
    @param {String} which
    one of "first" or "last"
    @protected
    */
   _focusOn(which) {
     const focusableTarget = this._getFocusableElement(which);
-    
+
     // if we found a focusing target we focus it
     if (focusableTarget) {
       focusableTarget.focus(preventScroll(this));
@@ -846,50 +846,50 @@ const BaseOverlay = (superClass) => class extends superClass {
       this.focus(preventScroll(this));
     }
   }
-  
+
   _getFocusableElements() {
     return Array.prototype.filter.call(this.querySelectorAll(commons.FOCUSABLE_ELEMENT_SELECTOR), item => item.offsetParent !== null && !item.hasAttribute('coral-tabcapture'));
   }
-  
+
   _getFocusableElement(which) {
     let focusableTarget;
-    
+
     if (which === 'first' || which === 'last') {
       const focusableElements = this._getFocusableElements();
       focusableTarget = focusableElements[which === 'first' ? 'shift' : 'pop']();
     }
-    
+
     return focusableTarget;
   }
-  
+
   /**
    Open the overlay and set the z-index accordingly.
-   
+
    @returns {BaseOverlay} this, chainable
    */
   show() {
     this.open = true;
-    
+
     return this;
   }
-  
+
   /**
    Close the overlay.
-   
+
    @returns {BaseOverlay} this, chainable
    */
   hide() {
     this.open = false;
-  
+
     return this;
   }
-  
+
   /**
    Set the element that focus should be returned to when the overlay is hidden.
-   
+
    @param {HTMLElement} element
    The element to return focus to. This must be a DOM element, not a jQuery object or selector.
-   
+
    @returns {BaseOverlay} this, chainable
    */
   returnFocusTo(element) {
@@ -897,12 +897,12 @@ const BaseOverlay = (superClass) => class extends superClass {
       // Switch on returning focus if it's off
       this.returnFocus = returnFocus.ON;
     }
-  
+
     // If the element is not focusable,
     if (!element.matches(commons.FOCUSABLE_ELEMENT_SELECTOR)) {
       // add tabindex so that it is programmatically focusable.
       element.setAttribute('tabindex', -1);
-    
+
       // On blur, restore element to its prior, not-focusable state
       const tempVent = new Vent(element);
       tempVent.on('blur.afterFocus', (event) => {
@@ -918,50 +918,50 @@ const BaseOverlay = (superClass) => class extends superClass {
         });
       }, true);
     }
-  
+
     this._returnFocusToElement = element;
     return this;
   }
-  
+
   static get _OverlayManager() {
     return OverlayManager;
   }
-  
+
   /**
    Returns {@link BaseOverlay} trap focus options.
-   
+
    @return {OverlayTrapFocusEnum}
    */
   static get trapFocus() { return trapFocus; }
-  
+
   /**
    Returns {@link BaseOverlay} return focus options.
-   
+
    @return {OverlayReturnFocusEnum}
    */
   static get returnFocus() { return returnFocus; }
-  
+
   /**
    Returns {@link BaseOverlay} scroll focus options.
-   
+
    @return {OverlayScrollOnFocusEnum}
    */
   static get scrollOnFocus() { return scrollOnFocus; }
-  
+
   /**
    Returns {@link BaseOverlay} focus on show options.
-   
+
    @return {OverlayFocusOnShowEnum}
    */
   static get focusOnShow() { return focusOnShow; }
-  
+
   /**
    Returns {@link BaseOverlay} fadetime in milliseconds.
-   
+
    @return {Number}
    */
   static get FADETIME() { return FADETIME; }
-  
+
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
       trapfocus: 'trapFocus',
@@ -969,7 +969,7 @@ const BaseOverlay = (superClass) => class extends superClass {
       focusonshow: 'focusOnShow',
     });
   }
-  
+
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat([
@@ -979,83 +979,83 @@ const BaseOverlay = (superClass) => class extends superClass {
       'open'
     ]);
   }
-  
+
   /** @ignore */
   connectedCallback() {
     super.connectedCallback();
-  
+
     if (!this.hasAttribute('trapfocus')) { this.trapFocus = this.trapFocus; }
     if (!this.hasAttribute('returnfocus')) { this.returnFocus = this.returnFocus; }
     if (!this.hasAttribute('focusonshow')) { this.focusOnShow = this.focusOnShow; }
     if (!this.hasAttribute('scrollonfocus')) { this.scrollOnFocus = this.scrollOnFocus; }
-    
+
     if (this.open) {
       this._pushOverlay();
-    
+
       if (this._showBackdropOnAttached) {
         // Show the backdrop again
         this._showBackdrop();
       }
     }
   }
-  
+
   /** @ignore */
   render() {
     super.render();
-    
+
     this.classList.add(CLASSNAME);
   }
-  
+
   /** @ignore */
   disconnectedCallback() {
     super.disconnectedCallback();
-  
+
     if (this.open) {
       // Release zIndex as we're not in the DOM any longer
       // When we're re-added, we'll get a new zIndex
       this._popOverlay();
-    
+
       if (this._requestedBackdrop) {
         // Mark that we'll need to show the backdrop when attached
         this._showBackdropOnAttached = true;
       }
     }
   }
-  
+
   /**
    Called when the {@link BaseOverlay} is clicked.
-   
+
    @function backdropClickedCallback
    @protected
    */
-  
+
   /**
    Triggered before the {@link BaseOverlay} is opened with <code>show()</code> or <code>instance.open = true</code>.
- 
+
    @typedef {CustomEvent} coral-overlay:beforeopen
-   
+
    @property {function} preventDefault
    Call to stop the overlay from opening.
    */
-  
+
   /**
    Triggered after the {@link BaseOverlay} is opened with <code>show()</code> or <code>instance.open = true</code>
- 
+
    @typedef {CustomEvent} coral-overlay:open
    */
-  
+
   /**
    Triggered before the {@link BaseOverlay} is closed with <code>hide()</code> or <code>instance.open = false</code>.
- 
+
    @typedef {CustomEvent} coral-overlay:beforeclose
-   
+
    @property {function} preventDefault
    Call to stop the overlay from closing.
    */
-  
+
   /**
    Triggered after the {@link BaseOverlay} is closed with <code>hide()</code> or <code>instance.open = false</code>
- 
+
    @typedef {CustomEvent} coral-overlay:close
    */
 };

--- a/coral-component-tooltip/src/scripts/Tooltip.js
+++ b/coral-component-tooltip/src/scripts/Tooltip.js
@@ -330,7 +330,6 @@ class Tooltip extends Overlay {
 
       if (!this.open) {
         this._cancelShow();
-        this.ariaDescribedby = this._contentId;
 
         if (this.delay === 0) {
           // Show immediately

--- a/coral-component-tooltip/src/scripts/Tooltip.js
+++ b/coral-component-tooltip/src/scripts/Tooltip.js
@@ -13,7 +13,7 @@
 import {Overlay} from '../../../coral-component-overlay';
 import Vent from '@adobe/vent';
 import base from '../templates/base';
-import {transform, validate, commons} from '../../../coral-utils';
+import {commons, transform, validate} from '../../../coral-utils';
 
 const arrowMap = {
   left: 'left',
@@ -28,9 +28,9 @@ const OFFSET = 5;
 
 /**
  Enumeration for {@link Tooltip} variants.
- 
+
  @typedef {Object} TooltipVariantEnum
- 
+
  @property {String} DEFAULT
  A default tooltip that provides additional information.
  @property {String} INFO
@@ -67,10 +67,10 @@ const placementClassMap = {};
 for (const key in Overlay.placement) {
   const direction = Overlay.placement[key];
   const placementClass = `${CLASSNAME}--${arrowMap[direction]}`;
-  
+
   // Store in map
   placementClassMap[direction] = placementClass;
-  
+
   // Store in list
   ALL_PLACEMENT_CLASSES.push(placementClass);
 }
@@ -86,19 +86,20 @@ class Tooltip extends Overlay {
   /** @ignore */
   constructor() {
     super();
-  
+
     // Override defaults
     this._lengthOffset = OFFSET;
     this._overlayAnimationTime = Overlay.FADETIME;
-  
+    this.focusOnShow = Overlay.focusOnShow.OFF;
+
     // Fetch or create the content zone element
     this._elements = commons.extend(this._elements, {
       content: this.querySelector('coral-tooltip-content') || document.createElement('coral-tooltip-content')
     });
-    
+
     // Generate template
     base.call(this._elements);
-  
+
     // Used for events
     this._id = commons.getUID();
     this._delegateEvents({
@@ -106,10 +107,10 @@ class Tooltip extends Overlay {
       'coral-overlay:_animate': '_onAnimate'
     });
   }
-  
+
   /**
    The variant of tooltip. See {@link TooltipVariantEnum}.
-   
+
    @type {String}
    @default TooltipVariantEnum.DEFAULT
    @htmlattribute variant
@@ -122,14 +123,14 @@ class Tooltip extends Overlay {
     value = transform.string(value).toLowerCase();
     this._variant = validate.enumeration(variant)(value) && value || variant.DEFAULT;
     this._reflectAttribute('variant', this._variant);
-  
+
     this.classList.remove(...ALL_VARIANT_CLASSES);
     this.classList.add(`${CLASSNAME}--${this._variant}`);
   }
-  
+
   /**
    The amount of time in miliseconds to wait before showing the tooltip when the target is interacted with.
-   
+
    @type {Number}
    @default 500
    @htmlattribute delay
@@ -140,10 +141,10 @@ class Tooltip extends Overlay {
   set delay(value) {
     this._delay = transform.number(value);
   }
-  
+
   /**
    The Tooltip content element.
-   
+
    @type {TooltipContent}
    @contentzone
    */
@@ -160,7 +161,7 @@ class Tooltip extends Overlay {
       }
     });
   }
-  
+
   /**
    Inherited from {@link Overlay#open}.
    */
@@ -169,13 +170,13 @@ class Tooltip extends Overlay {
   }
   set open(value) {
     super.open = value;
-    
+
     if (!this.open) {
       // Stop previous show operations from happening
       this._cancelShow();
     }
   }
-  
+
   /**
    Inherited from {@link Overlay#target}.
    */
@@ -184,12 +185,12 @@ class Tooltip extends Overlay {
   }
   set target(value) {
     super.target = value;
-  
+
     const target = this._getTarget(value);
-    
+
     if (target) {
       this._elements.tip.hidden = false;
-      
+
       if (this.interaction === this.constructor.interaction.ON) {
         // Add listeners to the target
         this._addTargetListeners(target);
@@ -199,7 +200,7 @@ class Tooltip extends Overlay {
       this._elements.tip.hidden = true;
     }
   }
-  
+
   /**
    Inherited from {@link Overlay#interaction}.
    */
@@ -208,9 +209,9 @@ class Tooltip extends Overlay {
   }
   set interaction(value) {
     super.interaction = value;
-  
+
     const target = this._getTarget();
-  
+
     if (target) {
       if (value === this.constructor.interaction.ON) {
         this._addTargetListeners(target);
@@ -220,18 +221,18 @@ class Tooltip extends Overlay {
       }
     }
   }
-  
+
   /** @ignore */
   _onPositioned(event) {
     // Set arrow placement
     this.classList.remove(...ALL_PLACEMENT_CLASSES);
     this.classList.add(placementClassMap[event.detail.placement]);
   }
-  
+
   _onAnimate() {
     // popper attribute
     const popperPlacement = this.getAttribute('x-placement');
-  
+
     // popper takes care of setting left, top to 0 on positioning
     if (popperPlacement === 'left') {
       this.style.left = '8px';
@@ -246,30 +247,30 @@ class Tooltip extends Overlay {
       this.style.top = '-8px';
     }
   }
-  
+
   /** @ignore */
   _handleFocusOut() {
     // The item that should have focus will get it on the next frame
     window.requestAnimationFrame(() => {
       const targetIsFocused = document.activeElement === this._getTarget();
-      
+
       if (!targetIsFocused) {
         this._cancelShow();
         this.open = false;
       }
     });
   }
-  
+
   /** @ignore */
   _cancelShow() {
     window.clearTimeout(this._showTimeout);
   }
-  
+
   /** @ignore */
   _cancelHide() {
     window.clearTimeout(this._hideTimeout);
   }
-  
+
   /** @ignore */
   _startHide() {
     if (this.delay === 0) {
@@ -282,7 +283,7 @@ class Tooltip extends Overlay {
       }, this.delay);
     }
   }
-  
+
   /** @ignore */
   _addTargetListeners(target) {
     // Make sure we don't add listeners twice to the same element for this particular tooltip
@@ -290,7 +291,7 @@ class Tooltip extends Overlay {
       return;
     }
     target[`_hasTooltipListeners${this._id}`] = true;
-    
+
     // Remove listeners from the old target
     if (this._oldTarget) {
       const oldTarget = this._getTarget(this._oldTarget);
@@ -298,20 +299,39 @@ class Tooltip extends Overlay {
         this._removeTargetListeners(oldTarget);
       }
     }
-    
+
     // Store the current target value
     this._oldTarget = target;
-    
+
     // Use Vent to bind events on the target
     this._targetEvents = new Vent(target);
-  
-    this._targetEvents.on(`mouseenter.Tooltip${this._id} focusin.Tooltip${this._id}`, () => {
+
+    this._targetEvents.on(`mouseenter.Tooltip${this._id}`, this._handleOpenTooltip());
+
+    this._targetEvents.on(`focusin.Tooltip${this._id}`, this._handleOpenTooltip());
+
+    this._targetEvents.on(`mouseleave.Tooltip${this._id}`, () => {
+      if (this.interaction === this.constructor.interaction.ON) {
+        this._startHide();
+      }
+    });
+
+    this._targetEvents.on(`focusout.Tooltip${this._id}`, () => {
+      if (this.interaction === this.constructor.interaction.ON) {
+        this._handleFocusOut();
+      }
+    });
+  }
+
+  _handleOpenTooltip() {
+    return () => {
       // Don't let the tooltip hide
       this._cancelHide();
-      
+
       if (!this.open) {
         this._cancelShow();
-        
+        this.ariaDescribedby = this._contentId;
+
         if (this.delay === 0) {
           // Show immediately
           this.show();
@@ -322,21 +342,9 @@ class Tooltip extends Overlay {
           }, this.delay);
         }
       }
-    });
-  
-    this._targetEvents.on(`mouseleave.Tooltip${this._id}`, () => {
-      if (this.interaction === this.constructor.interaction.ON) {
-        this._startHide();
-      }
-    });
-  
-    this._targetEvents.on(`focusout.Tooltip${this._id}`, () => {
-      if (this.interaction === this.constructor.interaction.ON) {
-        this._handleFocusOut();
-      }
-    });
+    };
   }
-  
+
   /** @ignore */
   _removeTargetListeners(target) {
     // Remove listeners for this tooltip and mark that the element doesn't have them
@@ -346,54 +354,54 @@ class Tooltip extends Overlay {
     }
     target[`_hasTooltipListeners${this._id}`] = false;
   }
-  
+
   get _contentZones() { return {'coral-tooltip-content': 'content'}; }
-  
+
   /**
    Returns {@link Tooltip} variants.
-   
+
    @return {TooltipVariantEnum}
    */
   static get variant() { return variant; }
-  
+
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat(['variant', 'delay']);
   }
-  
+
   /** @ignore */
   render() {
     super.render();
-    
+
     this.classList.add(CLASSNAME);
-  
+
     // ARIA
     this.setAttribute('role', 'tooltip');
     // Let the tooltip be focusable
     // We'll marshall focus around when its focused
     this.setAttribute('tabindex', '-1');
-  
+
     // Default reflected attributes
     if (!this._variant) { this.variant = variant.DEFAULT; }
-  
+
     // Support cloneNode
     const tip = this.querySelector('._coral-Tooltip-tip');
     if (tip) {
       tip.remove();
     }
-    
+
     const content = this._elements.content;
-  
+
     // Move the content into the content zone if none specified
     if (!content.parentNode) {
       while (this.firstChild) {
         content.appendChild(this.firstChild);
       }
     }
-    
+
     // Append template
     this.appendChild(this._elements.tip);
-  
+
     // Assign the content zone so the insert function will be called
     this.content = content;
   }

--- a/coral-component-tooltip/src/scripts/Tooltip.js
+++ b/coral-component-tooltip/src/scripts/Tooltip.js
@@ -90,7 +90,7 @@ class Tooltip extends Overlay {
     // Override defaults
     this._lengthOffset = OFFSET;
     this._overlayAnimationTime = Overlay.FADETIME;
-    this.focusOnShow = Overlay.focusOnShow.OFF;
+    this._focusOnShow = Overlay.focusOnShow.OFF;
 
     // Fetch or create the content zone element
     this._elements = commons.extend(this._elements, {
@@ -306,9 +306,9 @@ class Tooltip extends Overlay {
     // Use Vent to bind events on the target
     this._targetEvents = new Vent(target);
 
-    this._targetEvents.on(`mouseenter.Tooltip${this._id}`, this._handleOpenTooltip());
+    this._targetEvents.on(`mouseenter.Tooltip${this._id}`, this._handleOpenTooltip.bind(this));
 
-    this._targetEvents.on(`focusin.Tooltip${this._id}`, this._handleOpenTooltip());
+    this._targetEvents.on(`focusin.Tooltip${this._id}`, this._handleOpenTooltip.bind(this));
 
     this._targetEvents.on(`mouseleave.Tooltip${this._id}`, () => {
       if (this.interaction === this.constructor.interaction.ON) {
@@ -324,24 +324,22 @@ class Tooltip extends Overlay {
   }
 
   _handleOpenTooltip() {
-    return () => {
-      // Don't let the tooltip hide
-      this._cancelHide();
+    // Don't let the tooltip hide
+    this._cancelHide();
 
-      if (!this.open) {
-        this._cancelShow();
+    if (!this.open) {
+      this._cancelShow();
 
-        if (this.delay === 0) {
-          // Show immediately
-          this.show();
-        }
-        else {
-          this._showTimeout = window.setTimeout(() => {
-            this.show();
-          }, this.delay);
-        }
+      if (this.delay === 0) {
+        // Show immediately
+        this.show();
       }
-    };
+      else {
+        this._showTimeout = window.setTimeout(() => {
+          this.show();
+        }, this.delay);
+      }
+    }
   }
 
   /** @ignore */

--- a/coral-component-tooltip/src/tests/test.Tooltip.js
+++ b/coral-component-tooltip/src/tests/test.Tooltip.js
@@ -18,22 +18,22 @@ describe('Tooltip', function() {
     it('should be defined in Coral namespace', function() {
       expect(Tooltip).to.have.property('Content');
     });
-  
+
     it('should have correct default property values', function() {
       var tooltip = helpers.build(new Tooltip());
       helpers.target.appendChild(tooltip);
-    
+
       expect(tooltip.variant).to.equal('default');
       expect(tooltip.delay).to.equal(500);
     });
   });
-  
+
   describe('Instantiation', function() {
     helpers.cloneComponent(
       'should be possible to clone the element using markup',
       '<coral-tooltip></coral-tooltip>'
     );
-  
+
     helpers.cloneComponent(
       'should be possible to clone using js',
       new Tooltip()
@@ -41,60 +41,70 @@ describe('Tooltip', function() {
   });
 
   describe('API', function() {
-    
+
     describe('#content', function() {
       it('should set content', function() {
         var tooltip = helpers.build(new Tooltip());
         tooltip.content.innerHTML = 'Test';
-        
+
         expect(tooltip.textContent).to.equal('Test');
       });
     });
-    
+
     describe('#open', function() {
-      it('should open when target element is focused', function() {
-        var target = helpers.overlay.createFloatingTarget();
-    
-        var tooltip = new Tooltip().set({
-          content: {
-            textContent: 'A tooltip'
-          },
-          target: target,
-          placement: 'top',
-          delay: 0
+      it('should open when target element on proper events', function() {
+        let target;
+        let tooltip;
+
+        beforeEach(function() {
+          target = helpers.overlay.createFloatingTarget();
+          tooltip = new Tooltip().set({
+            content: {
+              textContent: 'A tooltip'
+            },
+            target: target,
+            placement: 'top',
+            delay: 0
+          });
+          helpers.target.appendChild(tooltip);
         });
-        helpers.target.appendChild(tooltip);
-    
-        expect(tooltip.open).to.equal(false, 'tooltip closed initially');
-    
-        helpers.mouseEvent('mouseenter', target);
-        
-        expect(tooltip.open).to.equal(true, 'tooltip open after focusing on target');
+
+        it('should open on hover', function() {
+          expect(tooltip.open).to.equal(false, 'tooltip closed initially');
+          helpers.mouseEvent('mouseenter', target);
+          expect(tooltip.open).to.equal(true, 'tooltip open after hovering on target');
+        });
+
+        it('should open on focusin', function() {
+          expect(tooltip.open).to.equal(false, 'tooltip closed initially');
+          helpers.mouseEvent('focusin', target);
+          expect(tooltip.open).to.equal(true, 'tooltip open after focusing on target');
+        });
       });
-  
+
       it('should not display the tooltip until the specified delay', function() {
         var target = helpers.overlay.createFloatingTarget();
-    
+
         var tooltip = new Tooltip().set({
           target: target,
           placement: 'top',
           delay: 0
         });
         helpers.target.appendChild(tooltip);
-    
+
         expect(tooltip.open).to.be.false;
-    
+
         // trigger twice to check that timeout is cleared.
         helpers.mouseEvent('mouseenter', target);
         helpers.mouseEvent('mouseenter', target);
         expect(tooltip.open).to.be.true;
       });
     });
-    
+
     describe('#target', function() {
       it('should remove and add target listeners when target changed', function() {
         var target = helpers.overlay.createStaticTarget();
-    
+
         var tooltip = new Tooltip().set({
           content: {
             textContent: 'A tooltip'
@@ -103,52 +113,52 @@ describe('Tooltip', function() {
           delay: 0
         });
         helpers.target.appendChild(tooltip);
-    
+
         // Point at the old target
         tooltip.target = target;
-    
+
         expect(tooltip.open).to.equal(false, 'tooltip closed initially');
-    
+
         // Show via focus
         helpers.mouseEvent('mouseenter', target);
-    
-        expect(tooltip.open).to.equal(true, 'tooltip open after focusing on target');
-    
+
+        expect(tooltip.open).to.equal(true, 'tooltip open after hovering on target');
+
         tooltip.hide();
-    
+
         expect(tooltip.open).to.equal(false, 'tooltip closed after hide() called');
-    
+
         // Set new target
         var newTarget = helpers.overlay.createStaticTarget();
         tooltip.target = newTarget;
-    
+
         // Try to show via focus on the old target
         helpers.mouseEvent('mouseenter', target);
-    
+
         expect(tooltip.open).to.equal(false, 'tooltip stays closed after clicking old target after target changed');
-    
-        // Show by focusing on the new target
+
+        // Show by hovering on the new target
         helpers.mouseEvent('mouseenter', newTarget);
-    
+
         expect(tooltip.open).to.equal(true, 'tooltip open after clicking new target');
       });
-  
+
       it('should be hidden when focusout triggered on the target element', function(done) {
         var target = helpers.overlay.createFloatingTarget();
-    
+
         var tooltip = new Tooltip().set({
           target: target,
           placement: 'top',
           delay: 0
         });
         helpers.target.appendChild(tooltip);
-    
+
         expect(tooltip.open).to.be.false;
-    
+
         tooltip.show();
 
         expect(tooltip.open).to.be.true;
-  
+
         helpers.mouseEvent('mouseleave', target);
 
         helpers.next(function() {
@@ -156,38 +166,38 @@ describe('Tooltip', function() {
           done();
         });
       });
-  
+
       it('should clear any remaining timeouts when focusout triggered on the target element', function(done) {
         var target = helpers.overlay.createFloatingTarget();
-    
+
         var tooltip = new Tooltip().set({
           target: target,
           placement: 'top',
           delay: 0
         });
         helpers.target.appendChild(tooltip);
-    
+
         expect(tooltip.open).to.be.false;
-    
+
         tooltip.on('coral-overlay:open', function() {
           expect(tooltip.open).to.be.true;
           helpers.mouseEvent('mouseenter', target);
           helpers.mouseEvent('mouseleave', target);
         });
-  
+
         tooltip.on('coral-overlay:close', function() {
           expect(tooltip.open).to.be.false;
           done();
         });
-        
+
         tooltip.show();
       });
     });
-    
+
     describe('#interaction', function() {
       it('should not open on target mouseenter when interaction="off"', function() {
         var target = helpers.overlay.createFloatingTarget();
-    
+
         var tooltip = new Tooltip().set({
           content: {
             textContent: 'A tooltip'
@@ -198,18 +208,18 @@ describe('Tooltip', function() {
           delay: 0
         });
         helpers.target.appendChild(tooltip);
-    
+
         expect(tooltip.open).to.equal(false, 'tooltip closed initially');
-  
+
         helpers.mouseEvent('mouseenter', target);
-        
+
         expect(tooltip.open).to.equal(false, 'tooltip still closed after mouseenter on target');
       });
     });
-  
+
     it('should not open on target mouseenter when interaction="off"', function() {
       var target = helpers.overlay.createFloatingTarget();
-    
+
       var tooltip = new Tooltip().set({
         content: {
           textContent: 'A tooltip'
@@ -220,26 +230,26 @@ describe('Tooltip', function() {
         delay: 0
       });
       helpers.target.appendChild(tooltip);
-    
+
       expect(tooltip.open).to.equal(false, 'tooltip closed initially');
-  
+
       helpers.mouseEvent('mouseenter', target);
-      
+
       expect(tooltip.open).to.equal(true, 'tooltip open after mouseenter on target');
-    
+
       tooltip.open = false;
       tooltip.interaction = 'off';
-  
+
       helpers.mouseEvent('mouseenter', target);
-      
+
       expect(tooltip.open).to.equal(false, 'tooltip still closed after mouseenter on target');
     });
   });
-  
+
   describe('Implementation Details', function() {
     it('should handle slide in animation', (done) => {
       const target = helpers.overlay.createFloatingTarget();
-  
+
       const el = new Tooltip().set({
         content: {
           textContent: 'A tooltip'
@@ -249,7 +259,7 @@ describe('Tooltip', function() {
         delay: 0
       });
       helpers.target.appendChild(el);
-      
+
       el.setAttribute('x-placement', 'top');
       el._onAnimate();
       expect(el.style.top).to.equal('8px');
@@ -257,13 +267,13 @@ describe('Tooltip', function() {
         expect(el.style.top).to.equal('0px');
         done();
       });
-      
+
       helpers.mouseEvent('mouseenter', target);
     });
-    
+
     it('should support multiple tooltips on the same target', function() {
       var target = helpers.overlay.createFloatingTarget();
-    
+
       var tooltipTop = new Tooltip().set({
         content: {
           textContent: 'A tooltip'
@@ -273,7 +283,7 @@ describe('Tooltip', function() {
         delay: 0
       });
       helpers.target.appendChild(tooltipTop);
-    
+
       var tooltipBottom = new Tooltip().set({
         content: {
           textContent: 'Another tooltip'
@@ -283,40 +293,40 @@ describe('Tooltip', function() {
         delay: 0
       });
       helpers.target.appendChild(tooltipBottom);
-    
+
       expect(tooltipTop.open).to.equal(false, 'tooltipTop closed initially');
       expect(tooltipBottom.open).to.equal(false, 'tooltipBottom closed initially');
-  
+
       helpers.mouseEvent('mouseenter', target);
-      
-      expect(tooltipTop.open).to.equal(true, 'tooltipTop open after focusing on target');
-      expect(tooltipBottom.open).to.equal(true, 'tooltipBottom open after focusing on target');
+
+      expect(tooltipTop.open).to.equal(true, 'tooltipTop open after hovering on target');
+      expect(tooltipBottom.open).to.equal(true, 'tooltipBottom open after hovering on target');
     });
-  
+
     it('should not set the tabindex attribute on a target element which already has a tabindex attribute', function() {
       var target = helpers.overlay.createFloatingTarget();
       target.setAttribute('tabindex', 1);
-    
+
       var tooltip = new Tooltip().set({
         target: target,
         variant: 'success'
       });
       helpers.target.appendChild(tooltip);
-    
+
       expect(target.getAttribute('tabindex')).to.equal('1');
     });
-    
+
     it('should hide the tip if no target defined', function() {
       var tooltip = new Tooltip();
       helpers.target.appendChild(tooltip);
-      
+
       expect(tooltip.target).to.equal(null);
       expect(tooltip._elements.tip.hidden).to.be.true;
-  
+
       var target = helpers.overlay.createFloatingTarget();
       tooltip.target = target;
       tooltip.open = true;
-  
+
       expect(tooltip.target).to.equal(target);
       expect(tooltip._elements.tip.hidden).to.be.false;
     });


### PR DESCRIPTION
Tooltip to show it's content when focused with tab button.

## Description
Vent doesn't handle multiple events, I moved two events that were trying to register in one call to two calls.
This helped for tooltip to open, but as it's focused by default, it triggered focusout on the icon causing this tooltip to close. I turned off autofocus on open, since there are no interactable elements in the tooltip.

My PR deletes redundant spaces cluttering the PR, the interesting parts are here:

https://github.com/adobe/coral-spectrum/compare/issue/58?expand=1#diff-ef943d799f5de6765589327dc5a4f795R93
https://github.com/adobe/coral-spectrum/compare/issue/58?expand=1#diff-ef943d799f5de6765589327dc5a4f795R309
https://github.com/adobe/coral-spectrum/compare/issue/58?expand=1#diff-7afc3cb344f58628908dfa726733a423R56

## Related Issue
https://github.com/adobe/coral-spectrum/issues/58

## Motivation and Context
Tooltip is accessible from keyboard

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manual tests and automated test, also checked in examples
<!--- Include details of your testing environment, and the tests you ran to -->
Chrome  80.0.3987.163
Firefox 74.0
<!--- see how your change affects other areas of the code, etc. -->
Could potentially affect examples, checked and it does not.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
