### PR TITLE
CUI-7370 [Accessibility] Coral.Autocomplete: Use WAI-ARIA 1.2 Combobox design pattern

### DIFF
--- a/coral-component-autocomplete/examples/index.html
+++ b/coral-component-autocomplete/examples/index.html
@@ -241,6 +241,34 @@
           </coral-autocomplete>
         </form>
       </div>
+
+      <h2 class="coral--Heading--S">AutoComplete within Dialog</h2>
+      <div class="markup">
+        <button is="coral-button" onclick="document.getElementById('dialogId').show()">Open dialog</button>
+        <coral-dialog id="dialogId" aria-label="Browser">
+          <coral-dialog-header>Browser</coral-dialog-header>
+          <form class="coral-Form coral-Form--vertical">
+            <coral-dialog-content>
+              <section class="coral-Form-fieldset">
+                <div class="coral-Form-fieldwrapper">
+                  <label class="coral-Form-fieldlabel" id="browserLabel">Browser</label>
+                  <coral-autocomplete labelledby="browserLabel" icon="search" name="browser">
+                    <coral-autocomplete-item icon="chrome" value="ch">Chrome</coral-autocomplete-item>
+                    <coral-autocomplete-item icon="firefox" value="fi">Firefox</coral-autocomplete-item>
+                    <coral-autocomplete-item disabled icon="internetExplorer" value="ie">Internet Explorer</coral-autocomplete-item>
+                    <coral-autocomplete-item icon="opera" value="op">Opera</coral-autocomplete-item>
+                    <coral-autocomplete-item icon="safari" value="sa">Safari</coral-autocomplete-item>
+                  </coral-autocomplete>
+                </div>
+              </section>
+            </coral-dialog-content>
+            <coral-dialog-footer>
+              <button is="coral-button" type="reset" coral-close>Cancel</button>
+              <button is="coral-button" type="button" variant="primary" coral-close>Done</button>
+            </coral-dialog-footer>
+          </form>
+        </coral-dialog>
+      </div>
     </main>
   </body>
 </html>

--- a/coral-component-autocomplete/examples/index.html
+++ b/coral-component-autocomplete/examples/index.html
@@ -241,34 +241,6 @@
           </coral-autocomplete>
         </form>
       </div>
-
-      <h2 class="coral--Heading--S">AutoComplete within Dialog</h2>
-      <div class="markup">
-        <button is="coral-button" onclick="document.getElementById('dialogId').show()">Open dialog</button>
-        <coral-dialog id="dialogId" aria-label="Browser">
-          <coral-dialog-header>Browser</coral-dialog-header>
-          <form class="coral-Form coral-Form--vertical">
-            <coral-dialog-content>
-              <section class="coral-Form-fieldset">
-                <div class="coral-Form-fieldwrapper">
-                  <label class="coral-Form-fieldlabel" id="browserLabel">Browser</label>
-                  <coral-autocomplete labelledby="browserLabel" icon="search" name="browser">
-                    <coral-autocomplete-item icon="chrome" value="ch">Chrome</coral-autocomplete-item>
-                    <coral-autocomplete-item icon="firefox" value="fi">Firefox</coral-autocomplete-item>
-                    <coral-autocomplete-item disabled icon="internetExplorer" value="ie">Internet Explorer</coral-autocomplete-item>
-                    <coral-autocomplete-item icon="opera" value="op">Opera</coral-autocomplete-item>
-                    <coral-autocomplete-item icon="safari" value="sa">Safari</coral-autocomplete-item>
-                  </coral-autocomplete>
-                </div>
-              </section>
-            </coral-dialog-content>
-            <coral-dialog-footer>
-              <button is="coral-button" type="reset" coral-close>Cancel</button>
-              <button is="coral-button" type="button" variant="primary" coral-close>Done</button>
-            </coral-dialog-footer>
-          </form>
-        </coral-dialog>
-      </div>
     </main>
   </body>
 </html>

--- a/coral-component-autocomplete/src/scripts/Autocomplete.js
+++ b/coral-component-autocomplete/src/scripts/Autocomplete.js
@@ -134,6 +134,7 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
     
     // Interaction
     events[`global:key:shift+tab #${overlayId} [is="coral-buttonlist-item"]`] = '_handleListFocusShift';
+    events[`global:key:esc`] = '_handleListFocusShift';
   
     // Overlay
     events[`global:capture:coral-overlay:positioned #${overlayId}`] = '_onOverlayPositioned';
@@ -602,6 +603,7 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
     super.labelled = value;
 
     this[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-label', this.labelled);
+    this._elements.selectList[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-label', this.labelled);
     
     if (this.labelled && this.multiple) {
       this._elements.tagList.setAttribute('aria-label', this.labelled);
@@ -621,6 +623,7 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
     super.labelledBy = value;
 
     this[this.labelledBy ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.labelledBy);
+    this._elements.selectList[this.labelledBy ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.labelledBy);
     
     if (this.labelledBy && this.multiple) {
       this._elements.tagList.setAttribute('aria-labelledby', this.labelledBy);

--- a/coral-component-autocomplete/src/scripts/Autocomplete.js
+++ b/coral-component-autocomplete/src/scripts/Autocomplete.js
@@ -137,6 +137,8 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
   
     // Overlay
     events[`global:capture:coral-overlay:positioned #${overlayId}`] = '_onOverlayPositioned';
+    events[`global:capture:coral-overlay:open #${overlayId}`] = '_onOverlayOpenOrClose';
+    events[`global:capture:coral-overlay:close #${overlayId}`] = '_onOverlayOpenOrClose';
     
     // SelectList
     events[`global:key:enter #${overlayId} button[is="coral-buttonlist-item"]`] = '_handleSelect';
@@ -589,6 +591,25 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
     
     this._elements.input.required = this._required;
   }
+
+  /**
+   Inherited from {@link BaseFormField#labelled}.
+   */
+  get labelled() {
+    return super.labelled;
+  }
+  set labelled(value) {
+    super.labelled = value;
+
+    this[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-label', this.labelled);
+    
+    if (this.labelled && this.multiple) {
+      this._elements.tagList.setAttribute('aria-label', this.labelled);
+    }
+    else {
+      this._elements.tagList.removeAttribute('aria-label');
+    }
+  }
   
   /**
    Inherited from {@link BaseFormField#labelledBy}.
@@ -598,6 +619,8 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   set labelledBy(value) {
     super.labelledBy = value;
+
+    this[this.labelledBy ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.labelledBy);
     
     if (this.labelledBy && this.multiple) {
       this._elements.tagList.setAttribute('aria-labelledby', this.labelledBy);
@@ -1823,6 +1846,23 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   
   /**
+   Matches the accessibility to the state of the popover.
+   
+   @ignore
+   */
+  _onOverlayOpenOrClose(event) {
+    if (this._elements.overlay.open) {
+      this._elements.input.setAttribute('aria-expanded', 'true');
+      this._elements.trigger.setAttribute('aria-expanded', 'true');
+    }
+    else {
+      this._elements.input.setAttribute('aria-expanded', 'false');
+      this._elements.trigger.setAttribute('aria-expanded', 'false');
+      this._elements.input.removeAttribute('aria-activedescendant');
+    }
+  }
+  
+  /**
    Inherited from {@link BaseFormField#reset}.
    */
   reset() {
@@ -1885,17 +1925,17 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
     this.classList.add(CLASSNAME);
   
     // Container role per ARIA Autocomplete
-    this.setAttribute('role', 'presentation');
+    this.setAttribute('role', 'group');
   
     // Input attributes per ARIA Autocomplete
     this._elements.input.setAttribute('role', 'combobox');
     this._elements.input.setAttribute('aria-autocomplete', 'list');
-    this._elements.input.setAttribute('aria-haspopup', 'true');
+    this._elements.input.setAttribute('aria-haspopup', 'listbox');
     this._elements.input.setAttribute('aria-expanded', 'false');
     this._elements.input.setAttribute('aria-controls', this._elements.selectList.id);
   
     // Trigger button attributes per ARIA Autocomplete
-    this._elements.trigger.setAttribute('aria-haspopup', 'true');
+    this._elements.trigger.setAttribute('aria-haspopup', 'listbox');
     this._elements.trigger.setAttribute('aria-expanded', 'false');
     this._elements.trigger.setAttribute('aria-controls', this._elements.selectList.id);
   

--- a/coral-component-autocomplete/src/templates/base.html
+++ b/coral-component-autocomplete/src/templates/base.html
@@ -8,7 +8,7 @@
 </coral-popover>
 <input type="hidden" handle="field">
 <div class="_coral-InputGroup _coral-Autocomplete-inputGroup" handle="inputGroup" role="presentation">
-  <input class="_coral-InputGroup-field _coral-Autocomplete-input" type="text" autocomplete="off" handle="input" role="textbox" is="coral-textfield">
+  <input class="_coral-InputGroup-field _coral-Autocomplete-input" type="text" autocomplete="off" handle="input" role="combobox" is="coral-textfield" />
   <button type="button" class="_coral-FieldButton _coral-InputGroup-button _coral-Autocomplete-trigger" is="coral-button" variant="_custom" handle="trigger" aria-label="{{data.i18n.get('Show suggestions')}}" title="{{data.i18n.get('Show suggestions')}}">
     <coral-button-label handle="label"></coral-button-label>
     <js>


### PR DESCRIPTION
## Description
Refactor Coral.Autocomplete to implement WAI-ARIA 1.2 Combobox design pattern where the `input` has `role="combobox"` rather than the container.

## Related Issue
Per: https://jira.corp.adobe.com/browse/CQ-4292426
and https://jira.corp.adobe.com/browse/CUI-7370

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested with VoiceOver on macOS and NVDA on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
