### PR TITLE
CQ-4292656 [Accessibility] Coral.Select include selected value and invalid icon in accessibility name

### DIFF
--- a/coral-component-select/examples/index.html
+++ b/coral-component-select/examples/index.html
@@ -39,6 +39,18 @@
         document.head.appendChild(script);
       });
     </script>
+    <script>
+      window.addEventListener('load', function() {
+        const selectElements = document.querySelectorAll('coral-select:not([labelledby])');
+        for (let i = 0; i < selectElements.length; i++) {
+          const header = selectElements[i].closest('.markup').previousElementSibling;
+          if (header) {
+            header.id = header.id || Coral.commons.getUID();
+            selectElements[i].setAttribute('labelledby', header.id);
+          }
+        }
+      });
+    </script>
   </head>
 
   <body class="coral--light">
@@ -466,6 +478,33 @@
           </coral-select>
         </form>
       </div>
+
+      <h2 class="coral--Heading--S">Select within Dialog</h2>
+      <div class="markup">
+        <button is="coral-button" onclick="document.getElementById('dialogId').show()">Open dialog</button>
+        <coral-dialog id="dialogId" aria-label="Browser">
+          <coral-dialog-header>Browser</coral-dialog-header>
+          <form class="coral-Form coral-Form--vertical">
+            <coral-dialog-content>
+              <section class="coral-Form-fieldset">
+                <div class="coral-Form-fieldwrapper">
+                  <label class="coral-Form-fieldlabel" id="browserLabel">Browser</label>
+                  <coral-select labelledby="browserLabel" icon="search" name="browser">
+                    <coral-select-item value="ch"><coral-icon alt="" icon="chrome"></coral-icon> Chrome</coral-select-item>
+                    <coral-select-item value="fi"><coral-icon alt="" icon="firefox"></coral-icon> Firefox</coral-select-item>
+                    <coral-select-item disabled value="ie"><coral-icon alt="" icon="internetExplorer"></coral-icon> Internet Explorer</coral-autocomplete-item>
+                    <coral-select-item value="op"><coral-icon alt="" icon="opera"></coral-icon> Opera</coral-select-item>
+                    <coral-select-item value="sa"><coral-icon alt="" icon="safari"></coral-icon> Safari</coral-select-item>
+                  </coral-select>
+                </div>
+              </section>
+            </coral-dialog-content>
+            <coral-dialog-footer>
+              <button is="coral-button" type="reset" coral-close>Cancel</button>
+              <button is="coral-button" type="button" variant="primary" coral-close>Done</button>
+            </coral-dialog-footer>
+          </form>
+        </coral-dialog>
     </main>
   </body>
 </html>

--- a/coral-component-select/src/scripts/Select.js
+++ b/coral-component-select/src/scripts/Select.js
@@ -527,6 +527,11 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     }
     else {
       this._elements.nativeSelect.removeAttribute('aria-labelledby');
+
+      // if the select is also labelled, make sure that aria-labelledby gets restored
+      if (this.labelled) {
+        this.labelled = this.labelled;
+      }
     }
     
     this._elements.taglist.labelledBy = this._labelledBy;

--- a/coral-component-select/src/scripts/Select.js
+++ b/coral-component-select/src/scripts/Select.js
@@ -107,6 +107,8 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       'click > ._coral-Dropdown-trigger': '_onButtonClick',
   
       'key:space > ._coral-Dropdown-trigger': '_onSpaceKey',
+      'key:enter > ._coral-Dropdown-trigger': '_onSpaceKey',
+      'key:return > ._coral-Dropdown-trigger': '_onSpaceKey',
       'key:down > ._coral-Dropdown-trigger': '_onSpaceKey'
     };
   
@@ -482,24 +484,52 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     this._elements.taglist.readOnly = this._readOnly || isDisabled;
     this._elements.taglist.disabled = this._readOnly || isDisabled;
   }
+
+  /**
+   Inherited from {@link BaseFormField#labelled}.
+   */
+  get labelled() {
+    return super.labelled;
+  }
+  set labelled(value) {
+    super.labelled = value;
+  
+    if (this.labelled) {
+      if (!this.labelledBy) {
+        this._elements.button.setAttribute('aria-labelledby', `${this._elements.button.id} ${this._elements.label.id} ${this.invalid ? this._elements.invalidIcon.id : ''}`);
+      }
+      this._elements.nativeSelect.setAttribute('aria-label', value);
+    }
+    else {
+      this._elements.button.removeAttribute('aria-label');
+      this._elements.nativeSelect.removeAttribute('aria-label');
+      if (!this.labelledBy) {
+        this._elements.button.removeAttribute('aria-labelledby');
+      }
+    }
+    
+    this._elements.taglist.labelled = value;
+  }
   
   /**
    Inherited from {@link BaseFormField#labelledBy}.
    */
   get labelledBy() {
-    return super.labelledBy;
+    return this._labelledBy;
   }
   set labelledBy(value) {
     super.labelledBy = value;
-  
-    if (this.labelledBy) {
-      this._elements.nativeSelect.setAttribute('aria-labelledby', this.labelledBy);
+    this._labelledBy = super.labelledBy;
+    
+    if (this._labelledBy) {
+      this._elements.button.setAttribute('aria-labelledby', `${this._labelledBy} ${this._elements.label.id} ${this.invalid ? this._elements.invalidIcon.id : ''}`);
+      this._elements.nativeSelect.setAttribute('aria-labelledby', this._labelledBy);
     }
     else {
       this._elements.nativeSelect.removeAttribute('aria-labelledby');
     }
     
-    this._elements.taglist.labelledBy = this.labelledBy;
+    this._elements.taglist.labelledBy = this._labelledBy;
   }
   
   /**
@@ -1033,6 +1063,9 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     this.trigger(`coral-select:_overlay${type}`);
     
     this._elements.button.classList.toggle('is-selected', event.target.open);
+
+    // communicate expanded state to assistive technology
+    this._elements.button.setAttribute('aria-expanded', event.target.open);
     
     if (!event.target.open) {
       this.classList.remove('is-openAbove', 'is-openBelow');

--- a/coral-component-select/src/templates/base.html
+++ b/coral-component-select/src/templates/base.html
@@ -2,7 +2,7 @@
   var buttonId = data.commons.getUID();
   var listId = data.commons.getUID();
 </js>
-<button tracking="off" variant="_custom" iconposition="right" handle="button" is="coral-button" aria-haspopup="listbox" id="{{buttonId}}" aria-controls="{{listId}}" aria-expanded="false" class="_coral-FieldButton _coral-Dropdown-trigger">
+<button tracking="off" variant="_custom" iconposition="right" handle="button" type="button" is="coral-button" aria-haspopup="listbox" id="{{buttonId}}" aria-controls="{{listId}}" aria-expanded="false" class="_coral-FieldButton _coral-Dropdown-trigger">
   <coral-button-label class="_coral-Dropdown-label" handle="label" id="{{data.commons.getUID()}}">&#x200b;</coral-button-label>
   <coral-icon icon="alert" hidden handle="invalidIcon" class="_coral-Dropdown-invalidIcon" alt="{{data.i18n.get('invalid')}}" id="{{data.commons.getUID()}}"></coral-icon>
 </button>

--- a/coral-component-select/src/templates/base.html
+++ b/coral-component-select/src/templates/base.html
@@ -2,9 +2,9 @@
   var buttonId = data.commons.getUID();
   var listId = data.commons.getUID();
 </js>
-<button tracking="off" variant="_custom" iconposition="right" handle="button" type="button" is="coral-button" aria-haspopup="listbox" id="{{buttonId}}" aria-controls="{{listId}}" aria-expanded="false" class="_coral-FieldButton _coral-Dropdown-trigger">
-  <coral-button-label class="_coral-Dropdown-label" handle="label">&#x200b;</coral-button-label>
-  <coral-icon icon="alert" hidden handle="invalidIcon" class="_coral-Dropdown-invalidIcon" alt="{{data.i18n.get('invalid')}}"></coral-icon>
+<button tracking="off" variant="_custom" iconposition="right" handle="button" is="coral-button" aria-haspopup="listbox" id="{{buttonId}}" aria-controls="{{listId}}" aria-expanded="false" class="_coral-FieldButton _coral-Dropdown-trigger">
+  <coral-button-label class="_coral-Dropdown-label" handle="label" id="{{data.commons.getUID()}}">&#x200b;</coral-button-label>
+  <coral-icon icon="alert" hidden handle="invalidIcon" class="_coral-Dropdown-invalidIcon" alt="{{data.i18n.get('invalid')}}" id="{{data.commons.getUID()}}"></coral-icon>
 </button>
 <js>
   // Don't wait for button MO to pick up the label

--- a/coral-component-select/src/tests/test.Select.js
+++ b/coral-component-select/src/tests/test.Select.js
@@ -324,12 +324,17 @@ describe('Select', function() {
   describe('API', function() {
     // the select list item used in every test
     var el;
+    var button;
+    var buttonLabel;
     var item1;
     var item2;
     var item3;
 
     beforeEach(function(done) {
       el = helpers.build(new Select());
+      button = el._elements.button;
+      buttonLabel = el._elements.label;
+
       // using a placeholder stops the component from finding an initial selection
       el.placeholder = 'Placeholder';
 
@@ -1017,7 +1022,66 @@ describe('Select', function() {
 
     describe('#readOnly', function() {});
 
-    describe('#labelledBy', function() {});
+    describe('#labelled', function() {
+      it('should update the aria-label of button', function() {
+        el.labelled = 'newlabel';
+
+        expect(button.getAttribute('aria-label')).to.equal('newlabel', 'button aria-label should have changed');
+      });
+
+      it('should update the aria-labelledBy of the button if there is none', function() {
+        el.labelled = 'newlabel';
+
+        expect(button.getAttribute('aria-label')).to.equal('newlabel', 'button aria-label should have changed');
+        expect(button.getAttribute('aria-labelledby').trim()).to.equal(`${button.id} ${buttonLabel.id}`, 'button aria-labelledby should include button itself and its label');
+
+        el.labelled = 'otherlabel';
+
+        expect(button.getAttribute('aria-label')).to.equal('otherlabel', 'button aria-label should have changed');
+        expect(button.getAttribute('aria-labelledby').trim()).to.equal(`${button.id} ${buttonLabel.id}`, 'button aria-labelledby should include button itself and its label');
+      });
+
+      it('should remove the aria-label of button if removed', function() {
+        el.labelled = 'newlabel';
+
+        expect(button.getAttribute('aria-label')).to.equal('newlabel');
+
+        el.labelled = '';
+        expect(button.getAttribute('aria-label')).to.equal(null, 'button aria-label should have been removed');
+        expect(button.getAttribute('aria-labelledby')).to.equal(null, 'button aria-labelledby should have been removed');
+      });
+    });
+
+    describe('#labelledBy', function() {
+      it('should not be present when creating a new element', function() {
+        expect(button.getAttribute('aria-labelledby')).to.be.null;
+      });
+
+      it('should update aria-labelledBy of included button element', function() {
+        el.labelledBy = 'newItemId';
+        expect(button.getAttribute('aria-labelledby').includes('newItemId')).to.be.true;
+        expect(button.getAttribute('aria-labelledby').includes(buttonLabel.id)).to.be.true;
+
+        el.labelledBy = '';
+        expect(button.getAttribute('aria-labelledby')).to.equal(null, 'button did not update aria-labelledby');
+      });
+
+      it('should take precedence over labelled', function() {
+        el.labelled = 'newlabel'
+        expect(button.getAttribute('aria-label')).to.equal('newlabel', 'button aria-label should have changed');
+        expect(button.getAttribute('aria-labelledby').trim()).to.equal(`${button.id} ${buttonLabel.id}`, 'button aria-labelledby should include button itself and its label');
+
+        el.labelledBy = 'newLabelId';
+        expect(button.getAttribute('aria-labelledby').trim()).to.equal(`newLabelId ${buttonLabel.id}`, 'button aria-labelledby should include external label id and its label');
+
+        el.labelled = 'newlabel2'
+        expect(button.getAttribute('aria-label')).to.equal('newlabel2', 'button aria-label should have changed');
+        expect(button.getAttribute('aria-labelledby').trim()).to.equal(`newLabelId ${buttonLabel.id}`, 'button aria-labelledby should still include external label id and its label');
+
+        el.labelledBy = '';
+        expect(button.getAttribute('aria-labelledby').trim()).to.equal(`${button.id} ${buttonLabel.id}`, 'button aria-labelledby should include button itself and its label');
+      });
+    });
 
     describe('#loading', function() {});
 


### PR DESCRIPTION
## Description

When setting labelledBy or labelled attribute on Coral.Select, the value or placeholder displayed as the button label, as well as the invalid icon, should be included in the accessibility name for the control.

## Related Issue

https://jira.corp.adobe.com/browse/CQ-4292656

## Motivation and Context

Labelling a Coral.Select control, fails to include the selected value as part of the accessibility name.

## How Has This Been Tested?
Tested use VoiceOver on macOS and NVDA on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
