### PR TITLE
CUI-7373 [Accessibility] Coral.ColorInput: Use WAI-ARIA 1.2 Combobox design pattern

### DIFF
--- a/coral-component-colorinput/src/scripts/ColorInput.js
+++ b/coral-component-colorinput/src/scripts/ColorInput.js
@@ -142,6 +142,7 @@ class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
     // Overlay
     events[`global:capture:coral-overlay:beforeopen #${overlayId}`] = '_beforeOverlayOpen';
     events[`global:capture:coral-overlay:close #${overlayId}`] = '_onOverlayClose';
+    events[`global:key:esc #${overlayId}`] = '_onKeyEsc';
     
     // Events
     this._delegateEvents(events);
@@ -619,10 +620,12 @@ class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   
   /** @ignore */
-  _onKeyEsc() {
+  _onKeyEsc(event) {
     if (!this._elements.overlay.open) {
       return;
     }
+
+    event.stopPropagation();
     
     this._elements.overlay.open = false;
   }

--- a/coral-component-colorinput/src/scripts/ColorInput.js
+++ b/coral-component-colorinput/src/scripts/ColorInput.js
@@ -474,7 +474,6 @@ class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
     this._required = transform.booleanAttr(value);
     this._reflectAttribute('required', this._required);
     
-    this.setAttribute('aria-required', this._required);
     this._elements.input.required = this._required;
   }
   
@@ -641,12 +640,14 @@ class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
     }
     
     // set aria-expanded state
+    this._elements.input.setAttribute('aria-expanded', true);
     this._elements.colorPreview.setAttribute('aria-expanded', true);
   }
   
   /** @ignore */
   _onOverlayClose() {
     // set aria-expanded state
+    this._elements.input.setAttribute('aria-expanded', true);
     this._elements.colorPreview.setAttribute('aria-expanded', false);
   }
   
@@ -886,8 +887,7 @@ class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
   
     this.classList.add(CLASSNAME);
   
-    this.setAttribute('role', 'combobox');
-    this.setAttribute('aria-expanded', false);
+    this.setAttribute('role', 'group');
     
     const frag = document.createDocumentFragment();
     

--- a/coral-component-colorinput/src/scripts/ColorInputSwatch.js
+++ b/coral-component-colorinput/src/scripts/ColorInputSwatch.js
@@ -58,7 +58,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
       this._reflectAttribute('selected', this.disabled ? false : this._selected);
       
       this.classList.toggle('is-selected', this._selected);
-      this.setAttribute('aria-selected', this._selected);
+      this._elements.colorButton.setAttribute('aria-selected', this._selected);
   
       this._elements.colorButton[this._selected ? 'setAttribute' : 'removeAttribute']('aria-label',
         `${i18n.get('checked')} ${this._elements.colorButton.label.textContent}`);
@@ -100,12 +100,12 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
     if (cssColorValue) {
       this._elements.colorButton.style.backgroundColor = cssColorValue;
       this._elements.colorButton.label.textContent = hexColorValue;
-      this.setAttribute('aria-value', hexColorValue);
+      this.setAttribute('data-value', hexColorValue);
     }
     else {
       this._elements.colorButton.classList.add('_coral-ColorInput-swatch-novalue');
       this._elements.colorButton.label.textContent = i18n.get('unset');
-      this.setAttribute('aria-value', '');
+      this.setAttribute('data-value', '');
     }
   }
 
@@ -126,11 +126,14 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   }
 
   /**
-   The tabindex of the color preview.
+   The tabindex of the color preview button. 
+   So that we don't wind up with nested focusable elements,
+   the internal colorButton should should receive the tabIndex property, 
+   while the coral-colorinput-swatch should reflect the value using the _tabindex attribute.
    
    @type {Integer}
    @default 0
-   @htmlattribute tabindex
+   @htmlattribute _tabindex
    @htmlattributereflected
    */
   get tabIndex() {
@@ -138,7 +141,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   }
   set tabIndex(value) {
     this._elements.colorButton.tabIndex = value;
-    this._reflectAttribute('tabindex', this.tabIndex);
+    this._reflectAttribute('_tabindex', this.tabIndex);
   }
   
   /** @ignore */
@@ -151,7 +154,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
-      tabindex: 'tabIndex',
+      _tabindex: 'tabIndex',
       targetcolor: 'targetColor'
     });
   }
@@ -160,7 +163,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   static get observedAttributes() {
     return super.observedAttributes.concat([
       'selected',
-      'tabindex',
+      '_tabindex',
       'disabled',
       'targetcolor'
     ]);
@@ -173,7 +176,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
     this.classList.add(CLASSNAME, 'u-coral-clearFix');
     
     // adds the role to support accessibility
-    this.setAttribute('role', 'option');
+    this.setAttribute('role', 'presentation');
     
     // Support cloneNode
     const button = this.querySelector('[handle="colorButton"]');

--- a/coral-component-colorinput/src/scripts/ColorInputSwatch.js
+++ b/coral-component-colorinput/src/scripts/ColorInputSwatch.js
@@ -167,7 +167,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   static get observedAttributes() {
     return super.observedAttributes.concat([
       'selected',
-      'tabIndex',
+      'tabindex',
       'disabled',
       'targetcolor'
     ]);

--- a/coral-component-colorinput/src/scripts/ColorInputSwatch.js
+++ b/coral-component-colorinput/src/scripts/ColorInputSwatch.js
@@ -56,9 +56,13 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
     if (!value || value && !this.disabled) {
       this._selected = value;
       this._reflectAttribute('selected', this.disabled ? false : this._selected);
+      this.removeAttribute('aria-selected', this._selected);
       
       this.classList.toggle('is-selected', this._selected);
       this._elements.colorButton.setAttribute('aria-selected', this._selected);
+
+      this._elements.colorButton.tabIndex = this.tabIndex;
+      this.removeAttribute('tabindex');
   
       this._elements.colorButton[this._selected ? 'setAttribute' : 'removeAttribute']('aria-label',
         `${i18n.get('checked')} ${this._elements.colorButton.label.textContent}`);
@@ -132,8 +136,8 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
    while the coral-colorinput-swatch should reflect the value using the _tabindex attribute.
    
    @type {Integer}
-   @default 0
-   @htmlattribute _tabindex
+   @default -1
+   @htmlattribute tabindex
    @htmlattributereflected
    */
   get tabIndex() {
@@ -141,7 +145,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   }
   set tabIndex(value) {
     this._elements.colorButton.tabIndex = value;
-    this._reflectAttribute('_tabindex', this.tabIndex);
+    this.removeAttribute('tabindex');
   }
   
   /** @ignore */
@@ -154,7 +158,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
-      _tabindex: 'tabIndex',
+      tabindex: 'tabIndex',
       targetcolor: 'targetColor'
     });
   }
@@ -163,7 +167,7 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
   static get observedAttributes() {
     return super.observedAttributes.concat([
       'selected',
-      '_tabindex',
+      'tabIndex',
       'disabled',
       'targetcolor'
     ]);

--- a/coral-component-colorinput/src/scripts/ColorInputSwatches.js
+++ b/coral-component-colorinput/src/scripts/ColorInputSwatches.js
@@ -195,12 +195,10 @@ class ColorInputSwatches extends BaseColorInputAbstractSubview(BaseComponent(HTM
       swatch.targetColor = color;
       
       if (color.selected) {
-        swatch.selected = color.selected;
+        swatch[color.selected ? 'setAttribute' : 'removeAttribute']('selected', color.selected);
         swatchSelected = true;
       }
-      
-      swatch.setAttribute('aria-selected', swatch.selected);
-      
+            
       // Update color button tabindex depending on selected state
       swatch.tabIndex = swatch.selected ? 0 : -1;
     }
@@ -306,6 +304,9 @@ class ColorInputSwatches extends BaseColorInputAbstractSubview(BaseComponent(HTM
     }
     
     event.matchedTarget.tabIndex = 0;
+    if (document.activeElement !== event.matchedTarget.firstChild) {
+      event.matchedTarget.firstChild.focus();
+    }
   }
   
   /** @ignore */

--- a/coral-component-colorinput/src/templates/base.html
+++ b/coral-component-colorinput/src/templates/base.html
@@ -18,14 +18,14 @@
   <coral-colorinput-item value="#DDDDDD"></coral-colorinput-item>
 </div>
 <js>var uid = data.commons.getUID();</js>
-<input handle="input" is="coral-textfield" class="_coral-ColorInput-input" type="text" value="">
+<input handle="input" is="coral-textfield" class="_coral-ColorInput-input" type="text" value="" role="combobox" aria-autocomplete="none" aria-haspopup="dialog" aria-expanded="false" aria-controls="{{uid}}" />
 <div class="_coral-ColorInput-buttonWrapper" handle="buttonWrapper" role="presentation">
-  <button handle="colorPreview" is="coral-button" variant="_custom" class="_coral-FieldButton _coral-ColorInput-button _coral-ColorInput-preview" type="button" aria-haspopup="true" aria-expanded="false" aria-controls="{{uid}}"></button>
+  <button handle="colorPreview" is="coral-button" variant="_custom" class="_coral-FieldButton _coral-ColorInput-button _coral-ColorInput-preview" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="{{uid}}"></button>
   <js>
     // Since we don't have a mutation observer anymore to replace content zones magically, we have to do it manually.
     this.colorPreview.label.classList.add('u-coral-screenReaderOnly');
     this.colorPreview.label.innerText = data.i18n.get('Color Picker');
-    this.id = uid + '-coral-button-label';
+    this.colorPreview.label.id = uid + '-coral-button-label';
   </js>
 </div>
 <coral-popover smart class="_coral-ColorInput-overlay" role="dialog" focusonshow="on" trapfocus="on" handle="overlay" breadthoffset="50%r - 50%p" placement="bottom" id="{{uid}}" aria-label="{{data.i18n.get('Color Picker')}}">

--- a/coral-component-colorinput/src/templates/colorButton.html
+++ b/coral-component-colorinput/src/templates/colorButton.html
@@ -1,2 +1,2 @@
-<button is="coral-button" variant="action" handle="colorButton" icon="checkmark" type="button" role="presentation"></button>
+<button is="coral-button" variant="action" handle="colorButton" icon="checkmark" type="button" role="option"></button>
 <js>this.colorButton.label.classList.add('u-coral-screenReaderOnly');</js>

--- a/coral-component-colorinput/src/templates/colorProperties.html
+++ b/coral-component-colorinput/src/templates/colorProperties.html
@@ -13,23 +13,23 @@
   </div>
   <div class="_coral-ColorInput-rgbaView _coral-ColorInput-editRgba" role="presentation">
     <div role="group" class="_coral-ColorInput-editRgba-group">
-      <label class="_coral-ColorInput-editRgba-group-label" for="{{uid}}-r">{{data.i18n.get('R')}}</label>
-      <coral-colorinput-slider handle="redSlider" min="0" max="255" value="0" gradient="#000000 #FF0000"></coral-colorinput-slider>
+      <label class="_coral-ColorInput-editRgba-group-label" id="{{uid}}-r-label" for="{{uid}}-r">{{data.i18n.get('R')}}</label>
+      <coral-colorinput-slider handle="redSlider" min="0" max="255" value="0" gradient="#000000 #FF0000" labelledby="{{uid}}-r-label"></coral-colorinput-slider>
       <input class="_coral-ColorInput-editRgba-group-input" id="{{uid}}-r" handle="redInput" is="coral-textfield" type="number" placeholder="{{data.i18n.get('R')}}" maxlength="3" value="" variant="quiet">
     </div>
     <div role="group" class="_coral-ColorInput-editRgba-group">
-      <label class="_coral-ColorInput-editRgba-group-label" for="{{uid}}-g">{{data.i18n.get('G')}}</label>
-      <coral-colorinput-slider handle="greenSlider" min="0" max="255" value="0" gradient="#000000 #00FF00"></coral-colorinput-slider>
+      <label class="_coral-ColorInput-editRgba-group-label" id="{{uid}}-g-label" for="{{uid}}-g">{{data.i18n.get('G')}}</label>
+      <coral-colorinput-slider handle="greenSlider" min="0" max="255" value="0" gradient="#000000 #00FF00" labelledby="{{uid}}-g-label"></coral-colorinput-slider>
       <input class="_coral-ColorInput-editRgba-group-input" id="{{uid}}-g" handle="greenInput" is="coral-textfield" type="number" class="_coral-ColorInput-editRgb" placeholder="{{data.i18n.get('G')}}" maxlength="3" value="" variant="quiet">
     </div>
     <div role="group" class="_coral-ColorInput-editRgba-group">
-      <label class="_coral-ColorInput-editRgba-group-label" for="{{uid}}-b">{{data.i18n.get('B')}}</label>
-      <coral-colorinput-slider handle="blueSlider" min="0" max="255" value="0" gradient="#000000 #0000FF"></coral-colorinput-slider>
+      <label class="_coral-ColorInput-editRgba-group-label" id="{{uid}}-b-label" for="{{uid}}-b">{{data.i18n.get('B')}}</label>
+      <coral-colorinput-slider handle="blueSlider" min="0" max="255" value="0" gradient="#000000 #0000FF" labelledby="{{uid}}-b-label"></coral-colorinput-slider>
       <input class="_coral-ColorInput-editRgba-group-input" id="{{uid}}-b" handle="blueInput" is="coral-textfield" type="number" placeholder="{{data.i18n.get('B')}}" maxlength="3" value="" variant="quiet">
     </div>
     <div role="group" class="_coral-ColorInput-editRgba-group">
-      <label class="_coral-ColorInput-editRgba-group-label" for="{{uid}}-a">{{data.i18n.get('A')}}</label>
-      <coral-colorinput-slider handle="alphaSlider" min="0" max="100" value="100" gradient="rgba(255,255,255,0) rgba(255,255,255,1)"></coral-colorinput-slider>
+      <label class="_coral-ColorInput-editRgba-group-label" id="{{uid}}-a-label" for="{{uid}}-a">{{data.i18n.get('A')}}</label>
+      <coral-colorinput-slider handle="alphaSlider" min="0" max="100" value="100" gradient="rgba(255,255,255,0) rgba(255,255,255,1)" labelledby="{{uid}}-a-label"></coral-colorinput-slider>
       <input class="_coral-ColorInput-editRgba-group-input" id="{{uid}}-a" handle="alphaInput" is="coral-textfield" type="number" placeholder="{{data.i18n.get('A')}}" maxlength="3" value="" variant="quiet">
     </div>
   </div>

--- a/coral-component-colorinput/src/templates/swatchesHeader.html
+++ b/coral-component-colorinput/src/templates/swatchesHeader.html
@@ -3,7 +3,7 @@
     <span handle="swatchesHeaderTitle" id="{{data.commons.getUID()}}" role="heading" aria-level="2">
       {{data.i18n.get('Swatches')}}</span>
   </div>
-  <div class="_coral-ColorInput-swatches-container" role="presentation" aria-labelledby="{{data.commons.getUID()}}">
+  <div class="_coral-ColorInput-swatches-container" role="presentation">
     <div handle="swatchesContainer" role="presentation"></div>
   </div>
 </div>

--- a/coral-component-colorinput/src/tests/test.ColorInput.js
+++ b/coral-component-colorinput/src/tests/test.ColorInput.js
@@ -496,7 +496,8 @@ describe('ColorInput', function() {
 
     it('should have the right role set', function() {
       const el = helpers.build(window.__html__['ColorInput.base.html']);
-      expect(el.getAttribute('role')).to.equal('combobox');
+      expect(el.getAttribute('role')).to.equal('group');
+      expect(el._elements.input.getAttribute('role')).to.equal('combobox');
     });
 
     it('should generate a swatches subview for the colorinput', function() {

--- a/coral-component-slider/src/scripts/Slider.js
+++ b/coral-component-slider/src/scripts/Slider.js
@@ -789,8 +789,10 @@ class Slider extends BaseFormField(BaseComponent(HTMLElement)) {
    @private
    */
   _mouseUp() {
-    this._currentHandle.style.cursor = 'grab';
-    this._currentHandle.classList.remove('is-dragged');
+    if (this._currentHandle) {
+      this._currentHandle.style.cursor = 'grab';
+      this._currentHandle.classList.remove('is-dragged');
+    }
     document.body.classList.remove('u-coral-closedHand');
     
     events.off('mousemove.Slider', this._draggingHandler);


### PR DESCRIPTION
## Description
Refactor Coral.ColorInput to implement WAI-ARIA 1.2 Combobox design pattern where the `input` has `role="combobox"` rather than the container.

Note that this PR also includes several relevant fixes for labelling of color slider controls, and navigating the swatches listbox using the keyboard within the ColorInput dialog.

## Related Issue
Per: https://jira.corp.adobe.com/browse/CQ-4292426
and https://jira.corp.adobe.com/browse/CUI-7373

## Motivation and Context
Fixes an issue where NVDA get stuck in forms mode and the user is unable to navigate from the input to the dropdown button using the down arrow in browse mode.

## How Has This Been Tested?
Tested with VoiceOver on macOS and NVDA on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
