### PR TITLE
[Accessibility] Making selectlist group items keyboard accessible

### DIFF
--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -220,27 +220,30 @@ class SelectList extends BaseComponent(HTMLElement) {
   }
   set _tabTarget(value) {
     this.__tabTarget = value;
-    
-    if(!this._groups){
-      // Set all but the current set _tabTarget to not be a tab target:
-      this.items.getAll().forEach((item) => {
-        item.setAttribute('tabindex', item === value ? 0 : -1);
-      });
-    }
-    else {
-      var groups=this._groups;
+    if (this._groups && this._groups.getAll().length > 0) {
+      // set first item or selected item to be tab target in each group
+      var groups = this._groups;
       groups.getAll().forEach((group) => {
-        var firstChild=group.firstElementChild;
-        firstChild.setAttribute('tabindex', 0);
-        for (let item in group.items.getAll().slice(1)) {
-            if (item === value) {
-              item.setAttribute('tabindex', 0);
+        if (group.items.getAll().length > 0) {
+          var firstChild = group.firstElementChild;
+          firstChild.setAttribute('tabindex', 0);
+          var items = group.items.getAll();
+          for (let i = 1; i < items.length; i++) {
+            if (items[i] === value) {
+              items[i].setAttribute('tabindex', 0);
               firstChild.setAttribute('tabindex', -1);
             }
             else {
-              item.setAttribute('tabindex', -1); 
+              items[i].setAttribute('tabindex', -1); 
             }
+          }
         }
+      });
+    }
+    else {
+      // Set all but the current set _tabTarget to not be a tab target:
+      this.items.getAll().forEach((item) => {
+        item.setAttribute('tabindex', item === value ? 0 : -1);
       });
     }
   }

--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -221,10 +221,28 @@ class SelectList extends BaseComponent(HTMLElement) {
   set _tabTarget(value) {
     this.__tabTarget = value;
     
-    // Set all but the current set _tabTarget to not be a tab target:
-    this.items.getAll().forEach((item) => {
-      item.setAttribute('tabindex', item === value ? 0 : -1);
-    });
+    if(!this._groups){
+      // Set all but the current set _tabTarget to not be a tab target:
+      this.items.getAll().forEach((item) => {
+        item.setAttribute('tabindex', item === value ? 0 : -1);
+      });
+    }
+    else {
+      var groups=this._groups;
+      groups.getAll().forEach((group) => {
+        var firstChild=group.firstElementChild;
+        firstChild.setAttribute('tabindex', 0);
+        for (let item in group.items.getAll().slice(1)) {
+            if (item === value) {
+              item.setAttribute('tabindex', 0);
+              firstChild.setAttribute('tabindex', -1);
+            }
+            else {
+              item.setAttribute('tabindex', -1); 
+            }
+        }
+      });
+    }
   }
   
   /** @private */

--- a/coral-component-list/src/tests/test.SelectList.js
+++ b/coral-component-list/src/tests/test.SelectList.js
@@ -423,4 +423,19 @@ describe('SelectList', function() {
     // @todo: focus on a hidden selected item
     // @todo: add a test for focus() and no children
   });
+
+  describe('Accessibility', function() {
+    it('should move focus between groups', function() {
+      const el = helpers.build(window.__html__['SelectList.groups.html']);
+      el.focus();
+
+      //switch the group to 2nd one
+      helpers.keypress('tab', document.activeElement);
+
+      // navigate inside group
+      helpers.keypress('down', document.activeElement);
+
+      expect(document.activeElement.value).to.equal('oc');
+    });
+  });
 });

--- a/coral-component-list/src/tests/test.SelectList.js
+++ b/coral-component-list/src/tests/test.SelectList.js
@@ -423,19 +423,4 @@ describe('SelectList', function() {
     // @todo: focus on a hidden selected item
     // @todo: add a test for focus() and no children
   });
-
-  describe('Accessibility', function() {
-    it('should move focus between groups', function() {
-      const el = helpers.build(window.__html__['SelectList.groups.html']);
-      el.focus();
-
-      //switch the group to 2nd one
-      helpers.keypress('tab', document.activeElement);
-
-      // navigate inside group
-      helpers.keypress('down', document.activeElement);
-
-      expect(document.activeElement.value).to.equal('oc');
-    });
-  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Select list group component does not allow using keyboard to move between different groups and items below them. This PR adds tabindex on first element of each group. This will allow user to access each group using only keyboard.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
