### PR TITLE
CUI-7371 [Accessibility] Coral.Datepicker: Use WAI-ARIA 1.2 Combobox design pattern

### DIFF
--- a/coral-component-calendar/src/scripts/Calendar.js
+++ b/coral-component-calendar/src/scripts/Calendar.js
@@ -211,6 +211,7 @@ class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
       'key:ctrl+pagedown': '_onCtrlPageDownKey',
   
       'key:enter ._coral-Calendar-body': '_onEnterKey',
+      'key:return ._coral-Calendar-body': '_onEnterKey',
       'key:space ._coral-Calendar-body': '_onEnterKey'
     }));
     
@@ -587,6 +588,9 @@ class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
             }
           }
         }
+        else {
+          el = this._elements.body.querySelector('.is-focused') || this._elements.body.querySelector('.is-today');
+        }
         
         if (el) {
           this._activeDescendant = el.parentElement.id;
@@ -613,11 +617,8 @@ class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
     
     if (el) {
       if (isTransitioning) {
-        commons.transitionEnd(newTable, () => {
-          // Prevents from chopping off the transition animation
-          window.setTimeout(() => {
-            el.querySelector('._coral-Calendar-date').classList.add('is-focused');
-          }, 50);
+        window.requestAnimationFrame(() => {
+          el.querySelector('._coral-Calendar-date').classList.add('is-focused');
         });
       }
       else {
@@ -1026,7 +1027,7 @@ class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
     
     this.classList.add(CLASSNAME);
   
-    this.setAttribute('role', 'region');
+    this.setAttribute('role', 'group');
     
     // Default reflected attribute
     if (!this._valueFormat) { this.valueFormat = INTERNAL_FORMAT; }

--- a/coral-component-calendar/src/templates/calendar.html
+++ b/coral-component-calendar/src/templates/calendar.html
@@ -1,6 +1,6 @@
 <input handle="input" type="hidden" name="">
 <div handle="header" class="_coral-Calendar-header">
-  <div handle="heading" class="_coral-Calendar-title" role="heading" aria-live="assertive" aria-atomic="true" aria-level="2"></div>
+  <div handle="heading" class="_coral-Calendar-title" role="heading" aria-live="assertive" aria-atomic="true" aria-level="2" id="{{data.commons.getUID()}}"></div>
   <button type="button" handle="prev" class="_coral-Calendar-prevMonth" is="coral-button" variant="quietaction" aria-label="{{data.i18n.get('Previous Month')}}" title="{{data.i18n.get('Previous Month')}}">
     <coral-button-label handle="prevLabel"></coral-button-label>
   </button>
@@ -17,4 +17,4 @@
     this.next.insertAdjacentHTML('beforeend', data.Icon._renderSVG('spectrum-css-icon-ChevronRightLarge', ['_coral-UIIcon-ChevronRightLarge']));
   </js>
 </div>
-<div class="_coral-Calendar-body" handle="body" role="grid" tabindex="0" aria-readonly="true"></div>
+<div class="_coral-Calendar-body" handle="body" role="grid" tabindex="0" aria-readonly="true" aria-labelledby="{{this.heading.id}}"></div>

--- a/coral-component-datepicker/examples/index.html
+++ b/coral-component-datepicker/examples/index.html
@@ -159,6 +159,28 @@
           <coral-datepicker class="coral-Form-field" labelledby="label12"></coral-datepicker>
         </form>
       </div>
+
+      <h2 class="coral--Heading--S">Datepicker within Dialog</h2>
+      <div class="markup">
+        <button is="coral-button" onclick="document.getElementById('dialogId').show()">Open dialog</button>
+        <coral-dialog id="dialogId" aria-label="Date">
+          <coral-dialog-header>Date</coral-dialog-header>
+          <form class="coral-Form coral-Form--vertical">
+            <coral-dialog-content>
+              <section class="coral-Form-fieldset">
+                <div class="coral-Form-fieldwrapper">
+                  <label class="coral-Form-fieldlabel" id="dateLabel">Date</label>
+                  <coral-datepicker labelledby="dateLabel" value="2014-12-31" displayformat="MM-DD-YYYY"></coral-datepicker>
+                </div>
+              </section>
+            </coral-dialog-content>
+            <coral-dialog-footer>
+              <button is="coral-button" type="reset" coral-close>Cancel</button>
+              <button is="coral-button" type="button" variant="primary" coral-close>Done</button>
+            </coral-dialog-footer>
+          </form>
+        </coral-dialog>
+      </div>
     </main>
   </body>
 </html>

--- a/coral-component-datepicker/examples/index.html
+++ b/coral-component-datepicker/examples/index.html
@@ -159,28 +159,6 @@
           <coral-datepicker class="coral-Form-field" labelledby="label12"></coral-datepicker>
         </form>
       </div>
-
-      <h2 class="coral--Heading--S">Datepicker within Dialog</h2>
-      <div class="markup">
-        <button is="coral-button" onclick="document.getElementById('dialogId').show()">Open dialog</button>
-        <coral-dialog id="dialogId" aria-label="Date">
-          <coral-dialog-header>Date</coral-dialog-header>
-          <form class="coral-Form coral-Form--vertical">
-            <coral-dialog-content>
-              <section class="coral-Form-fieldset">
-                <div class="coral-Form-fieldwrapper">
-                  <label class="coral-Form-fieldlabel" id="dateLabel">Date</label>
-                  <coral-datepicker labelledby="dateLabel" value="2014-12-31" displayformat="MM-DD-YYYY"></coral-datepicker>
-                </div>
-              </section>
-            </coral-dialog-content>
-            <coral-dialog-footer>
-              <button is="coral-button" type="reset" coral-close>Cancel</button>
-              <button is="coral-button" type="button" variant="primary" coral-close>Done</button>
-            </coral-dialog-footer>
-          </form>
-        </coral-dialog>
-      </div>
     </main>
   </body>
 </html>

--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -526,9 +526,9 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
     super.labelled = value;
     
     // in case the user focuses the buttons, he will still get a notion of the usage of the component
-    this[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.labelled);
-    this._elements.overlay[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.labelled);
-    this._elements.calendar[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.labelled);
+    this[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-label', this.labelled);
+    this._elements.overlay[this.labelled ? 'setAttribute' : 'removeAttribute']('aria-label', this.labelled);
+    this._elements.calendar[this.labelled ? 'setAttribute' : 'removeAttribute']('labelled', this.labelled);
   }
   
   /**

--- a/coral-component-datepicker/src/templates/base.html
+++ b/coral-component-datepicker/src/templates/base.html
@@ -1,7 +1,7 @@
 <coral-popover tracking="off" smart class="_coral-Datepicker-overlay" handle="overlay" id="{{data.commons.getUID()}}" breadthoffset="50%r - 50%p" placement="bottom"></coral-popover>
 <input type="hidden" handle="hiddenInput">
 <input tracking="off" is="coral-textfield" type="text" handle="input" class="_coral-InputGroup-field" role="textbox">
-<button tracking="off" is="coral-button" variant="_custom" class="_coral-InputGroup-button _coral-FieldButton" type="button" handle="toggle" aria-haspopup="true" aria-label="{{data.i18n.get('Calendar')}}" title="{{data.i18n.get('Calendar')}}">
+<button tracking="off" is="coral-button" variant="_custom" class="_coral-InputGroup-button _coral-FieldButton" type="button" handle="toggle" aria-haspopup="dialog" aria-label="{{data.i18n.get('Calendar')}}" title="{{data.i18n.get('Calendar')}}">
   <coral-icon icon="calendar" iconsize="S" class="u-coral-noMargin" handle="icon"></coral-icon>
   <coral-button-label></coral-button-label>
 </button>

--- a/coral-component-datepicker/src/tests/test.Datepicker.js
+++ b/coral-component-datepicker/src/tests/test.Datepicker.js
@@ -166,6 +166,27 @@ describe('Datepicker', function() {
     
       describe('#invalid', function() {
       });
+
+      describe('#labelled', function() {
+        it('should label the input', function() {
+          el.labelled = 'newLabel';
+
+          expect(el._elements.input.getAttribute('aria-label')).to.equal('newLabel');
+          expect(el._elements.hiddenInput.hasAttribute('aria-label')).to.be.false;
+            
+          expect(el.getAttribute('role')).to.equal('group', 'coral-datepicker wrapping element should have role of group');
+          expect(el.getAttribute('aria-label')).to.equal('newLabel', 'coral-datepicker wrapping element should also be labelled to provide context when focus moves to Calendar button');
+          expect(el._elements.overlay.getAttribute('aria-label')).to.equal('newLabel');
+          expect(el._elements.calendar.getAttribute('aria-label')).to.equal('newLabel');
+
+          el.labelled = '';
+          
+          expect(el._elements.input.hasAttribute('aria-label')).to.be.false;
+          expect(el._elements.hiddenInput.hasAttribute('aria-label')).to.be.false;
+          expect(el._elements.overlay.hasAttribute('aria-label'), 'aria-label should be removed').to.be.false;
+          expect(el._elements.calendar.hasAttribute('aria-label'), 'aria-label should be removed').to.be.false;
+        });
+      });
     
       describe('#labelledBy', function() {
         it('should label the input', function() {
@@ -182,9 +203,12 @@ describe('Datepicker', function() {
           expect(el._elements.input.getAttribute('aria-labelledby')).to.equal(label1.id);
           expect(el._elements.toggle.hasAttribute('aria-labelledby')).to.be.false;
           expect(el._elements.hiddenInput.hasAttribute('aria-labelledby')).to.be.false;
-        
-          expect(el.getAttribute('aria-labelledby')).to.equal(label1.id);
-        
+          
+          expect(el.getAttribute('role')).to.equal('group', 'coral-datepicker wrapping element should have role of group');
+          expect(el.getAttribute('aria-labelledby')).to.equal(label1.id, 'coral-datepicker wrapping element should also be labelled to provide context when focus moves to Calendar button');
+          expect(el._elements.overlay.getAttribute('aria-labelledby')).to.equal(label1.id);
+          expect(el._elements.calendar.getAttribute('aria-labelledby')).to.equal(label1.id);
+
           el.labelledBy = '';
         
           expect(el.labelledBy).to.be.null;
@@ -192,7 +216,9 @@ describe('Datepicker', function() {
           expect(el._elements.input.hasAttribute('aria-labelledby')).to.be.false;
           expect(el._elements.toggle.hasAttribute('aria-labelledby')).to.be.false;
           expect(el._elements.hiddenInput.hasAttribute('aria-labelledby')).to.be.false;
-          expect(el.hasAttribute('aria-labelledby'), 'aria should be removed').to.be.false;
+          expect(el.hasAttribute('aria-labelledby'), 'aria-labelledby should be removed').to.be.false;
+          expect(el._elements.overlay.hasAttribute('aria-labelledby')).to.be.false;
+          expect(el._elements.calendar.hasAttribute('aria-labelledby')).to.be.false;
         });
       });
     
@@ -879,6 +905,22 @@ describe('Datepicker', function() {
     });
   
     describe('Implementation details', function() {
+      describe('Accessibility', function() {
+        it('should implement combobox design pattern per WAI-ARIA 1.2', function() {
+          var el = new Datepicker();
+          el._renderCalendar();
+          helpers.target.appendChild(el);
+
+          expect(el.getAttribute('role')).to.equal('group');
+          expect(el._elements.input.getAttribute('role')).to.equal('combobox');
+          expect(el._elements.input.getAttribute('aria-haspopup')).to.equal('dialog');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.toggle.getAttribute('aria-haspopup')).to.equal('dialog');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.input.getAttribute('aria-controls')).to.equal(el._elements.overlay.id);
+        });
+      });
+
       it('should show different controls depending on the type', function(done) {
         var el = new Datepicker();
         el._renderCalendar();
@@ -980,7 +1022,8 @@ describe('Datepicker', function() {
 
         el.on('coral-overlay:open', function() {
           expect(el._elements.input.getAttribute('aria-expanded')).to.equal('true');
-          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('true');        });
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('true');
+        });
         
         el.on('coral-overlay:close', function() {
           expect(el._elements.input.getAttribute('aria-expanded')).to.equal('false');

--- a/coral-component-datepicker/src/tests/test.Datepicker.js
+++ b/coral-component-datepicker/src/tests/test.Datepicker.js
@@ -807,8 +807,8 @@ describe('Datepicker', function() {
 
         // Overlay does not open immediately any longer
         el.on('coral-overlay:open', function() {
-          expect(el.getAttribute('aria-expanded')).to.equal('true');
-
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('true');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('true');
           done();
         });
       
@@ -856,7 +856,8 @@ describe('Datepicker', function() {
           // hours input should have focus when popover opens
           expect(document.activeElement).to.equal(el._elements.clock._elements.hours);
 
-          expect(el.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('true');
+          expect(el._elements.trigger.getAttribute('aria-expanded')).to.equal('true');
         
           // trigger ESC key down event on hours input
           helpers.keydown(Keys.keyToCode('esc'), el._elements.clock._elements.hours);
@@ -866,7 +867,8 @@ describe('Datepicker', function() {
           // focus should return to toggle button
           expect(document.activeElement).to.equal(el._elements.toggle);
 
-          expect(el.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('false');
 
           done();
         });
@@ -912,11 +914,13 @@ describe('Datepicker', function() {
         const el = helpers.build(window.__html__['Datepicker.value.html']);
 
         el.on('coral-overlay:open', function() {
-          expect(el.getAttribute('aria-expanded')).to.equal('true');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('true');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('true');
         });
         
         el.on('coral-overlay:close', function() {
-          expect(el.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('false');
 
           done();
         });
@@ -942,11 +946,13 @@ describe('Datepicker', function() {
         const el = helpers.build(window.__html__['Datepicker.value.html']);
 
         el.on('coral-overlay:open', function() {
-          expect(el.getAttribute('aria-expanded')).to.equal('true');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('true');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('true');
         });
         
         el.on('coral-overlay:close', function() {
-          expect(el.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('false');
 
           done();
         });
@@ -973,11 +979,12 @@ describe('Datepicker', function() {
         const el = helpers.build(window.__html__['Datepicker.value.html']);
 
         el.on('coral-overlay:open', function() {
-          expect(el.getAttribute('aria-expanded')).to.equal('true');
-        });
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('true');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('true');        });
         
         el.on('coral-overlay:close', function() {
-          expect(el.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.input.getAttribute('aria-expanded')).to.equal('false');
+          expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('false');
 
           done();
         });

--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -482,9 +482,10 @@ class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
   }
   
   /** @ignore */
-  _handleEscape() {
+  _handleEscape(event) {
     // When escape is pressed, hide ourselves
     if (this.interaction === interaction.ON && this.open && this._isTopOverlay()) {
+      event.stopPropagation();
       this.open = false;
     }
   }

--- a/coral-component-overlay/src/scripts/Overlay.js
+++ b/coral-component-overlay/src/scripts/Overlay.js
@@ -510,8 +510,9 @@ class Overlay extends BaseOverlay(BaseComponent(HTMLElement)) {
    
    @ignore
    */
-  _handleEscape() {
+  _handleEscape(event) {
     if (this.interaction === interaction.ON && this.open && this._isTopOverlay()) {
+      event.stopPropagation();
       this.hide();
     }
   }

--- a/coral-component-toast/src/scripts/Toast.js
+++ b/coral-component-toast/src/scripts/Toast.js
@@ -414,8 +414,9 @@ class Toast extends BaseOverlay(BaseComponent(HTMLElement)) {
     }
   }
   
-  _onEscape() {
-    if (this.open && this.classList.contains('is-open')) {
+  _onEscape(event) {
+    if (this.open && this.classList.contains('is-open') && this._isTopOverlay()) {
+      event.stopPropagation();
       this.open = false;
     }
   }


### PR DESCRIPTION
## Description
Refactor Coral.Datepicker to implement WAI-ARIA 1.2 Combobox design pattern, where the `input` has `role="combobox"`, rather than the container element.

This PR also includes a fixes to Calendar for to the use case where no value is specified, so that the Calendar table grid is navigable using the keyboard.

## Related Issue
Per https://jira.corp.adobe.com/browse/CQ-4292426
and https://jira.corp.adobe.com/browse/CUI-7371

## Motivation and Context
Fixes an issue where NVDA get stuck in forms mode and the user is unable to navigate from the input to the dropdown button using the down arrow in browse mode.

## How Has This Been Tested?
Tested with VoiceOver on macOS and NVDA on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
