### PR TITLE
Adseth CQ-4273031:Updating attributes in underlined elements in readOnly mode for select and datepicker.

### DIFF
--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -24,9 +24,9 @@ import {transform, commons, validate, i18n} from '../../../coral-utils';
 
 /**
  Enum for {@link Datepicker} variant values.
- 
+
  @typedef {Object} DatepickerVariantEnum
- 
+
  @property {String} DEFAULT
  A default, gray Datepicker.
  @property {String} QUIET
@@ -54,7 +54,7 @@ function toMoment(value, format) {
   else if (DateTime.Moment.isMoment(value)) {
     return value.isValid() ? value.clone() : null;
   }
-  
+
   // if the value provided is a date it does not make sense to provide a format to parse the date
   const result = new DateTime.Moment(value, value instanceof Date ? null : format);
   return result.isValid() ? result : null;
@@ -62,9 +62,9 @@ function toMoment(value, format) {
 
 /**
  Enumeration for {@link Datepicker} variants.
- 
+
  @typedef {Object} DatepickerTypeEnum
- 
+
  @property {String} DATE
  The selection overlay contains only a calendar.
  @property {String} DATETIME
@@ -110,16 +110,16 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
-  
+
     // Prepare templates
     this._elements = {};
     base.call(this._elements, {commons, i18n});
     // Creates and stores the contents of the popover separately
     this._calendarFragment = overlayContent.call(this._elements, {commons, i18n});
-  
+
     // Pre-define labellable element
     this._labellableElement = this._elements.input;
-  
+
     const overlayId = this._elements.overlay.id;
     const events = {};
     events[`global:capture:click #${overlayId} coral-calendar`] = '_onCalendarDayClick';
@@ -130,24 +130,24 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
     events['key:alt+down [handle="input"],[handle="toggle"]'] = '_onAltDownKey';
     events['key:down [handle="toggle"]'] = '_onAltDownKey';
     events['change coral-datepicker > input[is="coral-textfield"]'] = '_onInputChange';
-    
+
     // Events
     this._delegateEvents(commons.extend(this._events, events));
   }
-  
+
   /**
    Returns the inner overlay to allow customization.
-   
+
    @type {Popover}
    @readonly
    */
   get overlay() {
     return this._elements.overlay;
   }
-  
+
   /**
    The type of datepicker to show to the user. See {@link DatepickerTypeEnum}.
-   
+
    @type {DatepickerTypeEnum}
    @default DatepickerTypeEnum.DATE
    @htmlattribute type
@@ -159,36 +159,36 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set type(value) {
     // Flag to indicate that we are changing the type for the first time
     this._typeFormatChanged = typeof this._type === 'undefined';
-    
+
     value = transform.string(value).toLowerCase();
     this._type = validate.enumeration(type)(value) && value || type.DATE;
     this._reflectAttribute('type', this._type);
-  
+
     const format = NATIVE_FORMATS[this._type];
     const isTime = this._type === type.TIME;
     const isDate = this._type === type.DATE;
-  
+
     this._elements.icon.icon = isTime ? 'clock' : 'calendar';
-  
+
     const toggleLabel = isTime ? i18n.get('Time') : i18n.get('Calendar');
     this._elements.toggle.setAttribute('aria-label', toggleLabel);
     this._elements.toggle.setAttribute('title', toggleLabel);
-  
+
     this._elements.clock.hidden = isDate;
     this._elements.clock.setAttribute('aria-hidden', isDate);
-  
+
     this._elements.calendar.hidden = isTime;
     this._elements.calendar.setAttribute('aria-hidden', isTime);
-    
+
     // Change format if we have a native format set
     if (isNativeFormat(this.valueFormat)) { this.valueFormat = format; }
     if (isNativeFormat(this.displayFormat)) { this.displayFormat = format; }
-    
+
     this._useNativeInput = this._useNativeInput;
-  
+
     this._typeFormatChanged = false;
   }
-  
+
   /**
    The format used to display the selected date(time) to the user. If the user manually types a date, this format
    will be used to parse the value. When using this component on a mobile device, the display format must follow
@@ -196,7 +196,7 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
    be used. The default value depends on the <code>type</code>, which can be one from <code>YYYY-MM-DD</code>,
    <code>YYYY-MM-DD[T]HH:mmZ</code> or <code>HH:mm</code>.  Include momentjs to support additional format string options
    see http://momentjs.com/docs/#/displaying/.
-   
+
    @type {String}
    @default "YYYY-MM-DD"
    @htmlattribute displayformat
@@ -207,32 +207,32 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
     if (this._useNativeInput && this.type !== type.DATETIME) {
       return NATIVE_FORMATS[this.type];
     }
-    
+
     return typeof this._displayFormat === 'undefined' ? NATIVE_FORMATS[this.type] : this._displayFormat;
   }
   set displayFormat(value) {
     value = transform.string(value).trim();
-  
+
     // In case a custom display format was set, we make sure that type doesn't change it to a native format
     const displayFormatAttribute = this.getAttribute('displayformat');
     if (this._typeFormatChanged && displayFormatAttribute && displayFormatAttribute !== value) {
       value = displayFormatAttribute;
     }
-    
+
     this._displayFormat = value === '' ? NATIVE_FORMATS[this.type] : value;
     this._reflectAttribute('displayformat', this._displayFormat);
-    
+
     this._elements.clock.displayFormat = this._displayFormat;
     this._elements.input.value = this._getValueAsString(this._value, this._displayFormat);
   }
-  
+
   /**
    The format to use on expressing the selected date as a string on the <code>value</code> attribute. The value
    will be sent to the server using this format. If an empty string is provided, then the default value per type
    will be used. The default value depends on the <code>type</code>, which can be one from <code>YYYY-MM-DD</code>,
    <code>YYYY-MM-DD[T]HH:mmZ</code> or <code>HH:mm</code>. Include momentjs to support additional format string options
    see http://momentjs.com/docs/#/displaying/.
-   
+
    @type {String}
    @default "YYYY-MM-DD"
    @htmlattribute valueformat
@@ -246,15 +246,15 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       this._valueFormat = newValue === '' ? NATIVE_FORMATS[this.type] : newValue;
       this._reflectAttribute('valueformat', this._valueFormat);
     };
-  
+
     value = transform.string(value).trim();
-  
+
     // In case a custom display format was set, we make sure that type doesn't change it to a native format
     const valueFormatAttribute = this.getAttribute('valueformat');
     if (this._typeFormatChanged && valueFormatAttribute && valueFormatAttribute !== value) {
       value = valueFormatAttribute;
     }
-  
+
     // Once the valueFormat is set, we make sure the value is also correct
     if (!this._valueFormat && this._originalValue) {
       setValueFormat(value);
@@ -263,39 +263,39 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
     else {
       setValueFormat(value);
     }
-    
+
     this._elements.calendar.valueFormat = this._valueFormat;
     this._elements.hiddenInput.value = this.value;
   }
-  
+
   /**
    The value of the element, interpreted as a date, or <code>null</code> if conversion is not possible.
-   
+
    @type {Date}
    @default null
    */
   get valueAsDate() {
     let value = this._value;
-  
+
     // If type is DATE, then you strip out the time
     if (this.type === 'date' && value) {
       value = value.startOf('day');
     }
-  
+
     return value ? value.toDate() : null;
   }
   set valueAsDate(value) {
     this._valueAsDate = value instanceof Date ? new DateTime.Moment(value) : '';
-  
+
     this.value = this._valueAsDate;
   }
-  
+
   /**
    The minimum date that the Datepicker will accept as valid. It must not be greated that its maximum. It accepts
    both date and string values. When a string is provided, it should match the {@link Coral.Datepicker#valueFormat}.
-   
+
    See {@link Coral.Calendar#min}
-   
+
    @type {String|Date}
    @default null
    @htmlattribute min
@@ -306,13 +306,13 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set min(value) {
     this._elements.calendar.min = value;
   }
-  
+
   /**
    The maximum date that the Datepicker will accept as valid. It must not be less than its minimum. It accepts both
    date and string values. When a string is provided, it should match the {@link Coral.Datepicker#valueFormat}.
-   
+
    See {@link Coral.Calendar#max}
-   
+
    @type {String|Date}
    @default null
    @htmlattribute max
@@ -323,14 +323,14 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set max(value) {
     this._elements.calendar.max = value;
   }
-  
+
   /**
    The format used to display the current month and year.
    'MMMM YYYY' is supported by default. Include momentjs to support additional format string options see
    http://momentjs.com/docs/#/displaying/.
-   
+
    See {@link Coral.Calendar#startDay}
-   
+
    @type {String}
    @default "MMMM YYYY"
    @htmlattribute headerformat
@@ -341,12 +341,12 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set headerFormat(value) {
     this._elements.calendar.headerFormat = value;
   }
-  
+
   /**
    Defines the start day for the week, 0 = Sunday, 1 = Monday etc., as depicted on the calendar days grid.
-   
+
    See {@link Coral.Calendar#startDay}
-   
+
    @type {Number}
    @default 0
    @htmlattribute startday
@@ -357,13 +357,13 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set startDay(value) {
     this._elements.calendar.startDay = value;
   }
-  
+
   /**
    The current value. When set to "today", the value is coerced into the client's local date expressed as string
    formatted in accordance to the set <code>valueFormat</code>.
-   
+
    See {@link Coral.Calendar#value}
-   
+
    @type {String}
    @default ""
    @htmlattribute value
@@ -374,18 +374,18 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set value(value) {
     // This is used to change the value if valueformat is also set but afterwards
     this._originalValue = value;
-    
+
     this._value = toMoment(value, this.valueFormat);
-  
+
     this._elements.calendar.valueAsDate = this.valueAsDate;
     this._elements.clock.valueAsDate = this.valueAsDate;
     this._elements.input.value = this._getValueAsString(this._value, this.displayFormat);
     this._elements.hiddenInput.value = this.value;
   }
-  
+
   /**
    Short hint that describes the expected value of the Datepicker. It is displayed when the Datepicker is empty.
-   
+
    @type {String}
    @default ""
    @htmlattribute placeholder
@@ -398,10 +398,10 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
     this._elements.input.placeholder = value;
     this._reflectAttribute('placeholder', this.placeholder);
   }
-  
+
   /**
    The datepicker's variant. See {@link DatepickerVariantEnum}.
-   
+
    @type {DatepickerVariantEnum}
    @default DatepickerVariantEnum.DEFAULT
    @htmlattribute variant
@@ -413,19 +413,19 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set variant(value) {
     value = transform.string(value).toLowerCase();
     this._variant = validate.enumeration(variant)(value) && value || variant.DEFAULT;
-  
+
     // passes down the variant to the underlying components
     this._elements.input.variant = this._variant;
     this._elements.toggle.classList.toggle('_coral-FieldButton--quiet', this._variant === variant.QUIET);
-  
+
     // removes every existing variant
     this.classList.remove(...ALL_VARIANT_CLASSES);
-  
+
     if (this._variant !== variant.DEFAULT) {
       this.classList.add(`${CLASSNAME}--${this._variant}`);
     }
   }
-  
+
   /**
    Name used to submit the data in a form.
    @type {String}
@@ -438,10 +438,10 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   set name(value) {
     this._reflectAttribute('name', value);
-  
+
     this._elements.hiddenInput.name = value;
   }
-  
+
   /**
    Whether this field is disabled or not.
    @type {Boolean}
@@ -455,15 +455,15 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set disabled(value) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
-    
+
     this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
-  
+
     this._elements.input.disabled = this._disabled;
     this._elements.hiddenInput.disabled = this._disabled;
-    this._elements.toggle.disabled = this._disabled || this.readOnly;
+    this._elements.toggle.disabled = this._disabled;
   }
-  
+
   /**
    Inherited from {@link BaseFormField#invalid}.
    */
@@ -472,13 +472,13 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   set invalid(value) {
     super.invalid = value;
-    
+
     this.classList.toggle('is-invalid', this.invalid);
     this._elements.toggle.classList.toggle('is-invalid', this.invalid);
     this._elements.input.invalid = this.invalid;
     this._elements.input.setAttribute('aria-invalid', this.invalid);
   }
-  
+
   /**
    Whether this field is required or not.
    @type {Boolean}
@@ -492,13 +492,13 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set required(value) {
     this._required = transform.booleanAttr(value);
     this._reflectAttribute('required', this._required);
-    
+
     this._elements.toggle.classList.toggle('is-invalid', this._required);
     this.setAttribute('aria-required', this._required);
-    
+
     this._elements.input.required = this._required;
   }
-  
+
   /**
    Whether this field is readOnly or not. Indicating that the user cannot modify the value of the control.
    @type {Boolean}
@@ -512,11 +512,12 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   set readOnly(value) {
     this._readOnly = transform.booleanAttr(value);
     this._reflectAttribute('readonly', this._readOnly);
-  
+
+    this._elements.hiddenInput.readOnly = this.readOnly;
     this._elements.input.readOnly = this._readOnly;
-    this._elements.toggle.disabled = this._readOnly || this.disabled;
+    this._elements.toggle.disabled = this._readOnly;
   }
-  
+
   /**
    Inherited from {@link BaseFormField#labelledBy}.
    */
@@ -525,16 +526,16 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   set labelledBy(value) {
     super.labelledBy = value;
-    
+
     // in case the user focuses the buttons, he will still get a notion of the usage of the component
     this[this.labelledBy ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.labelledBy);
   }
-  
+
   /**
    When <code>true</code> the component will default to the native input for the date selection. When
    {@link Coral.Datepicker.type.DATETIME} has been set, it will still use the Coral way because mobile browsers
    cannot handle a datetime input.
-   
+
    @ignore
    */
   get _useNativeInput() {
@@ -542,13 +543,13 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   set _useNativeInput(value) {
     this.__useNativeInput = value;
-  
+
     // we ignore _useNativeInput when the type is datetime because it is not supported by mobile libraries
     if (this.__useNativeInput && this.type !== type.DATETIME) {
       // Switch to native date/time picker:
       this._elements.toggle.hidden = true;
       this._elements.input.setAttribute('type', this.type);
-    
+
       // Hide pop-over and remove related attributes:
       this._elements.overlay.hidden = true;
       this.removeAttribute('aria-haspopup');
@@ -559,7 +560,7 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       // Switch to Calendar picker
       this._elements.toggle.hidden = false;
       this._elements.input.setAttribute('type', 'text');
-    
+
       // Show pop-over and add related attributes:
       this._elements.overlay.hidden = false;
       this.setAttribute('aria-haspopup', 'dialog');
@@ -567,16 +568,16 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       this.setAttribute('aria-owns', this._elements.overlay.id);
     }
   }
-  
+
   /** @ignore */
   _onPopoverBeforeOpen() {
     this._elements.calendar._validateCalendar();
     this._renderCalendar();
   }
-  
+
   /**
    Matches the accessibility to the state of the popover.
-   
+
    @ignore
    */
   _onPopoverOpenOrClose(event) {
@@ -596,7 +597,7 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       this._trackEvent('close', 'coral-datepicker', event);
     }
   }
-  
+
   /** @ignore */
   _onCalendarDayClick(event) {
     if (event.target.tagName === 'A') {
@@ -606,50 +607,50 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       this._trackEvent('click', 'coral-datepicker', event);
     }
   }
-  
+
   /** @ignore */
   _onInputChange(event) {
     // because we are reimplementing the form field mix in, we will have to stop the propagation and trigger the
     // 'change' event from here
     event.stopPropagation();
-    
+
     this.value = new DateTime.Moment(event.target.value, this.displayFormat);
     this._validateValue();
-    
+
     this.trigger('change');
     this._trackEvent('change', 'coral-datepicker', event);
   }
-  
+
   /** @ignore */
   _onChange(event) {
     if (event.target.tagName === 'CORAL-CALENDAR' || event.target.tagName === 'CORAL-CLOCK') {
       event.stopPropagation();
-  
+
       // we create the new value using both calendar and clock controls
       // datepicker should set the current time as default when no time is set, but a date was chosen (if in datetime
       // mode)
       this.value = this._mergeCalendarAndClockDates(true);
       this._validateValue();
-  
+
       this.trigger('change');
     }
   }
-  
+
   /** @private */
   _onAltDownKey(event) {
     // Stop any consequences of pressing the key
     event.preventDefault();
-    
+
     if (!this._elements.overlay.open) {
       this._elements.overlay.open = true;
     }
   }
-  
+
   /** @ignore */
   _validateValue() {
     // calendar validates only on user input, we have to manually force the validation
     this._elements.calendar._validateCalendar();
-    
+
     // check if the current value is valid and update the internal state of the component
     if (this.type === type.DATE) {
       this.invalid = this._elements.calendar.invalid;
@@ -661,45 +662,45 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       this.invalid = this._elements.calendar.invalid || this._elements.clock.invalid;
     }
   }
-  
+
   /** @ignore */
   _mergeCalendarAndClockDates(autoSetTimeIfNeeded) {
     let value = new DateTime.Moment(this._elements.calendar.valueAsDate);
     let time = this._elements.clock.valueAsDate;
-    
+
     if (autoSetTimeIfNeeded && value && !time && this.type === type.DATETIME) {
       // datepicker should set the current time as default when no time is set, but a date was chosen (if in datetime
       // mode)
       time = new DateTime.Moment().toDate();
     }
-    
+
     if (time) {
       if (!value.isValid()) {
         value = new DateTime.Moment();
       }
-      
+
       value.hours(time.getHours());
       value.minutes(time.getMinutes());
     }
-    
+
     return value;
   }
-  
+
   /**
    Helper class that converts the internal moment value into a String using the provided date format. If the value is
    invalid, empty string will be returned.
-   
+
    @param {?Moment} value
    The value representing the date. It has to be a moment object or <code>null</code>
    @param {String} format
    The Date format to be used.
-   
+
    @ignore
    */
   _getValueAsString(value, format) {
     return value && value.isValid() ? value.format(format) : '';
   }
-  
+
   /** @ignore */
   _renderCalendar() {
     if (this._elements.overlay.content.innerHTML === '') {
@@ -707,21 +708,21 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       this._calendarFragment = undefined;
     }
   }
-  
+
   /**
    Returns {@link Datepicker} variants.
-   
+
    @return {DatepickerVariantEnum}
    */
   static get variant() { return variant; }
-  
+
   /**
    Returns {@link Datepicker} types.
-   
+
    @return {DatepickerTypeEnum}
    */
   static get type() { return type; }
-  
+
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
       startday: 'startDay',
@@ -730,7 +731,7 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       valueformat: 'valueFormat'
     });
   }
-  
+
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat([
@@ -745,11 +746,11 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       'variant'
     ]);
   }
-  
+
   /** @ignore */
   connectedCallback() {
     super.connectedCallback();
-    
+
     const overlay = this._elements.overlay;
     // Cannot be open by default when rendered
     overlay.removeAttribute('open');
@@ -758,47 +759,47 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       overlay._parent.appendChild(overlay);
     }
   }
-  
+
   /** @ignore */
   render() {
     super.render();
-    
+
     this.classList.add(CLASSNAME);
-    
+
     // a11y
     this.setAttribute('role', 'combobox');
-    
+
     // a11y we only have AUTO mode.
     this._useNativeInput = IS_MOBILE_DEVICE;
-    
+
     // Default reflected attributes
     if (!this._variant) { this.variant = variant.DEFAULT; }
     // "type" takes care of reflecting "displayFormat" and "valueFormat"
     if (!this._type) { this.type = type.DATE; }
-    
+
     // clean up to be able to clone it
     while (this.firstChild) {
       this.removeChild(this.firstChild);
     }
-  
+
     const frag = document.createDocumentFragment();
-    
+
     // Render template
     frag.appendChild(this._elements.hiddenInput);
     frag.appendChild(this._elements.input);
     frag.appendChild(this._elements.toggle);
     frag.appendChild(this._elements.overlay);
-  
+
     // Point at the button from the bottom
     this._elements.overlay.target = this._elements.toggle;
-    
+
     this.appendChild(frag);
   }
-  
+
   /** @ignore */
   disconnectedCallback() {
     super.disconnectedCallback();
-    
+
     const overlay = this._elements.overlay;
     // In case it was moved out don't forget to remove it
     if (!this.contains(overlay)) {

--- a/coral-component-datepicker/src/tests/test.Datepicker.js
+++ b/coral-component-datepicker/src/tests/test.Datepicker.js
@@ -36,16 +36,16 @@ describe('Datepicker', function() {
       'should be possible to clone the element using markup',
       window.__html__['Datepicker.base.html']
     );
-  
+
     helpers.cloneComponent(
       'should be possible to clone the element using markup type="time"',
       window.__html__['Datepicker.type.time.html']
     );
   });
-  
+
   // Run tests once with moment fallback and once with moment
   for (let useMomentJS = 0; useMomentJS < 2; useMomentJS++) {
-    
+
     const momentJS = window.moment;
 
     beforeEach(function() {
@@ -58,135 +58,135 @@ describe('Datepicker', function() {
         window.moment = momentJS;
       }
     });
-  
+
     describe('API', function() {
       var el;
-    
+
       beforeEach(function() {
         el = helpers.build(new Datepicker());
         el._renderCalendar();
       });
-    
+
       afterEach(function() {
         el = null;
       });
-    
+
       describe('#disabled', function() {
       });
-    
+
       describe('#displayFormat', function() {
         it('should default to YYYY-MM-DD', function() {
           expect(el.displayFormat).to.equal('YYYY-MM-DD');
         });
-      
+
         it('should change the default based on the type', function() {
           expect(el.type).to.equal(Datepicker.type.DATE);
           expect(el.displayFormat).to.equal('YYYY-MM-DD');
-        
+
           el.type = Datepicker.type.DATETIME;
           expect(el.displayFormat).to.equal('YYYY-MM-DD[T]HH:mmZ');
-        
+
           el.type = Datepicker.type.TIME;
           expect(el.displayFormat).to.equal('HH:mm');
         });
-      
+
         it('should allow a custom value', function() {
           expect(el.type).to.equal(Datepicker.type.DATE);
           el.displayFormat = 'MM-DD-YYYY';
           expect(el.displayFormat).to.equal('MM-DD-YYYY');
-        
+
           el.type = Datepicker.type.DATETIME;
           expect(el.displayFormat).to.equal('MM-DD-YYYY');
         });
-      
+
         it('should fallback empty strings to the defaults', function() {
           expect(el.type).to.equal(Datepicker.type.DATE);
           el.displayFormat = 'MM-DD-YYYY';
           expect(el.displayFormat).to.equal('MM-DD-YYYY');
-        
+
           el.displayFormat = '';
           expect(el.displayFormat).to.equal('YYYY-MM-DD');
         });
-      
+
         it('should allow the user to type dates in the displayFormat', function() {
           if (useMomentJS) {
             el.displayFormat = 'DD-MM-YY';
-  
+
             // types a new value in the input field and triggers a change event
             el._elements.input.value = '30-05-15';
             el._elements.input.trigger('change');
-  
+
             expect(el._elements.input.value).to.equal('30-05-15');
-  
+
             // internal value should follow the valueFormat
             expect(el.value).to.equal('2015-05-30');
-  
+
             expect(el._elements.hiddenInput.value).to.equal('2015-05-30');
           }
         });
-      
+
         it('should reject the value if it does not match the format', function() {
           el.displayFormat = 'MM-DD-YYYY';
           el._elements.input.value = '30';
           el._elements.input.trigger('change');
-        
+
           expect(el.value).to.equal('');
           expect(el._elements.input.value).to.equal('');
         });
-      
+
         it('should update the input with the new value based on the format', function() {
           el.value = '2015-07-10';
-        
+
           expect(el._elements.input.value).to.equal('2015-07-10');
-        
+
           if (useMomentJS) {
             el.displayFormat = 'YY';
-  
+
             expect(el.value).to.equal('2015-07-10');
-  
+
             expect(el._elements.input.value).to.equal('15');
           }
         });
-      
+
         it('should allow setting a format with am/pm', function() {
           if (useMomentJS) {
             el.type = Datepicker.type.TIME;
             el.displayFormat = 'hh:mm A';
             expect(el._elements.clock.displayFormat).to.equal('hh:mm A', 'Format should be set on the clock as well');
-  
+
             el.value = '15:37';
-  
+
             expect(el._elements.input.value).to.equal('03:37 PM', 'The input should reflect the format');
           }
         });
       });
-    
+
       describe('#headerFormat', function() {
       });
-    
+
       describe('#invalid', function() {
       });
-    
+
       describe('#labelledBy', function() {
         it('should label the input', function() {
           var label1 = document.createElement('label');
           label1.textContent = 'label1';
           label1.id = commons.getUID();
-        
+
           helpers.target.insertBefore(label1, el);
-        
+
           el.labelledBy = label1.id;
-        
+
           expect(el.labelledBy).to.equal(label1.id);
           expect(label1.getAttribute('for')).to.equal(el._elements.input.id);
           expect(el._elements.input.getAttribute('aria-labelledby')).to.equal(label1.id);
           expect(el._elements.toggle.hasAttribute('aria-labelledby')).to.be.false;
           expect(el._elements.hiddenInput.hasAttribute('aria-labelledby')).to.be.false;
-        
+
           expect(el.getAttribute('aria-labelledby')).to.equal(label1.id);
-        
+
           el.labelledBy = '';
-        
+
           expect(el.labelledBy).to.be.null;
           expect(label1.hasAttribute('for')).to.be.false;
           expect(el._elements.input.hasAttribute('aria-labelledby')).to.be.false;
@@ -195,84 +195,84 @@ describe('Datepicker', function() {
           expect(el.hasAttribute('aria-labelledby'), 'aria should be removed').to.be.false;
         });
       });
-    
+
       describe('#max', function() {
       });
-    
+
       describe('#min', function() {
       });
-    
+
       describe('#name', function() {
         it('should have empty string as default', function() {
           expect(el.name).to.equal('');
           expect(el._elements.hiddenInput.name).to.equal('');
           expect(el._elements.input.name).to.equal('');
         });
-      
+
         it('should set the name', function() {
           el.name = 'dp';
           expect(el.name).to.equal('dp');
           expect(el._elements.hiddenInput.name).to.equal('dp');
           expect(el._elements.input.name).to.equal('');
         });
-      
+
         it('should submit nothing when the name is not specified', function() {
           // we wrap first the select
           var form = document.createElement('form');
           form.appendChild(el);
           helpers.target.appendChild(form);
-        
+
           el.value = '2000-05-29';
-        
+
           expect(el._elements.hiddenInput.name).to.equal('');
           expect(el._elements.input.name).to.equal('');
-        
+
           var values = helpers.serializeArray(form);
-        
+
           expect(values.length).to.equal(0);
         });
-      
+
         it('should submit the value', function() {
           // we wrap first the select
           var form = document.createElement('form');
           form.appendChild(el);
           helpers.target.appendChild(form);
-        
+
           el.name = 'dp';
           el.value = '2000-05-04';
-        
+
           expect(el.name).to.equal('dp');
           expect(el._elements.hiddenInput.name).to.equal('dp');
           expect(el._elements.input.name).to.equal('');
-        
+
           // the native has the correct value
           expect(el._elements.hiddenInput.value).to.equal('2000-05-04');
-        
+
           expect(helpers.serializeArray(form)).to.deep.equal([{
             name: 'dp',
             value: '2000-05-04'
           }]);
         });
-      
+
         it('should use the valueformat for the submitted value', function() {
           if (useMomentJS) {
             // we wrap first the select
             var form = document.createElement('form');
             form.appendChild(el);
             helpers.target.appendChild(form);
-  
+
             el.name = 'dp';
             el.valueFormat = 'DD-MM-YYYY';
             el.value = '30-08-2005';
-  
+
             expect(el.name).to.equal('dp');
             expect(el._elements.hiddenInput.name).to.equal('dp');
             expect(el._elements.input.name).to.equal('');
-  
+
             // the native has the correct value
             expect(el._elements.hiddenInput.value).to.equal('30-08-2005');
             expect(el._elements.input.value).to.equal('2005-08-30');
-  
+
             expect(helpers.serializeArray(form)).to.deep.equal([{
               name: 'dp',
               value: '30-08-2005'
@@ -280,202 +280,217 @@ describe('Datepicker', function() {
           }
         });
       });
-    
+
       describe('#placeholder', function() {
         it('should default to ""', function() {
           expect(el.placeholder).to.equal('');
           expect(el.hasAttribute('placeholder')).to.be.false;
         });
-      
+
         it('should be set and reflected', function() {
           el.placeholder = 'dp1';
           expect(el.placeholder).to.equal('dp1');
           expect(el._elements.input.getAttribute('placeholder')).to.equal('dp1');
         });
       });
-    
+
       describe('#readOnly', function() {
         it('should default to false', function() {
           expect(el.readOnly).to.be.false;
           expect(el.hasAttribute('readonly')).to.be.false;
         });
-      
-        it('should set readonly', function() {
+
+        it('should set readonly with value true', function() {
           el.readOnly = true;
-        
+
           expect(el._elements.input.readOnly).to.be.true;
           expect(el._elements.toggle.disabled).to.be.true;
           expect(el.hasAttribute('readonly')).to.be.true;
         });
+
+        it('should set readonly with value 1', function() {
+                  el.readOnly = 1;
+
+                  expect(el._elements.input.readOnly).to.be.true;
+                  expect(el._elements.toggle.disabled).to.be.true;
+                  expect(el.hasAttribute('readonly')).to.be.true;
+        });
+
+        it('should not be selectable with readOnly set to true', function() {
+                  el.readOnly = true;
+                  el.focus();
+
+                  expect(el.contains(document.activeElement)).to.be.false;
+        });
       });
-    
+
       describe('#required', function() {
       });
-    
+
       describe('#startDay', function() {
       });
-    
+
       describe('#type', function() {
         it('should default to false', function() {
           expect(el.type).to.equal(Datepicker.type.DATE);
           expect(el.getAttribute('type')).to.equal(Datepicker.type.DATE);
         });
-      
+
         it('should set the new type', function() {
           el.type = Datepicker.type.TIME;
           expect(el.type).to.equal(Datepicker.type.TIME);
-        
+
           expect(el.getAttribute('type')).to.equal(Datepicker.type.TIME);
         });
       });
-    
+
       describe('#value', function() {
         it('should default to empty string', function() {
           expect(el.value).to.equal('');
         });
-      
+
         it('should accept valid dates', function() {
           el.value = '2000-12-31';
-        
+
           expect(el.value).to.equal('2000-12-31');
           expect(new DateTime.Moment(el.valueAsDate).isSame(new DateTime.Moment(new Date(2000, 11, 31)), 'day')).to.be.true;
         });
-      
+
         it('should accept "today" as a value', function() {
           el.value = 'today';
-        
+
           expect(new DateTime.Moment().isSame(new DateTime.Moment(el.valueAsDate), 'day')).to.be.true;
           expect(new DateTime.Moment(el.value).isSame(new DateTime.Moment(Date.now()), 'day')).to.be.true;
         });
-      
+
         it('should reject invalid value strings', function() {
           el.value = 'nondate';
-        
+
           expect(el.value).to.equal('');
           expect(el.valueAsDate).to.be.null;
         });
-      
+
         it('should reject invalid date strings', function() {
           el.value = 'a';
-        
+
           expect(el.value).to.equal('');
           expect(el.valueAsDate).to.be.null;
         });
-      
+
         it('should accept date objects', function() {
           var today = new Date();
-        
+
           el.value = today;
           expect(new DateTime.Moment(el.value, el.valueFormat).isSame(new DateTime.Moment(today), 'day')).to.be.true;
           expect(new DateTime.Moment(el.valueAsDate).isSame(new DateTime.Moment(today), 'day')).to.be.true;
         });
-      
+
         it('should accept moment objects', function() {
           var date = new DateTime.Moment('1988-01-12');
-        
+
           el.value = date;
           expect(new DateTime.Moment(el.value, el.valueFormat).isSame(new DateTime.Moment(date), 'day')).to.be.true;
           expect(new DateTime.Moment(el.valueAsDate).isSame(new DateTime.Moment(date), 'day')).to.be.true;
         });
       });
-    
+
       describe('#valueAsDate', function() {
         it('should default to null', function() {
           expect(el.valueAsDate).to.be.null;
         });
-      
+
         it('should accept dates', function() {
           var newDate = new Date();
           el.valueAsDate = newDate;
           expect(new DateTime.Moment(newDate).isSame(new DateTime.Moment(el.valueAsDate), 'day')).to.be.true;
         });
-      
+
         it('should reject date strings', function() {
           el.valueAsDate = '2000-02-20';
-        
+
           expect(el.value).to.equal('');
           expect(el.valueAsDate).to.be.null;
         });
-      
+
         it('should be able to clear the value', function() {
           el.valueAsDate = new Date();
           expect(el.value).not.to.equal('');
-        
+
           el.valueAsDate = '';
           expect(el.value).to.equal('');
           expect(el.valueAsDate).to.be.null;
         });
       });
-    
+
       describe('#valueFormat', function() {
         it('should default to YYYY-MM-DD', function() {
           expect(el.valueFormat).to.equal('YYYY-MM-DD');
         });
-      
+
         it('should change the default based on the type', function() {
           expect(el.type).to.equal(Datepicker.type.DATE);
           expect(el.valueFormat).to.equal('YYYY-MM-DD');
-        
+
           el.type = Datepicker.type.DATETIME;
           expect(el.valueFormat).to.equal('YYYY-MM-DD[T]HH:mmZ');
-        
+
           el.type = Datepicker.type.TIME;
           expect(el.valueFormat).to.equal('HH:mm');
         });
-      
+
         it('should allow a custom value', function() {
           expect(el.type).to.equal(Datepicker.type.DATE);
           el.valueFormat = 'MM-DD-YYYY';
           expect(el.valueFormat).to.equal('MM-DD-YYYY');
-        
+
           el.type = Datepicker.type.DATETIME;
           expect(el.valueFormat).to.equal('MM-DD-YYYY');
         });
-      
+
         it('should fallback empty strings to the defaults', function() {
           expect(el.type).to.equal(Datepicker.type.DATE);
           el.valueFormat = 'MM-DD-YYYY';
           expect(el.valueFormat).to.equal('MM-DD-YYYY');
-        
+
           el.valueFormat = '';
           expect(el.valueFormat).to.equal('YYYY-MM-DD');
         });
-      
+
         it('should accept values with the new format', function() {
           if (useMomentJS) {
             el.valueFormat = 'DD-MM-YY';
-  
+
             el.value = '30-05-15';
             expect(el._elements.input.value).to.equal('2015-05-30');
           }
         });
-      
+
         it('should update the hidden input with the new value based on the format', function() {
           el.value = '2015-07-10';
-  
+
           expect(el._elements.hiddenInput.value).to.equal('2015-07-10');
-  
+
           if (useMomentJS) {
             el.valueFormat = 'YY';
-  
+
             expect(el.value).to.equal('15');
             expect(el._elements.hiddenInput.value).to.equal('15');
           }
         });
-      
+
         it('should update Min and Max values with the new format', function() {
           if (useMomentJS) {
             el.valueFormat = 'DD-MM-YYYY';
-  
+
             el.min = '10-07-2015';
             el.max = '25-07-2015';
-  
+
             // Compare Min value date object to the assigned date
             var minDate = el.min;
             expect(minDate.getFullYear()).to.equal(2015);
             expect(minDate.getMonth() + 1).to.equal(7);
             expect(minDate.getDate()).to.equal(10);
-  
+
             // Compare Max value date object to the assigned date
             var maxDate = el.max;
             expect(maxDate.getFullYear()).to.equal(2015);
@@ -484,49 +499,49 @@ describe('Datepicker', function() {
           }
         });
       });
-    
+
       describe('#variant', function() {
         it('should be set to "default" by default', function() {
           expect(el.variant).to.equal(Datepicker.variant.DEFAULT, '"default" should be set');
         });
-      
+
         it('should be possible to set the variant', function() {
           expect(el.classList.contains('_coral-InputGroup--quiet')).to.be.false;
-        
+
           expect(el.variant).to.equal(Datepicker.variant.DEFAULT, '"default" should be set');
           expect(el._elements.toggle.classList.contains('_coral-FieldButton--quiet')).to.be.false;
           expect(el._elements.input.variant).to.equal(Datepicker.variant.DEFAULT, '"default" should be set to the input variant');
-        
+
           el.variant = Datepicker.variant.QUIET;
-        
+
           expect(el.variant).to.equal(Datepicker.variant.QUIET, '"quiet" should be set');
           expect(el._elements.toggle.classList.contains('_coral-FieldButton--quiet')).to.be.true;
           expect(el._elements.input.variant).to.equal(Datepicker.variant.QUIET, '"quiet" should be set tp the input variant');
-        
+
           expect(el.classList.contains('_coral-InputGroup--quiet')).to.be.true;
         });
       });
     });
-  
+
     describe('Markup', function() {
-    
+
       describe('#invalid', function() {
         it('should consider the markup as the truth until user interaction happened', function() {
           helpers.build(window.__html__['Datepicker.invalid.html']);
           var validDatepicker1 = document.getElementById('validDatepicker1');
           var validDatepicker2 = document.getElementById('validDatepicker2');
           var invalidDatepicker = document.getElementById('invalidDatepicker');
-        
+
           expect(validDatepicker1.invalid).to.equal(false, 'validDatepicker1 should not be invalid (markup should be right)');
           expect(validDatepicker2.invalid).to.equal(false, 'validDatepicker2 should not be invalid (markup should be right)');
           expect(invalidDatepicker.invalid).to.equal(true, 'invalidDatepicker should be invalid (markup should be right)');
-        
+
           expect(validDatepicker1.hasAttribute('invalid')).to.equal(false, 'validDatepicker1 should not have an invalid attribute');
           expect(validDatepicker1.hasAttribute('invalid')).to.equal(false, 'validDatepicker2 should not have an invalid attribute');
           expect(invalidDatepicker.hasAttribute('invalid')).to.equal(true, 'invalidDatepicker should have an invalid attribute');
         });
       });
-    
+
       describe('#type', function() {
         it('should default to "date"', function() {
           const el = helpers.build(window.__html__['Datepicker.base.html']);
@@ -534,21 +549,21 @@ describe('Datepicker', function() {
           expect(el.valueFormat).to.equal('YYYY-MM-DD');
           expect(el.displayFormat).to.equal(el.valueFormat);
         });
-      
+
         it('should accept "datetime"', function() {
           const el = helpers.build(window.__html__['Datepicker.type.datetime.html']);
           expect(el.type).to.equal('datetime');
           expect(el.valueFormat).to.equal('YYYY-MM-DD[T]HH:mmZ');
           expect(el.displayFormat).to.equal(el.valueFormat);
         });
-      
+
         it('should accept "time"', function() {
           const el = helpers.build(window.__html__['Datepicker.type.time.html']);
           expect(el.type).to.equal('time');
           expect(el.valueFormat).to.equal('HH:mm');
           expect(el.displayFormat).to.equal(el.valueFormat);
         });
-      
+
         it('should accept custom value format', function() {
           const el = helpers.build(window.__html__['Datepicker.type.customvalueformat.html']);
           expect(el.type).to.equal('time');
@@ -557,7 +572,7 @@ describe('Datepicker', function() {
           // should use the default display that matches the type
           expect(el.displayFormat).to.equal('HH:mm');
         });
-      
+
         it('should accept custom display format', function() {
           const el = helpers.build(window.__html__['Datepicker.type.customdisplayformat.html']);
           expect(el.type).to.equal('time');
@@ -567,69 +582,69 @@ describe('Datepicker', function() {
           expect(el.displayFormat).to.equal('mm:HH');
         });
       });
-    
+
       describe('#value', function() {
         it('should default to empty string', function() {
           const el = helpers.build(window.__html__['Datepicker.base.html']);
           expect(el.value).to.equal('');
         });
-      
+
         it('should accept valid dates', function() {
           const el = helpers.build(window.__html__['Datepicker.value.html']);
           expect(el.value).to.equal('2000-12-31');
           expect(el.getAttribute('value')).to.equal('2000-12-31');
           expect(new DateTime.Moment(el.valueAsDate).isSame(new DateTime.Moment(new Date(2000, 11, 31)), 'day')).to.be.true;
         });
-      
+
         it('should accept "today" as a value', function() {
           const el = helpers.build(window.__html__['Datepicker.value.today.html']);
           expect(new DateTime.Moment(el.value, el.valueFormat).isSame(new DateTime.Moment(Date.now()), 'day')).to.be.true;
           expect(el.getAttribute('value')).to.equal('today');
-        
+
           expect(new DateTime.Moment().isSame(new DateTime.Moment(el.valueAsDate), 'day')).to.be.true;
           expect(new DateTime.Moment(el.value).isSame(new DateTime.Moment(Date.now()), 'day')).to.be.true;
         });
-      
+
         it('should automatically initialize the clock to "now" if the type is "time" and value "today"', function() {
           const el = helpers.build('<coral-datepicker type="time" value="today"></coral-datepicker>');
           // this test just verifies that the current time is set
-        
+
           var currentDate = new Date();
           var initDate = el.valueAsDate;
-        
+
           var passedMinutesOfCurrentDay = currentDate.getHours() * 60 + currentDate.getMinutes();
           var passedMinutesOfInitDay = initDate.getHours() * 60 + initDate.getMinutes();
-        
+
           // (for simplicity simply check that not more than one minute has passed since init)
           expect(passedMinutesOfInitDay <= passedMinutesOfCurrentDay && passedMinutesOfInitDay + 2 > passedMinutesOfCurrentDay).to.equal(true, 'current time should have been set as default time');
         });
-      
+
         it('should automatically initialize the clock to "now" if the type is "datetime" and value "today"', function() {
           const el = helpers.build('<coral-datepicker type="datetime" value="today" ></coral-datepicker>');
           // this test just verifies that the current date & time is set
-        
+
           var currentDate = new Date();
           var currentTime = currentDate.getTime();
           var initTime = el.valueAsDate.getTime();
-        
+
           // (for simplicity simply check that not more than one minute has passed since init)
           expect(initTime <= currentTime && initTime + 60000 > currentTime).to.equal(true, 'current date & time should have been set as default time');
         });
-      
+
         it('should initialize the clock to 0am if the type is "date" and value "today"', function() {
           const el = helpers.build('<coral-datepicker value="today" type="date"></coral-datepicker>');
           // this test just verifies that the current date & time is set
-        
+
           var currentDate = new Date();
           var initDate = el.valueAsDate;
-        
+
           var passedMinutesOfCurrentDay = currentDate.getHours() * 60 + currentDate.getMinutes();
           var passedMinutesOfInitDay = initDate.getHours() * 60 + initDate.getMinutes();
-        
+
           // (for simplicity simply check that not more than one minute has passed since init)
           expect(passedMinutesOfInitDay === 0 && passedMinutesOfCurrentDay >= passedMinutesOfInitDay).to.equal(true, 'time should have been set to 0:00');
         });
-      
+
         it('should reject invalid value strings', function() {
           const el = helpers.build(window.__html__['Datepicker.value.invalid.html']);
           expect(el.value).to.equal('');
@@ -637,171 +652,171 @@ describe('Datepicker', function() {
           expect(el.valueAsDate).to.be.null;
         });
       });
-    
+
       describe('#valueAsDate', function() {
         it('should default to null', function() {
           const el = helpers.build(window.__html__['Datepicker.base.html']);
           expect(el.valueAsDate).to.be.null;
         });
-      
+
         it('should return assigned value as Date', function() {
           const el = helpers.build(window.__html__['Datepicker.value.html']);
           expect(el.valueAsDate instanceof Date).to.be.true;
           expect(new DateTime.Moment(el.valueAsDate).isSame(new DateTime.Moment('2000-12-31'), 'day')).to.be.true;
         });
-      
+
         it('should not accept valueAsDate as an attribute', function() {
           const el = helpers.build(window.__html__['Datepicker.valueasdate.html']);
           expect(el.valueAsDate).to.be.null;
         });
       });
     });
-  
+
     describe('Events', function() {
       describe('#change', function() {
         it('should not trigger a change event at instantiation', function() {
           var changeSpy = sinon.spy();
-        
+
           // we assign the listener to the container in case the event bubbles
           helpers.target.addEventListener('change', changeSpy);
-        
+
           const el = helpers.build(window.__html__['Datepicker.value.html']);
-        
+
           expect(changeSpy.callCount).to.equal(0);
         });
-      
+
         it('should not trigger a change event when a value is set programmatically', function() {
           var changeSpy = sinon.spy();
-        
+
           const el = helpers.build(window.__html__['Datepicker.value.html']);
           el.on('change', changeSpy);
           el.value = null;
-        
+
           expect(changeSpy.callCount).to.equal(0);
         });
-      
+
         it('should trigger a change event when a date is selected', function(done) {
           var changeSpy = sinon.spy();
-        
+
           const el = helpers.build(window.__html__['Datepicker.value.html']);
           el.on('change', changeSpy);
-        
+
           el._elements.toggle.click();
-        
+
           // Overlay does not open immediately any longer
           helpers.next(function() {
             var cell = el._elements.calendar._elements.body.querySelector('a');
-          
+
             cell.click();
-          
+
             expect(changeSpy.callCount).to.equal(1);
-          
+
             done();
           });
         });
-      
+
         it('should trigger a change event when a time is selected', function(done) {
           var changeSpy = sinon.spy();
-        
+
           const el = helpers.build(window.__html__['Datepicker.type.time.html']);
           el.on('change', changeSpy);
-        
+
           el._elements.toggle.click();
-        
+
           // Overlay does not open immediately any longer
           helpers.next(function() {
             // we need to select a full time to have a valid change event
             el._elements.clock._elements.hours.value = '12';
             el._elements.clock._elements.hours.trigger('change');
-          
+
             el._elements.clock._elements.minutes.value = '59';
             el._elements.clock._elements.minutes.trigger('change');
-          
+
             expect(changeSpy.callCount).to.equal(1);
             done();
           });
         });
-      
+
         it('should trigger a change event when a datetime is selected', function(done) {
           var changeSpy = sinon.spy();
-        
+
           const el = helpers.build('<coral-datepicker type="datetime" value="2015-04-20T00:00+02:00"></coral-datepicker>');
           el.on('change', changeSpy);
-        
+
           el._elements.toggle.click();
-        
+
           // Overlay does not open immediately any longer
           helpers.next(function() {
             el._elements.clock._elements.minutes.value = '59';
             el._elements.clock._elements.minutes.trigger('change');
-          
+
             expect(changeSpy.callCount).to.equal(1);
             done();
           });
         });
-      
+
         it('should trigger a change event when a datetime (with no initial value) is selected', function(done) {
           var changeSpy = sinon.spy();
-        
+
           const el = helpers.build(window.__html__['Datepicker.type.datetime.html']);
           el.on('change', changeSpy);
-        
+
           el._elements.toggle.click();
-        
+
           // Overlay does not open immediately any longer
           helpers.next(function() {
             // we need to set a full time for the change event to be triggered
             el._elements.clock._elements.hours.value = '12';
             el._elements.clock._elements.hours.trigger('change');
-          
+
             el._elements.clock._elements.minutes.value = '59';
             el._elements.clock._elements.minutes.trigger('change');
-          
+
             expect(changeSpy.callCount).to.equal(1);
             done();
           });
         });
       });
     });
-  
+
     describe('User Interaction', function() {
       it('should show the invalid style if the user sets the date manually', function() {
         const el = helpers.build('<coral-datepicker min="2015-04-10" max="2015-04-28" value="2015-04-15"></coral-datepicker>');
         // sets a value outside of the range
         el._elements.input.value = '2015-04-29';
         el._elements.input.trigger('change');
-      
+
         expect(el.value).to.equal('2015-04-29');
         expect(el.invalid).to.be.true;
         expect(el.classList.contains('is-invalid')).to.be.true;
       });
-    
+
       it('should show set the current time as default when no time is set, but a date was chosen', function(done) {
         const el = helpers.build('<coral-datepicker type="datetime" value=""></coral-datepicker>');
-      
+
         // we open the calendar to select a new date
         el._elements.toggle.click();
-      
+
         // Overlay does not open immediately any longer
         helpers.next(function() {
           var cell = el._elements.calendar._elements.body.querySelector('a');
           cell.click();
-        
+
           // this test is simple and just verifies that the current time is set
           var currentDate = new Date();
           var initDate = el.valueAsDate;
-        
+
           // (for simplicity we only check the minutes)
           var passedMinutesOfCurrentDay = currentDate.getHours() * 60 + currentDate.getMinutes();
           var passedMinutesOfInitDay = initDate.getHours() * 60 + initDate.getMinutes();
-        
+
           // (for simplicity simply check that not more than one minute has passed since init)
           expect(passedMinutesOfInitDay <= passedMinutesOfCurrentDay && passedMinutesOfInitDay + 2 > passedMinutesOfCurrentDay).to.equal(true, 'current time should have been set as default time');
-        
+
           done();
         });
       });
-    
+
       it('toggle should open calendar', function(done) {
         const el = helpers.build(window.__html__['Datepicker.base.html']);
 
@@ -811,57 +826,57 @@ describe('Datepicker', function() {
 
           done();
         });
-      
+
         // opens the popover
         el._elements.toggle.click();
       });
-    
+
       it('should not toggle the calendar when readonly', function() {
         const el = helpers.build(window.__html__['Datepicker.readonly.html']);
         // opens the popover
         el._elements.toggle.click();
-      
+
         expect(el._elements.overlay.open).to.be.false;
       });
-    
+
       it('should recheck the invalid state after a user interaction happened', function() {
         helpers.build(window.__html__['Datepicker.invalid.html']);
         var datepicker1 = document.getElementById('validDatepicker1');
         var datepicker2 = document.getElementById('validDatepicker2');
         var datepicker3 = document.getElementById('invalidDatepicker');
-      
+
         datepicker1._elements.input.trigger('change');
         datepicker2._elements.input.trigger('change');
         datepicker3._elements.input.trigger('change');
-      
+
         expect(datepicker1.invalid).to.equal(true, 'datepicker1 should be invalid (calculated by calendar)');
         expect(datepicker2.invalid).to.equal(true, 'datepicker2 should be invalid (calculated by calendar)');
         expect(datepicker3.invalid).to.equal(false, 'datepicker3 should not be invalid (calculated by calendar)');
-      
+
         expect(datepicker1.hasAttribute('invalid')).to.equal(true, 'datepicker1 should have an invalid attribute');
         expect(datepicker2.hasAttribute('invalid')).to.equal(true, 'datepicker2 should have an invalid attribute');
         expect(datepicker3.hasAttribute('invalid')).to.equal(false, 'datepicker3 should not have an invalid attribute');
       });
-      
+
       // @flaky on FF
       it.skip('should restore focus to toggle when closed using ESC key', function(done) {
         const el = helpers.build(window.__html__['Datepicker.type.time.html']);
         el._elements.overlay._overlayAnimationTime = 0;
-        
+
         // explicitly set focus to toggle button
         el._elements.toggle.focus();
-      
+
         // Overlay does not open immediately any longer
         el.on('coral-overlay:open', function() {
           // hours input should have focus when popover opens
           expect(document.activeElement).to.equal(el._elements.clock._elements.hours);
 
           expect(el.getAttribute('aria-expanded')).to.equal('false');
-        
+
           // trigger ESC key down event on hours input
           helpers.keydown(Keys.keyToCode('esc'), el._elements.clock._elements.hours);
         });
-        
+
         el.on('coral-overlay:close', function() {
           // focus should return to toggle button
           expect(document.activeElement).to.equal(el._elements.toggle);
@@ -870,51 +885,51 @@ describe('Datepicker', function() {
 
           done();
         });
-      
+
         // trigger a click event on the toggle to open popover
         el._elements.toggle.click();
       });
     });
-  
+
     describe('Implementation details', function() {
       it('should show different controls depending on the type', function(done) {
         var el = new Datepicker();
         el._renderCalendar();
         helpers.target.appendChild(el);
-      
+
         expect(el.type).to.equal('date');
-      
+
         el._elements.toggle.click();
-      
+
         helpers.next(function() {
           expect(el._elements.calendar.hidden).to.be.false;
           expect(el._elements.clock.hidden).to.be.true;
           expect(el._elements.toggle.icon).to.equal('calendar');
-        
+
           // we change the type and check the expected display
           el.type = Datepicker.type.TIME;
-        
+
           expect(el._elements.calendar.hidden).to.be.true;
           expect(el._elements.clock.hidden).to.be.false;
           expect(el._elements.toggle.icon).to.equal('clock');
-        
+
           el.type = Datepicker.type.DATETIME;
-        
+
           expect(el._elements.calendar.hidden).to.be.false;
           expect(el._elements.clock.hidden).be.false;
           expect(el._elements.toggle.icon).to.equal('calendar');
-        
+
           done();
         });
       });
-    
+
       it('should close the popover when a date is clicked', function(done) {
         const el = helpers.build(window.__html__['Datepicker.value.html']);
 
         el.on('coral-overlay:open', function() {
           expect(el.getAttribute('aria-expanded')).to.equal('true');
         });
-        
+
         el.on('coral-overlay:close', function() {
           expect(el.getAttribute('aria-expanded')).to.equal('false');
 
@@ -923,28 +938,28 @@ describe('Datepicker', function() {
 
         // checks that initial value
         expect(el.value).to.equal('2000-12-31');
-      
+
         // we open the calendar to select a new date
         el._elements.toggle.click();
-      
+
         // Overlay does not open immediately any longer
         helpers.next(function() {
           var cell = el._elements.calendar._elements.body.querySelector('a');
-        
+
           cell.click();
-        
+
           expect(el.value).to.equal(cell.dataset.date);
           expect(el._elements.overlay.open).to.be.false;
         });
       });
-    
+
       it('should close the popover when the same date is clicked', function(done) {
         const el = helpers.build(window.__html__['Datepicker.value.html']);
 
         el.on('coral-overlay:open', function() {
           expect(el.getAttribute('aria-expanded')).to.equal('true');
         });
-        
+
         el.on('coral-overlay:close', function() {
           expect(el.getAttribute('aria-expanded')).to.equal('false');
 
@@ -953,29 +968,29 @@ describe('Datepicker', function() {
 
         // checks that initial value
         expect(el.value).to.equal('2000-12-31');
-      
+
         // we open the calendar to select a new date
         el._elements.toggle.click();
-      
+
         // Overlay does not open immediately any longer
         helpers.next(function() {
           var cell = el._elements.calendar._elements.body.querySelector('a[data-date="2000-12-31"]');
           expect(cell.dataset.date).to.equal('2000-12-31');
-        
+
           cell.click();
-        
+
           expect(el.value).to.equal(cell.dataset.date);
           expect(el._elements.overlay.open).to.be.false;
         });
       });
-    
+
       it('should close the popover when the same date is clicked', function(done) {
         const el = helpers.build(window.__html__['Datepicker.value.html']);
 
         el.on('coral-overlay:open', function() {
           expect(el.getAttribute('aria-expanded')).to.equal('true');
         });
-        
+
         el.on('coral-overlay:close', function() {
           expect(el.getAttribute('aria-expanded')).to.equal('false');
 
@@ -984,34 +999,34 @@ describe('Datepicker', function() {
 
         // checks that initial value
         expect(el.value).to.equal('2000-12-31');
-      
+
         // we open the calendar to select a new date
         el._elements.toggle.click();
-      
+
         // Overlay does not open immediately any longer
         helpers.next(function() {
           var cell = el._elements.calendar._elements.body.querySelector('a[data-date="2000-12-31"]');
           expect(cell.dataset.date).to.equal('2000-12-31');
-        
+
           cell.click();
-        
+
           expect(el.value).to.equal(cell.dataset.date);
           expect(el._elements.overlay.open).to.be.false;
         });
       });
-  
+
       describe('Tracking', function() {
         var trackerFnSpy;
-    
+
         beforeEach(function() {
           trackerFnSpy = sinon.spy();
           tracking.addListener(trackerFnSpy);
         });
-    
+
         afterEach(function() {
           tracking.removeListener(trackerFnSpy);
         });
-    
+
         it('should call tracker callback with the expected tracker data when toggle button is clicked', function(done) {
           const el = helpers.build(window.__html__['Datepicker.base.trackingOnWithAttributes.html']);
           el._elements.toggle.click();
@@ -1028,7 +1043,7 @@ describe('Datepicker', function() {
             done();
           });
         });
-    
+
         it('should call tracker callback with the expected tracker data when value is manually changed', function(done) {
           const el = helpers.build(window.__html__['Datepicker.base.trackingOnWithAttributes.html']);
           var inputEl = el._elements.input;
@@ -1047,11 +1062,11 @@ describe('Datepicker', function() {
           });
         });
       });
-  
+
       describe('Smart Overlay', () => {
         helpers.testSmartOverlay('coral-datepicker');
       });
-  
+
       describe('#formField', function() {
         helpers.testFormField(window.__html__['Datepicker.value.html'], {
           value: '2014-12-31'

--- a/coral-component-select/src/scripts/Select.js
+++ b/coral-component-select/src/scripts/Select.js
@@ -23,9 +23,9 @@ import {transform, validate, commons, i18n, Keys} from '../../../coral-utils';
 
 /**
  Enumeration for {@link Select} variants.
- 
+
  @typedef {Object} SelectVariantEnum
- 
+
  @property {String} DEFAULT
  A default, gray Select.
  @property {String} QUIET
@@ -43,12 +43,12 @@ const IS_MOBILE_DEVICE = navigator.userAgent.match(/iPhone|iPad|iPod|Android/i) 
 
 /**
  Extracts the value from the item in case no explicit value was provided.
- 
+
  @param {HTMLElement} item
  the item whose value will be extracted.
- 
+
  @returns {String} the value that will be submitted for this item.
- 
+
  @private
  */
 const itemValueFromDOM = function(item) {
@@ -59,10 +59,10 @@ const itemValueFromDOM = function(item) {
 
 /**
  Calculates the difference between two given arrays. It returns the items that are in a that are not in b.
- 
+
  @param {Array.<String>} a
  @param {Array.<String>} b
- 
+
  @returns {Array.<String>}
  the difference between the arrays.
  */
@@ -87,31 +87,31 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     // Templates
     this._elements = {};
     base.call(this._elements, {commons, Icon, i18n});
-    
+
     const events = {
       'global:click': '_onGlobalClick',
       'global:touchstart': '_onGlobalClick',
-      
+
       'coral-collection:add coral-taglist': '_onInternalEvent',
       'coral-collection:remove coral-taglist': '_onInternalEvent',
-  
+
       // item events
       'coral-select-item:_valuechanged coral-select-item': '_onItemValueChange',
       'coral-select-item:_contentchanged coral-select-item': '_onItemContentChange',
       'coral-select-item:_disabledchanged coral-select-item': '_onItemDisabledChange',
       'coral-select-item:_selectedchanged coral-select-item': '_onItemSelectedChange',
-  
+
       'change coral-taglist': '_onTagListChange',
       'change select': '_onNativeSelectChange',
       'click select': '_onNativeSelectClick',
       'click > ._coral-Dropdown-trigger': '_onButtonClick',
-  
+
       'key:space > ._coral-Dropdown-trigger': '_onSpaceKey',
       'key:enter > ._coral-Dropdown-trigger': '_onSpaceKey',
       'key:return > ._coral-Dropdown-trigger': '_onSpaceKey',
       'key:down > ._coral-Dropdown-trigger': '_onSpaceKey'
     };
-  
+
     // Overlay
     const overlayId = this._elements.overlay.id;
     events[`global:capture:coral-collection:add #${overlayId} coral-selectlist`] = '_onSelectListItemAdd';
@@ -129,19 +129,19 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     // TODO for some reason this disables tabbing into the select
     // events[`global:key:tab #${overlayId} coral-selectlist-item`] = '_onTabKey';
     // events[`global:key:tab+shift #${overlayId} coral-selectlist-item`] = '_onTabKey';
-    
+
     // Attach events
     this._delegateEvents(commons.extend(this._events, events));
-  
+
     // Pre-define labellable element
     this._labellableElement = this._elements.button;
-    
+
     // default value of inner flag to process events
     this._bulkSelectionChange = false;
 
     // we only have AUTO mode.
     this._useNativeInput = IS_MOBILE_DEVICE;
-    
+
     this._elements.taglist.reset = () => {
       // since reseting a form will call the reset on every component, we need to kill the behavior of the taglist
       // otherwise the state will not be accurate
@@ -152,20 +152,20 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     // Init the collection mutation observer
     this.items._startHandlingItems();
   }
-  
+
   /**
    Returns the inner overlay to allow customization.
-   
+
    @type {Popover}
    @readonly
    */
   get overlay() {
     return this._elements.overlay;
   }
-  
+
   /**
    The item collection.
-   
+
    @type {SelectableCollection}
    @readonly
    */
@@ -182,10 +182,10 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     }
     return this._items;
   }
-  
+
   /**
    Indicates whether the select accepts multiple selected values.
-   
+
    @type {Boolean}
    @default false
    @htmlattribute multiple
@@ -197,7 +197,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   set multiple(value) {
     this._multiple = transform.booleanAttr(value);
     this._reflectAttribute('multiple', this._multiple);
-  
+
     // taglist should not be in DOM if multiple === false
     if (!this._multiple) {
       this.removeChild(this._elements.taglist);
@@ -205,14 +205,14 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     else {
       this.appendChild(this._elements.taglist);
     }
-    
+
     // we need to remove and re-add the native select to loose the selection
     if (this._nativeInput) {
       this.removeChild(this._elements.nativeSelect);
     }
     this._elements.nativeSelect.multiple = this._multiple;
     this._elements.nativeSelect.selectedIndex = -1;
-    
+
     if (this._nativeInput) {
       if (this._multiple) {
         // We might not be rendered yet
@@ -224,15 +224,15 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
         this.appendChild(this._elements.nativeSelect);
       }
     }
-    
+
     this._elements.list.multiple = this._multiple;
-    
+
     // sets the correct name for value submission
     this._setName(this.getAttribute('name') || '');
-    
+
     // we need to make sure the selection is valid
     this._setStateFromDOM();
-    
+
     // everytime multiple changes, the state of the selectlist and taglist need to be updated
     this.items.getAll().forEach((item) => {
       if (this._multiple && item.hasAttribute('selected')) {
@@ -241,7 +241,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       else {
         // taglist is never used for multiple = false
         this._removeTagFromTagList(item);
-        
+
         // when multiple = false and the item is selected, the value needs to be updated in the input
         if (item.hasAttribute('selected')) {
           this._elements.input.value = itemValueFromDOM(item);
@@ -249,11 +249,11 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       }
     });
   }
-  
+
   /**
    Contains a hint to the user of what can be selected in the component. If no placeholder is provided, the first
    option will be displayed in the component.
-   
+
    @type {String}
    @default ""
    @htmlattribute placeholder
@@ -274,7 +274,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   set placeholder(value) {
     this._placeholder = transform.string(value);
     this._reflectAttribute('placeholder', this._placeholder);
-    
+
     // case 1:  p +  m +  se = p
     // case 2:  p +  m + !se = p
     // case 6:  p + !m + !se = p
@@ -292,11 +292,11 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     else if (!this.selectedItem) {
       // we clean the value because there is no selected item
       this._elements.input.value = '';
-      
+
       // gets the first candidate for selection
       const placeholderItem = this.items._getFirstSelectable();
       this._elements.label.classList.remove('is-placeholder');
-      
+
       if (placeholderItem) {
         // selects using the attribute in case the item is not yet initialized
         placeholderItem.setAttribute('selected', '');
@@ -308,7 +308,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       }
     }
   }
-  
+
   /**
    Name used to submit the data in a form.
    @type {String}
@@ -323,7 +323,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     this._setName(value);
     this._reflectAttribute('name', this.name);
   }
-  
+
   /**
    This field's current value.
    @type {String}
@@ -339,18 +339,18 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     // we rely on the the values property to handle this correctly
     this.values = [value];
   }
-  
+
   /**
    The current selected values, as submitted during form submission. When {@link Coral.Select#multiple} is
    <code>false</code>, this will be an array of length 1.
-   
+
    @type {Array.<String>}
    */
   get values() {
     if (this.multiple) {
       return this._elements.taglist.values;
     }
-    
+
     // if there is a selection, we return whatever value it has assigned
     return this.selectedItem ? [this._elements.input.value] : [];
   }
@@ -360,10 +360,10 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       if (!this.multiple && values.length > 1) {
         values = [values[0]];
       }
-      
+
       // gets all the items
       const items = this.items.getAll();
-      
+
       let itemValue;
       // if multiple, we need to explicitely set the selection state of every item
       if (this.multiple) {
@@ -380,27 +380,27 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
         let targetItem;
         // since multiple = false, there is only 1 value value
         const value = values[0] || '';
-        
+
         items.forEach((item) => {
           // small optimization to avoid calculating the value from every item
           if (!targetItem) {
             itemValue = itemValueFromDOM(item);
-            
+
             if (itemValue === value) {
               // selecting the item will cause the taglist or input to be updated
               item.setAttribute('selected', '');
               // we store the first ocurrence, afterwards we deselect all items
               targetItem = item;
-              
+
               // since we found our target item, we continue to avoid removing the selected attribute
               return;
             }
           }
-          
+
           // every-non targetItem must be deselected
           item.removeAttribute('selected');
         });
-        
+
         // if no targetItem was found, _setStateFromDOM will make sure that the state is valid
         if (!targetItem) {
           this._setStateFromDOM();
@@ -408,7 +408,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       }
     }
   }
-  
+
   /**
    Whether this field is disabled or not.
    @type {Boolean}
@@ -422,16 +422,16 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   set disabled(value) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
-    
+
     this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
     this.classList.toggle('is-disabled', this._disabled);
-    
+
     const isReadOnly = this.hasAttribute('readonly');
-    this._elements.button.disabled = this._disabled || isReadOnly;
-    this._elements.input.disabled = this._disabled || isReadOnly;
-    this._elements.taglist.disabled = this._disabled || isReadOnly;
+    this._elements.button.disabled = this._disabled;
+    this._elements.input.disabled = this._disabled;
+    this._elements.taglist.disabled = this._disabled;
   }
-  
+
   /**
    Inherited from {@link BaseFormField#invalid}.
    */
@@ -440,12 +440,12 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   set invalid(value) {
     super.invalid = value;
-    
+
     this.classList.toggle('is-invalid', this.invalid);
     this._elements.button.classList.toggle('is-invalid', this.invalid);
     this._elements.invalidIcon.hidden = !this.invalid;
   }
-  
+
   /**
    Whether this field is required or not.
    @type {Boolean}
@@ -459,11 +459,11 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   set required(value) {
     this._required = transform.booleanAttr(value);
     this._reflectAttribute('required', this._required);
-    
+
     this._elements.input.required = this._required;
     this._elements.taglist.required = this._required;
   }
-  
+
   /**
    Whether this field is readOnly or not. Indicating that the user cannot modify the value of the control.
    @type {Boolean}
@@ -477,12 +477,11 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   set readOnly(value) {
     this._readOnly = transform.booleanAttr(value);
     this._reflectAttribute('readonly', this._readOnly);
-    
+
     const isDisabled = this.hasAttribute('disabled');
-    this._elements.button.disabled = this._readOnly || isDisabled;
-    this._elements.input.readOnly = this._readOnly || isDisabled;
-    this._elements.taglist.readOnly = this._readOnly || isDisabled;
-    this._elements.taglist.disabled = this._readOnly || isDisabled;
+    this._elements.input.readOnly = this._readOnly;
+    this._elements.taglist.readOnly = this._readOnly;
+    this._elements.taglist.disabled = this._readOnly;
   }
 
   /**
@@ -493,7 +492,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   }
   set labelled(value) {
     super.labelled = value;
-  
+
     if (this.labelled) {
       if (!this.labelledBy) {
         this._elements.button.setAttribute('aria-labelledby', `${this._elements.button.id} ${this._elements.label.id} ${this.invalid ? this._elements.invalidIcon.id : ''}`);
@@ -507,10 +506,10 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
         this._elements.button.removeAttribute('aria-labelledby');
       }
     }
-    
+
     this._elements.taglist.labelled = value;
   }
-  
+
   /**
    Inherited from {@link BaseFormField#labelledBy}.
    */
@@ -520,7 +519,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   set labelledBy(value) {
     super.labelledBy = value;
     this._labelledBy = super.labelledBy;
-    
+
     if (this._labelledBy) {
       this._elements.button.setAttribute('aria-labelledby', `${this._labelledBy} ${this._elements.label.id} ${this.invalid ? this._elements.invalidIcon.id : ''}`);
       this._elements.nativeSelect.setAttribute('aria-labelledby', this._labelledBy);
@@ -533,24 +532,24 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
         this.labelled = this.labelled;
       }
     }
-    
+
     this._elements.taglist.labelledBy = this._labelledBy;
   }
-  
+
   /**
    Returns the first selected item in the Select. The value <code>null</code> is returned if no element is
    selected.
-   
+
    @type {?HTMLElement}
    @readonly
    */
   get selectedItem() {
     return this.hasAttribute('multiple') ? this.items._getFirstSelected() : this.items._getLastSelected();
   }
-  
+
   /**
    Returns an Array containing the set selected items.
-   
+
    @type {Array.<HTMLElement>}
    @readonly
    */
@@ -558,14 +557,14 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     if (this.hasAttribute('multiple')) {
       return this.items._getAllSelected();
     }
-    
+
     const item = this.selectedItem;
     return item ? [item] : [];
   }
-  
+
   /**
    Indicates that the Select is currently loading remote data. This will set the wait indicator inside the list.
-   
+
    @type {Boolean}
    @default false
    @htmlattribute loading
@@ -573,14 +572,14 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
   get loading() {
     return this._elements.list.loading;
   }
-  
+
   set loading(value) {
     this._elements.list.loading = value;
   }
-  
+
   /**
    The Select's variant. See {@link SelectVariantEnum}.
-   
+
    @type {SelectVariantEnum}
    @default SelectVariantEnum.DEFAULT
    @htmlattribute variant
@@ -593,10 +592,10 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     value = transform.string(value).toLowerCase();
     this._variant = validate.enumeration(variant)(value) && value || variant.DEFAULT;
     this._reflectAttribute('variant', this._variant);
-    
+
     this._elements.button.classList.toggle('_coral-FieldButton--quiet', this._variant === variant.QUIET);
   }
-  
+
   /** @ignore */
   _setName(value) {
     if (this.multiple) {
@@ -608,64 +607,64 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       this._elements.input.name = value;
     }
   }
-  
+
   /**
    @param {Boolean} [checkAvailableSpace=false]
    If <code>true</code>, the event is triggered based on the available space.
-   
+
    @private
    */
   _showOptions(checkAvailableSpace) {
     if (checkAvailableSpace) {
       // threshold in pixels
       const ITEM_SIZE_THRESHOLD = 30;
-      
+
       let scrollHeight = this._elements.list.scrollHeight;
       const viewportHeight = this._elements.list.clientHeight;
       const scrollTop = this._elements.list.scrollTop;
       // we should not do this, but it increases performance since we do not need to find the item
       const loadIndicator = this._elements.list._elements.loadIndicator;
-      
+
       // we remove the size of the load indicator
       if (loadIndicator && loadIndicator.parentNode) {
         const outerHeight = function(el) {
           let height = el.offsetHeight;
           const style = getComputedStyle(el);
-          
+
           height += parseInt(style.marginTop, 10) + parseInt(style.marginBottom, 10);
           return height;
         };
-        
+
         scrollHeight -= outerHeight(loadIndicator);
       }
-      
+
       // if we are not close to the bottom scroll, we cancel triggering the event
       if (scrollTop + viewportHeight < scrollHeight - ITEM_SIZE_THRESHOLD) {
         return;
       }
     }
-    
+
     // we do not show the list with native
     if (!this._useNativeInput) {
       if (!this._elements.overlay.open) {
         // Show the overlay
         this._elements.overlay.open = true;
       }
-  
+
       // Force overlay repositioning (remote loading)
       requestAnimationFrame(() => {
         this._elements.overlay._onAnimate();
         this._elements.overlay.reposition();
       });
     }
-    
+
     // Trigger an event
     // @todo: maybe we should only trigger this event when the button is toggled and we have space for more items
     const event = this.trigger('coral-select:showitems', {
       // amount of items in the select
       start: this.items.length
     });
-    
+
     // while using native there is no need to show the loading
     if (!this._useNativeInput) {
       // if the default is prevented, we should the loading indicator
@@ -675,70 +674,70 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     // communicate expanded state to assistive technology
     this._elements.button.setAttribute('aria-expanded', true);
   }
-  
+
   /** @private */
   _hideOptions() {
     // Don't close the overlay if selection = multiple
     if (!this.multiple) {
       this._elements.overlay.open = false;
-  
+
       this.trigger('coral-select:hideitems');
     }
 
     // communicate collapsed state to assistive technology
     this._elements.button.setAttribute('aria-expanded', false);
   }
-  
+
   /** @ignore */
   _onGlobalClick(event) {
     if (!this._elements.overlay.open) {
       return;
     }
-  
+
     const eventTargetWithinOverlayTarget = this._elements.button.contains(event.target);
     const eventTargetWithinItself = this._elements.overlay.contains(event.target);
     if (!eventTargetWithinOverlayTarget && !eventTargetWithinItself) {
       this._hideOptions();
     }
   }
-  
+
   /** @private */
   _onSelectListItemAdd(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     // When items have been added, we are no longer loading
     this.loading = false;
-    
+
     // Reset height
     this._elements.list.style.height = '';
-    
+
     // Measure actual height
     const style = window.getComputedStyle(this._elements.list);
     const height = parseInt(style.height, 10);
     const maxHeight = parseInt(style.maxHeight, 10);
-    
+
     if (height < maxHeight) {
       // Make it scrollable
       this._elements.list.style.height = `${height - 1}px`;
     }
   }
-  
+
   /** @private */
   _onInternalEvent(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
   }
-  
+
   /** @ignore */
   _onItemAdded(item) {
     const selectListItemParent = this._elements.list;
-  
+
     const selectListItem = item._selectListItem || new SelectList.Item();
-    
+
     // @todo: Make sure it is added at the right index.
     selectListItemParent.appendChild(selectListItem);
-    
+
     selectListItem.set({
       value: item.value,
       content: {
@@ -748,22 +747,22 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       selected: item.selected,
       trackingElement: item.trackingElement
     }, true);
-  
+
     const nativeOption = item._nativeOption || new Option();
-    
+
     // @todo: make sure it is added at the right index.
     this._elements.nativeSelect.appendChild(nativeOption);
-    
+
     // Need to store the initially selected values in the native select so that it can be reset
     if (this._initialValues.indexOf(item.value) !== -1) {
       nativeOption.setAttribute('selected', 'selected');
     }
-    
+
     nativeOption.selected = item.selected;
     nativeOption.value = item.value;
     nativeOption.disabled = item.disabled;
     nativeOption.innerHTML = item.innerHTML;
-    
+
     if (this.multiple) {
       // in case it was selected before it was added
       if (item.selected) {
@@ -774,14 +773,14 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     else if (item.selected) {
       this._elements.input.value = item.value;
     }
-    
+
     item._selectListItem = selectListItem;
     item._nativeOption = nativeOption;
-    
+
     selectListItem._selectItem = item;
     nativeOption._selectItem = item;
   }
-  
+
   /** @private */
   _onItemRemoved(item) {
     if (item._selectListItem) {
@@ -789,26 +788,26 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       item._selectListItem._selectItem = undefined;
       item._selectListItem = undefined;
     }
-    
+
     if (item._nativeOption) {
       this._elements.nativeSelect.removeChild(item._nativeOption);
       item._nativeOption._selectItem = undefined;
       item._nativeOption = undefined;
     }
-    
+
     this._removeTagFromTagList(item, true);
   }
-  
+
   /** @private */
   _onItemSelected(item) {
     // in case the component is not in the DOM or the internals have not been created we force it
     if (!item._selectListItem || !item._selectListItem.parentNode) {
       this._onItemAdded(item);
     }
-    
+
     item._selectListItem.selected = true;
     item._nativeOption.selected = true;
-    
+
     if (this.multiple) {
       this._addTagToTagList(item);
       // @todo: what happens when ALL items have been selected
@@ -819,64 +818,64 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       this._elements.input.value = item.value;
     }
   }
-  
+
   /** @private */
   _onItemDeselected(item) {
     // in case the component is not in the DOM or the internals have not been created we force it
     if (!item._selectListItem || !item._selectListItem.parentNode) {
       this._onItemAdded(item);
     }
-    
+
     item._selectListItem.selected = false;
     item._nativeOption.selected = false;
-    
+
     if (this.multiple) {
       // we use the internal reference to remove the related tag from the taglist
       this._removeTagFromTagList(item);
     }
   }
-  
+
   /**
    Detects when something is about to change inside the select.
-   
+
    @private
    */
   _onSelectListBeforeChange(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     // We prevent the selection to change if we're in single selection and the clicked item is already selected
     if (!this.multiple && event.detail.item.selected) {
       event.preventDefault();
       this._elements.overlay.open = false;
     }
   }
-  
+
   /**
    Detects when something inside the select list changes.
-   
+
    @private
    */
   _onSelectListChange(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     // avoids triggering unnecessary changes in the selectist because selecting items programatically will trigger
     // a change event
     if (this._bulkSelectionChange) {
       return;
     }
-    
+
     let oldSelection = event.detail.oldSelection || [];
     oldSelection = !Array.isArray(oldSelection) ? [oldSelection] : oldSelection;
-  
+
     let selection = event.detail.selection || [];
     selection = !Array.isArray(selection) ? [selection] : selection;
-    
+
     // if the arrays are the same, there is no point in calculating the selection changes
     if (event.detail.oldSelection !== event.detail.selection) {
       this._bulkSelectionChange = true;
-      
+
       // we deselect first the ones that have to go
       const removedSelection = arrayDiff(oldSelection, selection);
       removedSelection.forEach((listItem) => {
@@ -885,7 +884,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
           listItem._selectItem.removeAttribute('selected');
         }
       });
-      
+
       // we only sync the items that changed
       const newSelection = arrayDiff(selection, oldSelection);
       newSelection.forEach((listItem) => {
@@ -893,15 +892,15 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
           listItem._selectItem.setAttribute('selected', '');
         }
       });
-      
+
       this._bulkSelectionChange = false;
-      
+
       // hides the list since something was selected. if the overlay was open, it means there was user interaction so
       // the necessary events need to be triggered
       if (this._elements.overlay.open) {
         // closes and triggers the hideitems event
         this._hideOptions();
-        
+
         // if there is a change in the added or removed selection, we trigger a change event
         if (newSelection.length || removedSelection.length) {
           this.trigger('change');
@@ -914,25 +913,25 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       // closes and triggers the hideitems event
       this._hideOptions();
     }
-  
+
     if (!this.multiple) {
       this._trackEvent('change', 'coral-select-item', event, this.selectedItem);
     }
   }
-  
+
   /** @private */
   _onTagListChange(event) {
     // cancels the change event from the taglist
     event.stopImmediatePropagation();
-    
+
     // avoids triggering unnecessary changes in the selectist because selecting items programatically will trigger
     // a change event
     if (this._bulkSelectionChange) {
       return;
     }
-    
+
     this._bulkSelectionChange = true;
-  
+
     const values = event.target.values;
     // we use the selected items, because they are the only possible items that may change
     let itemValue;
@@ -942,18 +941,18 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       // if the item is inside the values array, then it has to be selected
       item[values.indexOf(itemValue) !== -1 ? 'setAttribute' : 'removeAttribute']('selected', '');
     });
-    
+
     this._bulkSelectionChange = false;
-    
+
     // if the taglist is empty, we should return the focus to the button
     if (!values.length) {
       this._elements.button.focus();
     }
-    
+
     // reparents the change event with the select as the target
     this.trigger('change');
   }
-  
+
   /** @private */
   _addTagToTagList(item) {
     // we prepare the tag
@@ -964,11 +963,11 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
         innerHTML: item.innerHTML
       }
     }, true);
-    
+
     // we add the new tag at the end
     this._elements.taglist.items.add(item._tag);
   }
-  
+
   /** @private */
   _removeTagFromTagList(item, destroy) {
     if (item._tag) {
@@ -977,31 +976,31 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       item._tag = destroy ? undefined : item._tag;
     }
   }
-  
+
   /** @private */
   _onSelectListScrollBottom(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     if (this._elements.overlay.open) {
       // Checking if the overlay is open guards against debounced scroll events being handled after an overlay has
       // already been closed (e.g. clicking the last element in a selectlist always reopened the overlay emediately
       // after closing)
-      
+
       // triggers the corresponding event
       // since we got the the event from select list we need to trigger the event
       this._showOptions();
     }
   }
-  
+
   /** @private */
   _onButtonClick(event) {
     event.preventDefault();
-    
-    if (this.disabled) {
+
+    if (this.disabled || this.readOnly) {
       return;
     }
-    
+
     // if native is required, we do not need to do anything
     if (!this._useNativeInput) {
       // @todo: this was removed cause otherwise the coral-select:showitems event is never triggered.
@@ -1010,7 +1009,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       // if (this.multiple && this.selectedItems.length === this.items.length) {
       //   return;
       // }
-      
+
       // Toggle openness
       if (this._elements.overlay.classList.contains('is-open')) {
         this._hideOptions();
@@ -1021,25 +1020,25 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       }
     }
   }
-  
+
   /** @private */
   _onNativeSelectClick() {
     this._showOptions(false);
   }
-  
+
   _onOverlayKeyPress(event) {
     // Focus on item which text starts with pressed keys
     this._elements.list._onKeyPress(event);
   }
-  
+
   /** @private */
   _onSpaceKey(event) {
-    if (this.disabled) {
+    if (this.disabled || this.readOnly) {
       return;
     }
-    
+
     event.preventDefault();
-    
+
     if (this._useNativeInput) {
       // we try to open the native select
       this._elements.nativeSelect.dispatchEvent(new MouseEvent('mousedown'));
@@ -1048,77 +1047,77 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       this._elements.button.click();
     }
   }
-  
+
   /**
    Prevents tab key default handling on selectList Items.
-   
+
    @private
    */
   // _onTabKey(event) {
   // event.preventDefault();
   // }
-  
+
   /** @private */
   _onOverlayToggle(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     // Trigger private event instead
     const type = event.type.split(':').pop();
     this.trigger(`coral-select:_overlay${type}`);
-    
+
     this._elements.button.classList.toggle('is-selected', event.target.open);
 
     // communicate expanded state to assistive technology
     this._elements.button.setAttribute('aria-expanded', event.target.open);
-    
+
     if (!event.target.open) {
       this.classList.remove('is-openAbove', 'is-openBelow');
     }
   }
-  
+
   /** @private */
   _onOverlayPositioned(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     if (this._elements.overlay.open) {
       this._elements.overlay.style.width = `${this.offsetWidth}px`;
     }
   }
-  
+
   // @todo: while the select is multiple, if everything is deselected no change event will be triggered.
   _onNativeSelectChange(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     // avoids triggering unnecessary changes in the selectist because selecting items programatically will trigger
     // a change event
     if (this._bulkSelectionChange) {
       return;
     }
-    
+
     this._bulkSelectionChange = true;
     // extracts the native options for the selected items. We use the selected options, instead of the complete
     // options to make the diff since it will normally be a smaller set
     const oldSelectedOptions = this.selectedItems.map((element) => element._nativeOption);
-    
+
     // we convert the HTMLCollection to an array
     const selectedOptions = Array.prototype.slice.call(event.target.querySelectorAll(':checked'));
-    
+
     const diff = arrayDiff(oldSelectedOptions, selectedOptions);
     diff.forEach((item) => {
       item._selectItem.selected = false;
     });
-    
+
     // we only sync the items that changed
     const newSelection = arrayDiff(selectedOptions, oldSelectedOptions);
     newSelection.forEach((item) => {
       item._selectItem.selected = true;
     });
-    
+
     this._bulkSelectionChange = false;
-    
+
     // since multiple keeps the select open, we cannot return the focus to the button otherwise the user cannot
     // continue selecting values
     if (!this.multiple) {
@@ -1127,43 +1126,43 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       // since selecting an item closes the native select, we need to trigger an event
       this.trigger('coral-select:hideitems');
     }
-    
+
     // if the native change event was triggered, then it means there is some new value
     this.trigger('change');
   }
-  
+
   /**
    This handles content change of coral-select-item and updates its associatives.
-   
+
    @private
    */
   _onItemContentChange(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     const item = event.target;
     if (item._selectListItem) {
       const content = new SelectList.Item.Content();
       content.innerHTML = item.innerHTML;
       item._selectListItem.content = content;
     }
-    
+
     if (item._nativeOption) {
       item._nativeOption.innerHTML = item.innerHTML;
     }
-    
+
     if (item._tag && item._tag.label) {
       item._tag.label.innerHTML = item.innerHTML;
     }
-    
+
     // since the content changed, we need to sync the placeholder in case it was the selected item
     this._syncSelectedItemPlaceholder();
   }
-  
+
   /** @private */
   _syncSelectedItemPlaceholder() {
     this.placeholder = this.getAttribute('placeholder');
-    
+
     // case 3: !p + !m +  se = se
     // case 5:  p + !m +  se = se
     if (this.selectedItem && !this.multiple) {
@@ -1171,72 +1170,72 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       this._elements.label.innerHTML = this.selectedItem.innerHTML;
     }
   }
-  
+
   /**
    This handles value change of coral-select-item and updates its associatives.
-   
+
    @private
    */
   _onItemValueChange(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     const item = event.target;
     if (item._selectListItem) {
       item._selectListItem.value = item.value;
     }
-    
+
     if (item._nativeOption) {
       item._nativeOption.value = item.value;
     }
-    
+
     if (item._tag) {
       item._tag.value = item.value;
     }
   }
-  
+
   /**
    This handles disabled change of coral-select-item and updates its associatives.
-   
+
    @private
    */
   _onItemDisabledChange(event) {
     // stops propagation cause the event is internal to the component
     event.stopImmediatePropagation();
-    
+
     const item = event.target;
     if (item._selectListItem) {
       item._selectListItem.disabled = item.disabled;
     }
-    
+
     if (item._nativeOption) {
       item._nativeOption.disabled = item.disabled;
     }
   }
-  
+
   /**
    In case an item from the initial selection is removed, we need to remove it from the initial values.
-   
+
    @private
    */
   _validateInitialState(nodes) {
     let item;
     let index;
-    
+
     // we iterate over all the nodes, checking if they matched the initial value
     for (let i = 0, nodeCount = nodes.length; i < nodeCount; i++) {
       // since we are not sure if the item has been upgraded, we try first the attribute, otherwise we extract the
       // value from the textContent
       item = nodes[i];
-      
+
       index = this._initialValues.indexOf(item.value);
-      
+
       if (index !== -1) {
         this._initialValues.splice(index, 1);
       }
     }
   }
-  
+
   /** @private */
   // eslint-disable-next-line no-unused-vars
   _onCollectionChange(addedNodes, removedNodes) {
@@ -1245,20 +1244,20 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     // makes sure that the selection state matches the multiple variable
     this._setStateFromDOM();
   }
-  
+
   /**
    Updates the label to reflect the current state. The label needs to be updated when the placeholder changes and
    when the selection changes.
-   
+
    @private
    */
   _updateLabel() {
     this._syncSelectedItemPlaceholder();
   }
-  
+
   /**
    Handles the selection state.
-   
+
    @ignore
    */
   _setStateFromDOM() {
@@ -1266,22 +1265,22 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     if (!this.hasAttribute('multiple')) {
       // makes sure that only one is selected
       this.items._deselectAllExceptLast();
-      
+
       // we execute _getFirstSelected instead of _getSelected because it is faster
       const selectedItem = this.items._getFirstSelected();
-      
+
       // case 1. there is a selected item, so no further change is required
       // case 2. no selected item and no placeholder. an item will be automatically selected
       // case 3. no selected item and a placehoder. we just make sure the value is really empty
       if (!selectedItem) {
         // we clean the value because there is no selected item
         this._elements.input.value = '';
-        
+
         // when there is no placeholder, we need to force a selection to behave like the native select
         if (transform.string(this.getAttribute('placeholder')) === '') {
           // gets the first candidate for selection
           const selectable = this.items._getFirstSelectable();
-          
+
           if (selectable) {
             // selects using the attribute in case the item is not yet initialized
             selectable.setAttribute('selected', '');
@@ -1295,34 +1294,34 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
         this._elements.input.value = itemValueFromDOM(selectedItem);
       }
     }
-    
+
     // handles the initial item in the select
     this._updateLabel();
   }
-  
+
   /**
    Handles selecting multiple items. Selection could result a single or multiple selected items.
-   
+
    @private
    */
   _onItemSelectedChange(event) {
     // we stop propagation since it is a private event
     event.stopImmediatePropagation();
-    
+
     // the item that was selected
     const item = event.target;
-    
+
     // setting this to true will ignore any changes from the selectlist al
     this._bulkSelectionChange = true;
-    
+
     // when the item is selected, we need to enforce the selection mode
     if (item.selected) {
       this._onItemSelected(item);
-  
+
       if (this.multiple) {
         this._trackEvent('select', 'coral-select-item', event, item);
       }
-      
+
       // enforces the selection mode
       if (!this.hasAttribute('multiple')) {
         this.items._deselectAllExcept(item);
@@ -1330,28 +1329,28 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     }
     else {
       this._onItemDeselected(item);
-  
+
       if (this.multiple) {
         this._trackEvent('deselect', 'coral-select-item', event, item);
       }
     }
-    
+
     this._bulkSelectionChange = false;
-    
+
     // since there is a change in selection, we need to update the placeholder
     this._updateLabel();
   }
-  
+
   /**
    Inherited from {@link BaseFormField#clear}.
    */
   clear() {
     this.value = '';
   }
-  
+
   /**
    Focuses the component.
-   
+
    @ignore
    */
   focus() {
@@ -1359,7 +1358,7 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       this._elements.button.focus();
     }
   }
-  
+
   /**
    Inherited from {@link BaseFormField#reset}.
    */
@@ -1367,23 +1366,23 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     // reset the values to the initial values
     this.values = this._initialValues;
   }
-  
+
   /**
    Returns {@link Select} variants.
-   
+
    @return {SelectVariantEnum}
    */
   static get variant() { return variant; }
-  
+
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat(['variant', 'multiple', 'placeholder', 'loading']);
   }
-  
+
   /** @ignore */
   connectedCallback() {
     super.connectedCallback();
-    
+
     const overlay = this._elements.overlay;
     // Cannot be open by default when rendered
     overlay.removeAttribute('open');
@@ -1392,32 +1391,32 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       overlay._parent.appendChild(overlay);
     }
   }
-  
+
   /** @ignore */
   render() {
     super.render();
-    
+
     this.classList.add(CLASSNAME);
-  
+
     // Default reflected attributes
     if (!this._variant) { this.variant = variant.DEFAULT; }
-    
+
     this.classList.toggle(`${CLASSNAME}--native`, this._useNativeInput);
-  
+
     if (!this._useNativeInput && this.contains(this._elements.nativeSelect)) {
       this.removeChild(this._elements.nativeSelect);
     }
-    
+
     // handles the initial selection
     this._setStateFromDOM();
-    
+
     // we need to keep a state of the initial items to be able to reset the component. values is not reliable during
     // initialization since items are not yet initialized
     this.selectedItems.forEach((item) => {
       // we use DOM API instead of properties in case the item is not yet initialized
       this._initialValues.push(itemValueFromDOM(item));
     });
-  
+
     // Cleanup template elements (supporting cloneNode)
     const templateElements = this.querySelectorAll('[handle]');
     for (let i = 0; i < templateElements.length; ++i) {
@@ -1426,28 +1425,28 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
         this.removeChild(currentElement);
       }
     }
-  
+
     // Render the main template
     const frag = document.createDocumentFragment();
-    
+
     frag.appendChild(this._elements.button);
     frag.appendChild(this._elements.input);
     frag.appendChild(this._elements.nativeSelect);
     frag.appendChild(this._elements.taglist);
     frag.appendChild(this._elements.overlay);
-  
+
     // Assign the button as the target for the overlay
     this._elements.overlay.target = this._elements.button;
     // handles the focus allocation every time the overlay closes
     this._elements.overlay.returnFocusTo(this._elements.button);
-    
+
     this.appendChild(frag);
   }
-  
+
   /** @ignore */
   disconnectedCallback() {
     super.disconnectedCallback();
-    
+
     const overlay = this._elements.overlay;
     // In case it was moved out don't forget to remove it
     if (!this.contains(overlay)) {
@@ -1455,22 +1454,22 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
       overlay.remove();
     }
   }
-  
+
   /**
    Triggered when the {@link Select} could accept external data to be loaded by the user. If <code>preventDefault()</code> is
    called, then a loading indicator will be shown. {@link Select#loading} should be set to false to indicate
    that the data has been successfully loaded.
-   
+
    @typedef {CustomEvent} coral-select:showitems
-   
+
    @property {Number} detail.start
    The count of existing items, which is the index where new items should start.
    */
-  
+
   /**
    Triggered when the {@link Select} hides the UI used to select items. This is typically used to cancel a load request
    because the items will not be shown anymore.
-   
+
    @typedef {CustomEvent} coral-select:hideitems
    */
 }

--- a/coral-component-select/src/tests/test.Select.js
+++ b/coral-component-select/src/tests/test.Select.js
@@ -44,17 +44,17 @@ describe('Select', function() {
       const el = helpers.build('<coral-select></coral-select>');
       testDefaultInstance(el);
     });
-  
+
     helpers.cloneComponent(
       'should be possible to clone using markup',
       helpers.build(window.__html__['Select.multiple.base.html'])
     );
-  
+
     helpers.cloneComponent(
       'should be possible to clone using markup with framework data',
       window.__html__['Select.mustache.html']
     );
-  
+
     helpers.cloneComponent(
       'should be possible to clone using js',
       new Select()
@@ -87,7 +87,7 @@ describe('Select', function() {
       el.items.add(item1);
       el.items.add(item2);
       el.items.add(item3);
-      
+
       // Wait for MO
       helpers.next(function() {
         done();
@@ -105,7 +105,7 @@ describe('Select', function() {
 
         // selects the second item
         item2.selected = true;
-        
+
         expect(el.placeholder).to.equal('');
         expect(el._elements.label.textContent.trim()).to.equal(item2.content.textContent);
       });
@@ -113,21 +113,21 @@ describe('Select', function() {
       // case 3: !p + !m +  se = se
       it('should correctly change to selected item after changing from multiple to single', function() {
         el.multiple = true;
-        
+
         expect(el.placeholder).to.equal('');
-  
+
         // selects an item
         item1.selected = true;
         item2.selected = true;
-        
+
         expect(el.selectedItem).to.equal(item1);
         expect(el.selectedItems).to.deep.equal([item1, item2]);
         // should update to the default placeholder for multiple
         expect(el._elements.label.textContent).to.equal('Select');
-  
+
         // we switch back to single
         el.multiple = false;
-  
+
         // should switch to the 2nd item
         expect(el._elements.label.innerHTML).to.equal(item2.content.innerHTML);
       });
@@ -159,13 +159,13 @@ describe('Select', function() {
         el.multiple = true;
 
         expect(el.placeholder).to.equal('');
-        
+
         // should update to the default placeholder for multiple
         expect(el._elements.label.textContent).to.equal('Select');
 
         // we switch back to single
         el.multiple = false;
-        
+
         // should show the first item since there is no placeholder
         expect(el._elements.label.innerHTML).to.equal(item1.content.innerHTML);
       });
@@ -174,7 +174,7 @@ describe('Select', function() {
       it('should show "Select" if no placeholder, multiple and nothing selected', function() {
         el.multiple = true;
         el.selectedItem.selected = false;
-        
+
         expect(el.placeholder).to.equal('');
         expect(el._elements.label.textContent).to.equal('Select');
       });
@@ -186,14 +186,14 @@ describe('Select', function() {
         expect(el.multiple).to.be.false;
         // with no placeholder
         expect(el.placeholder).to.equal('');
-        
+
         // should show the first item since there is no placeholder
         expect(el._elements.label.innerHTML).to.equal(item1.content.innerHTML);
 
         // activates the multiple
         el.multiple = true;
         el.selectedItem.selected = false;
-        
+
         // should update to the default placeholder for multiple
         expect(el._elements.label.textContent).to.equal('Select');
       });
@@ -226,7 +226,7 @@ describe('Select', function() {
         // we change to multiple to see if the label is correctly updated
         el.multiple = true;
         item1.selected = true;
-        
+
         // should show the default placeholder since we are multiple
         expect(el._elements.label.textContent).to.equal('Select');
       });
@@ -237,7 +237,7 @@ describe('Select', function() {
 
         // selects the second item
         item2.selected = true;
-        
+
         expect(el.placeholder).to.equal('Choose an item');
         expect(el._elements.label.innerHTML).to.equal(item2.content.innerHTML);
         expect(el.selectedItems).to.deep.equal([item2]);
@@ -249,7 +249,7 @@ describe('Select', function() {
 
         // since the select was initialized without a placeholder we revert the forced selection
         item1.selected = false;
-        
+
         expect(el._elements.label.innerHTML).to.equal('Choose an item');
         expect(el.selectedItems).to.deep.equal([]);
       });
@@ -261,7 +261,7 @@ describe('Select', function() {
 
         item1.selected = true;
         item2.selected = true;
-        
+
         expect(el.placeholder).to.equal('Choose an item');
         expect(el._elements.label.innerHTML).to.equal('Choose an item');
         expect(el.selectedItems).to.deep.equal([item1, item2]);
@@ -272,7 +272,7 @@ describe('Select', function() {
         el.placeholder = 'Choose an item';
 
         el.multiple = true;
-        
+
         expect(el.placeholder).to.equal('Choose an item');
         expect(el._elements.label.innerHTML).to.equal('Choose an item');
         expect(el.selectedItem).to.equal(item1);
@@ -284,7 +284,7 @@ describe('Select', function() {
 
         // selects the second item
         item2.selected = true;
-      
+
         expect(el.placeholder).to.equal('Choose an item');
         expect(el._elements.label.innerHTML).to.equal(item2.content.innerHTML);
         expect(el.selectedItems).to.deep.equal([item2]);
@@ -301,7 +301,7 @@ describe('Select', function() {
 
         // selects the second item
         item2.selected = true;
-        
+
         expect(el.placeholder).to.equal('Choose an item');
         expect(el._elements.label.innerHTML).to.equal(item2.content.innerHTML);
         expect(el.selectedItems).to.deep.equal([item2]);
@@ -314,7 +314,7 @@ describe('Select', function() {
         // we wait for the MO to kick in
         helpers.next(function() {
           expect(el._elements.label.innerHTML).to.equal('Choose an item');
-          
+
           done();
         });
       });
@@ -353,7 +353,7 @@ describe('Select', function() {
       el.items.add(item1);
       el.items.add(item2);
       el.items.add(item3);
-      
+
       // Wait for MO
       helpers.next(function() {
         done();
@@ -377,7 +377,7 @@ describe('Select', function() {
 
         item3.selected = true;
         expect(el.selectedItem).to.equal(item3);
-        
+
         expect(el._elements.label.textContent).to.equal(item3.textContent, 'label should match the selected item');
         // we remove all items which should cause the placeholder to fallback to the initial value
         el.items.clear();
@@ -387,7 +387,7 @@ describe('Select', function() {
           expect(el.items.length).to.equal(0);
           expect(el.selectedItems).to.deep.equal([]);
           expect(el._elements.label.textContent).to.equal(el.placeholder, 'label should be the placeholder');
-          
+
           done();
         });
       });
@@ -413,7 +413,7 @@ describe('Select', function() {
       it('should default to the first item when the placeholder is removed', function() {
         // removing the placeholder should cause the select to find a candiate for selection
         el.placeholder = '';
-        
+
         expect(el.selectedItem).to.equal(el.items.first());
         expect(el._elements.label.textContent).to.equal(el.items.first().textContent);
       });
@@ -434,7 +434,7 @@ describe('Select', function() {
         expect(el._elements.nativeSelect.value).to.equal(item2.value);
 
         item2.remove();
-        
+
         // Wait for MO
         helpers.next(function() {
           expect(el.selectedItem).to.be.null;
@@ -504,7 +504,7 @@ describe('Select', function() {
         item1.selected = false;
         item2.selected = true;
         item3.selected = true;
-        
+
         expect(el.selectedItem).to.equal(item2, 'item2 should be selected because it is the first selected one');
         expect(el.selectedItems).to.deep.equal([item2, item3], 'both items should be selected');
 
@@ -539,7 +539,7 @@ describe('Select', function() {
 
         item2.selected = true;
         item3.selected = true;
-      
+
         expect(el.selectedItem).to.equal(item2, 'item2 should be selected because it is the first selected one.');
         expect(el.selectedItems).to.deep.equal([item2, item3], 'Both items should be selected');
 
@@ -550,49 +550,49 @@ describe('Select', function() {
         // expect(el._elements.nativeSelect.selectedOptions.length).to.equal(2, 'there should be two selected options');
         expect(el._elements.list.selectedItems.length).to.equal(2, 'there should be two selected items');
         expect(el._elements.taglist.items.length).to.equal(2, 'there should be two taglist items');
-        
+
         el.multiple = false;
-  
+
         // we check the internals to make sure the selection is correct
         expect(el.selectedItem).to.equal(item3, 'the last item should remain selected');
         expect(el.selectedItems).to.deep.equal([item3]);
-  
+
         expect(el.value).to.equal('3');
         expect(el.values).to.deep.equal(['3']);
-  
+
         // expect(el._elements.nativeSelect.selectedOptions.length).to.equal(1, 'there should be one selected option');
         expect(el._elements.list.selectedItems.length).to.equal(1, 'there should be one selected item');
         expect(el._elements.taglist.items.length).to.equal(0, 'there should be zero taglist items');
-        
+
         // now instead of showing 'Select', the actual item needs to be shown
         expect(el._elements.label.textContent).to.equal(item3.content.textContent);
       });
 
       it('should have tags when switched from single to multiple', function() {
         expect(el.multiple).to.be.false;
-  
+
         // changes selection to 2nd item
         item2.selected = true;
-  
+
         expect(el.selectedItem).to.equal(item2);
         expect(el.selectedItems).to.deep.equal([item2]);
-  
+
         expect(el.value).to.equal('2', 'there should be the value of the 2nd item');
         expect(el.values).to.deep.equal(['2'], 'there should be the array with value of the 2nd item');
-  
+
         // we check the internals to make sure the selection is correct
         // expect(el._elements.nativeSelect.selectedOptions.length).to.equal(1, 'there should be one selected option');
         expect(el._elements.list.selectedItems.length).to.equal(1, 'there should be one selected item');
         expect(el._elements.taglist.items.length).to.equal(0, 'there should be zero taglist items');
-  
+
         el.multiple = true;
-  
+
         expect(el.selectedItem).to.equal(item2);
         expect(el.selectedItems).to.deep.equal([item2]);
-  
+
         expect(el.value).to.equal('2', 'there should be the value two');
         expect(el.values).to.deep.equal(['2'], 'there should be the array with value two');
-  
+
         // we check the internals to make sure the selection is correct
         // expect(el._elements.nativeSelect.selectedOptions.length).to.equal(1, 'there should be one selected option');
         expect(el._elements.list.selectedItems.length).to.equal(1, 'there should be one selected item');
@@ -707,13 +707,13 @@ describe('Select', function() {
 
       it('should deselect the other items', function() {
         el.value = '2';
-        
+
         expect(el.value).to.equal('2');
         expect(item2.selected).to.be.true;
         expect(el.selectedItem).to.equal(item2);
-  
+
         el.value = '3';
-  
+
         expect(el.value).to.equal('3');
         expect(item2.selected).to.be.false;
         expect(item3.selected).to.be.true;
@@ -725,7 +725,7 @@ describe('Select', function() {
         item3.value = '2';
 
         el.value = '2';
-        
+
         expect(el.value).to.equal('2');
         expect(item2.selected).to.be.true;
         // should be deselected because item2 was found first
@@ -734,21 +734,21 @@ describe('Select', function() {
 
       it('should default to empty string when multiple', function() {
         el.multiple = true;
-        
+
         expect(el.value).to.equal('');
       });
 
       it('should deselect all other items when multiple', function() {
         el.multiple = true;
         el.value = '2';
-  
+
         expect(el.value).to.equal('2');
         expect(item2.selected).to.be.true;
         expect(el.selectedItem).to.equal(item2);
         expect(el.selectedItems).to.deep.equal([item2]);
-  
+
         el.value = '3';
-  
+
         expect(el.value).to.equal('3');
         expect(item2.selected).to.be.false;
         expect(item3.selected).to.be.true;
@@ -761,7 +761,7 @@ describe('Select', function() {
 
         // sets an invalid value
         el.value = '10';
-        
+
         // since the value was invalid, it should default to empty string
         expect(el.value).to.equal('');
         expect(el.selectedItem).to.be.null;
@@ -774,7 +774,7 @@ describe('Select', function() {
 
         // sets an empty value
         el.value = '';
-        
+
         // since the value was empty, it should default to placeholder string
         expect(el._elements.label.textContent).to.equal(el.placeholder);
       });
@@ -809,7 +809,7 @@ describe('Select', function() {
       it('should get an array with the first item when there is no placeholder and multiple=false', function() {
         // setting the placeholder as empty will cause the first item to be selected
         el.placeholder = '';
-        
+
         expect(el.values).to.deep.equal(['1']);
       });
 
@@ -946,7 +946,7 @@ describe('Select', function() {
         var form = document.createElement('form');
         form.appendChild(el);
         helpers.target.appendChild(form);
-        
+
         el.name = 'select';
         item2.selected = true;
 
@@ -972,9 +972,9 @@ describe('Select', function() {
         var template = document.createElement('template');
         template.innerHTML = '<coral-select id="select"><coral-select-item value="abc" selected></coral-select-item></coral-select>';
         var frag = document.importNode(template.content, true);
-        
+
         helpers.target.appendChild(frag);
-  
+
         var el = document.getElementById('select');
         expect(el._elements.input.value).to.equal('abc');
         expect(el.value).to.equal(el._elements.input.value);
@@ -983,27 +983,27 @@ describe('Select', function() {
       it('should submit multiple values when multiple', function() {
         // we make sure it is multiple
         el.multiple = true;
-  
+
         // we wrap first the select
         var form = document.createElement('form');
         form.appendChild(el);
         helpers.target.appendChild(form);
-  
+
         el.name = 'select';
         item2.selected = true;
         item3.selected = true;
-  
+
         expect(el.name).to.equal('select');
         expect(el.selectedItems).to.deep.equal([item2, item3]);
         expect(el._elements.input.name).to.equal('');
         expect(el._elements.taglist.name).to.equal('select');
-  
+
         // the native has the first value
         expect(el._elements.nativeSelect.multiple).to.be.true;
         expect(el._elements.nativeSelect.value).to.equal(item2.value);
-  
+
         expect(el._elements.nativeSelect.selectedOptions.length).to.equal(2);
-  
+
         expect(helpers.serializeArray(form)).to.deep.equal([{
           name: 'select',
           value: '2'
@@ -1144,13 +1144,13 @@ describe('Select', function() {
     describe('#clear()', function() {
       it('should default value "" when placeholder is available', function() {
         expect(el.placeholder).not.to.equal('');
-  
+
         item2.selected = true;
         expect(el.selectedItem).to.equal(item2);
         expect(el._elements.label.textContent).to.equal(item2.textContent, 'label should be updated to the item');
-  
+
         el.clear();
-  
+
         expect(el.selectedItem).to.equal(null, 'no item should be selected');
         expect(el.value).to.equal('', 'new value should be empty string');
         expect(el._elements.label.textContent).to.equal(el.placeholder, 'label should match the placeholder');
@@ -1158,13 +1158,13 @@ describe('Select', function() {
 
       it('should default to the first item when placeholder is not available', function() {
         el.placeholder = '';
-  
+
         item2.selected = true;
         expect(el.selectedItem).to.equal(item2);
         expect(el._elements.label.textContent).to.equal(item2.textContent, 'label should be updated to the item');
-  
+
         el.clear();
-  
+
         expect(el.selectedItem).to.equal(item1, 'should automatically select the first item');
         expect(el.value).to.equal(item1.value, 'should have the value of the first item');
         expect(el._elements.label.textContent).to.equal(item1.textContent, 'label should match the first item');
@@ -1174,13 +1174,13 @@ describe('Select', function() {
         expect(el.placeholder).not.to.equal('');
 
         el.multiple = true;
-  
+
         item2.selected = true;
         expect(el.selectedItem).to.equal(item2);
         expect(el._elements.label.textContent).to.equal(el.placeholder, 'label should match the placeholder');
-  
+
         el.clear();
-  
+
         expect(el.selectedItem).to.equal(null, 'no item should be selected');
         expect(el.value).to.equal('');
         expect(el._elements.label.textContent).to.equal(el.placeholder, 'label should match the placeholder');
@@ -1215,7 +1215,7 @@ describe('Select', function() {
         el.disabled = true;
 
         // we wait a frame because disable is applied on a sync()
-        
+
         // we focus the component
         el.focus();
         expect(el.contains(document.activeElement)).to.be.false;
@@ -1241,7 +1241,7 @@ describe('Select', function() {
       it('should remove variant classnames when variant changes', function() {
         const el = helpers.build(window.__html__['Select.variant.quiet.html']);
         expect(el._elements.button.classList.contains('_coral-FieldButton--quiet')).to.be.true;
-        
+
         el.variant = Select.variant.DEFAULT;
         expect(el._elements.button.classList.contains('_coral-FieldButton--quiet')).to.be.false;
       });
@@ -1311,7 +1311,7 @@ describe('Select', function() {
         expect(el.hasAttribute('multiple')).to.be.true;
 
         el.multiple = false;
-        
+
         expect(el.hasAttribute('multiple')).to.be.false;
       });
 
@@ -1408,12 +1408,12 @@ describe('Select', function() {
 
       it('should return the value of the selected item', function() {
         const el = helpers.build(window.__html__['Select.base.html']);
-        
+
         var item2 = el.items.getAll()[1];
         expect(item2.value).to.equal('af');
 
         el.value = 'af';
-        
+
         expect(el.value).to.equal(item2.value);
         expect(el.selectedItem).to.equal(item2);
       });
@@ -1452,7 +1452,45 @@ describe('Select', function() {
 
     describe('#disabled', function() {});
 
-    describe('#readOnly', function() {});
+    describe('#readOnly', function() {
+
+      it('should not be readOnly by default', function(done) {
+          const el = helpers.build(window.__html__['Select.base.html']);
+          expect(el.readOnly).to.be.false;
+          expect(el.hasAttribute('readOnly')).to.be.false;
+          done();
+      });
+
+      it('should be settable with value true', function(done) {
+          const el = helpers.build(window.__html__['Select.base.html']);
+          el.readOnly = true;
+
+          expect(el.readOnly).to.be.true;
+          expect(el.hasAttribute('readOnly')).to.be.true;
+          done();
+      });
+
+      it('should be settable with value 1', function(done) {
+          const el = helpers.build(window.__html__['Select.base.html']);
+          el.readOnly = 1;
+
+          expect(el.readOnly).to.be.true;
+          expect(el.hasAttribute('readOnly')).to.be.true;
+          done();
+      });
+
+      it('should be selectable with readOnly set to true', function(done) {
+          const el = helpers.build(window.__html__['Select.base.html']);
+          el.readOnly = true;
+          el.focus();
+
+          expect(el.readOnly).to.be.true;
+          expect(el.hasAttribute('readOnly')).to.be.true;
+          expect(el.contains(document.activeElement)).to.be.true;
+          done();
+      });
+
+      });
 
     describe('#labelledBy', function() {});
 
@@ -1580,7 +1618,7 @@ describe('Select', function() {
             el._elements.list.items.getAll()[1].click();
           }
 
-          
+
           expect(el.value).to.equal('af');
 
           expect(changeSpy.callCount).to.equal(1);
@@ -1628,12 +1666,12 @@ describe('Select', function() {
 
           openEventCount++;
         });
-        
+
         el.on('coral-select:_overlayclose', function() {
           // opens the overlay the second time
           el._elements.button.click();
         });
-  
+
         // opens the overlay the first time
         helpers.next(() => {
           el._elements.button.click();
@@ -1660,24 +1698,24 @@ describe('Select', function() {
         // opens the overlay
         el._elements.button.click();
       });
-  
+
       it('should trigger a change event when a selectlist item is deselected', () => {
         const changeSpy = sinon.spy();
-  
+
         const el = helpers.build(window.__html__['Select.multiple.selected.html']);
         el.on('change', changeSpy);
-        
+
         expect(el.values).to.deep.equal(['af', 'eu']);
-  
+
         // Ensure overlay is open for change event to trigger
         el.overlay.open = true;
-        
+
         // Deselect "af"
         el._elements.list.selectedItem.click();
         expect(changeSpy.callCount).to.equal(1);
         expect(changeSpy.getCall(0).args[0].target.value).to.equal('eu');
         expect(changeSpy.getCall(0).args[0].target.values).to.deep.equal(['eu']);
-  
+
         // Deselect "eu"
         el._elements.list.selectedItem.click();
         expect(changeSpy.callCount).to.equal(2);
@@ -1699,13 +1737,13 @@ describe('Select', function() {
 
         // no change event since the selection was done programmatically
         expect(changeSpy.callCount).to.equal(0);
-        
+
         // checks that the corresponding tags were created
         expect(el._elements.taglist.values).to.deep.equal(['af', 'eu']);
 
         // clicks on the close button of the tag
         el._elements.taglist.items.getAll()[0]._elements.button.click();
-        
+
         // change event must be triggered
         expect(changeSpy.callCount).to.equal(1);
 
@@ -1784,19 +1822,19 @@ describe('Select', function() {
       });
     });
   });
-  
+
   describe('User Interaction', function() {
     // @todo: add tests for space key
     // @todo: add tests for key down
     // @todo: add tests for tab key
     // @todo: add tests for global click
     // @todo: add tests for scrolling at the bottom of the list
-    
+
     describe('Removing the selected item', function() {
-    
+
       it('should not cause an error with single selection', function(done) {
         var changeSpy = sinon.spy();
-  
+
         const el = helpers.build(window.__html__['Select.selected.html']);
         el.on('change', changeSpy);
 
@@ -1828,7 +1866,7 @@ describe('Select', function() {
         // opens the list
         el._elements.button.click();
       });
-      
+
       it('should not cause an error with multiple selection', function(done) {
         var changeSpy = sinon.spy();
 
@@ -1840,10 +1878,10 @@ describe('Select', function() {
 
         // we remove the selected item ("Africa")
         el.selectedItem.remove();
-  
+
         // no change event should have been triggered
         expect(changeSpy.callCount).to.equal(0);
-  
+
         // Wait for MO
         helpers.next(function() {
           // checks the item was properly removed
@@ -1854,7 +1892,7 @@ describe('Select', function() {
 
           // Change event is only triggered if the overlay is opened
           el._elements.overlay.open = true;
-          
+
           // selects the item on index 1 ("Asia")
           el._elements.list.items.getAll()[1].click();
 
@@ -1868,7 +1906,7 @@ describe('Select', function() {
           expect(changeSpy.callCount).to.equal(1);
           expect(changeSpy.getCall(0).args[0].target.value).to.equal('eu');
           expect(changeSpy.getCall(0).args[0].target.values).to.deep.equal(['eu', 'as']);
-    
+
           done();
         });
       });
@@ -1885,7 +1923,7 @@ describe('Select', function() {
           // selects the item on index 1
           el._elements.list.items.getAll()[1].click();
           expect(el.selectedItem).to.equal(items[1]);
-          
+
           expect(el._elements.label.innerHTML).to.equal(items[1].content.innerHTML);
 
           done()
@@ -1900,22 +1938,22 @@ describe('Select', function() {
         // all the available items
         var items = el.items.getAll();
         var itemCount = items.length;
-        
+
         el.on('coral-select:_overlayopen', function() {
           // selects the item on index 1, this will cause the overlay to close
           el._elements.list.items.getAll()[1].click();
-  
+
           expect(el.selectedItem).to.equal(items[1]);
-  
+
           expect(el._elements.label.innerHTML).to.equal(items[1].content.innerHTML);
-  
+
           // we remove the selected item
           items[1].remove();
-  
+
           expect(el.selectedItem).to.be.null;
           // we have one item less in the collection
           expect(el.items.length).to.equal(itemCount - 1);
-  
+
           // Wait for MO
           helpers.next(function() {
             // there is now one item less in the selectlist
@@ -1939,7 +1977,7 @@ describe('Select', function() {
       it('should update the placeholder when the content of the selectedItem changes', function(done) {
         const el = helpers.build(window.__html__['Select.selected.html']);
         expect(el._elements.label.textContent).to.equal('Europe');
-        
+
         el.selectedItem.content.textContent = 'New Content';
 
         // we wait for the MO to trigger
@@ -1961,13 +1999,13 @@ describe('Select', function() {
           // closes the overlay
            el._elements.button.click();
         });
-        
+
         el.on('coral-select:_overlayclose', function() {
           expect(el._elements.button.getAttribute('aria-expanded')).to.equal('false');
-          
+
           done();
         });
-  
+
         // opens the overlay
         el._elements.button.click();
       });
@@ -1982,7 +2020,7 @@ describe('Select', function() {
       var tags = el._elements.taglist.items.getAll();
       // we remove the a tag through interaction, which causes the taglist to trigger a change event
       tags[0]._elements.button.click();
-      
+
       expect(el.selectedItems.length).to.equal(selectedItemCount - 1);
     });
 
@@ -1992,10 +2030,10 @@ describe('Select', function() {
         // selects the 2nd item in the list
         el._elements.list.items.getAll()[1].click();
       });
-      
+
       el.on('coral-select:_overlayclose', function() {
         expect(document.activeElement).to.equal(el._elements.button);
-        
+
         done();
       });
 
@@ -2011,10 +2049,10 @@ describe('Select', function() {
         expect(selectListItems[2].selected).to.be.true;
         selectListItems[2].click();
       });
-      
+
       el.on('coral-select:_overlayclose', function() {
         expect(document.activeElement).to.equal(el._elements.button);
-  
+
         done();
       });
 
@@ -2031,10 +2069,10 @@ describe('Select', function() {
         // we click the button again to toggle the overlay
         el._elements.button.click();
       });
-      
+
       el.on('coral-select:_overlayclose', function() {
         expect(document.activeElement).to.equal(el._elements.button);
-  
+
         done();
       });
 
@@ -2049,10 +2087,10 @@ describe('Select', function() {
         // we simulate a click somewhere else in the page
         document.body.click();
       });
-      
+
       el.on('coral-select:_overlayclose', function() {
         expect(document.activeElement).to.equal(el._elements.button);
-  
+
         done();
       });
 
@@ -2079,19 +2117,19 @@ describe('Select', function() {
         done();
       });
     });
-  
+
     it('should keep the overlay open if multiple=true and an item is selected', function(done) {
       const el = helpers.build(window.__html__['Select.placeholder.multiple.html']);
-      
+
       el.on('coral-select:_overlayopen', function() {
         // selects the 2nd item in the list
         el._elements.list.items.getAll()[1].click();
-        
+
         expect(el._elements.overlay.open).to.be.true;
-        
+
         done();
       });
-    
+
       // opens the overlay
       el._elements.button.click();
     });
@@ -2141,7 +2179,7 @@ describe('Select', function() {
       el.items.add(item1);
       el.items.add(item2);
       el.items.add(item3);
-      
+
       // Wait for MO
       helpers.next(function() {
         done();
@@ -2249,7 +2287,7 @@ describe('Select', function() {
         expect(arrayDiff([item1, item2], [item2, item1])).to.deep.equal([], 'order should not matter');
       });
     });
-  
+
     describe('Smart Overlay', () => {
       helpers.testSmartOverlay('coral-select');
     });
@@ -2272,29 +2310,29 @@ describe('Select', function() {
       });
     });
   });
-  
+
   describe('Tracking', function() {
     var trackerFnSpy;
-    
+
     beforeEach(function () {
       trackerFnSpy = sinon.spy();
       tracking.addListener(trackerFnSpy);
     });
-    
+
     afterEach(function () {
       tracking.removeListener(trackerFnSpy);
     });
-    
+
     it('should call the tracker callback fn with expected parameters when the simple select changes it\'s value that has a trackingElement attribute', function() {
       const el = helpers.build(window.__html__['Select.tracking.single.html']);
       el.click();
-      
+
       el._elements.list.items.first().click();
       expect(trackerFnSpy.callCount).to.equal(1, 'Tracker should have been called only once.');
-      
+
       var spyCall = trackerFnSpy.getCall(0);
       expect(spyCall.args.length).to.equal(4);
-      
+
       var trackData = spyCall.args[0];
       expect(trackData).to.have.property('targetElement', 'First element name');
       expect(trackData).to.have.property('targetType', 'coral-select-item');
@@ -2305,17 +2343,17 @@ describe('Select', function() {
       expect(spyCall.args[1]).to.be.an.instanceof(CustomEvent);
       expect(spyCall.args[2]).to.be.an.instanceof(Select);
     });
-    
+
     it('should call the tracker callback fn with expected parameters when the simple select changes it\'s value that doesn\'t have a trackingElement attribute', function() {
       const el = helpers.build(window.__html__['Select.tracking.single.html']);
       el.click();
-      
+
       el._elements.list.items.getAll()[1].click();
-      
+
       expect(trackerFnSpy.callCount).to.equal(1, 'Tracker should have been called only once.');
       var spyCall = trackerFnSpy.getCall(0);
       expect(spyCall.args.length).to.equal(4);
-      
+
       var trackData = spyCall.args[0];
       expect(trackData).to.have.property('targetElement', 'Second');
       expect(trackData).to.have.property('targetType', 'coral-select-item');
@@ -2326,17 +2364,17 @@ describe('Select', function() {
       expect(spyCall.args[1]).to.be.an.instanceof(CustomEvent);
       expect(spyCall.args[2]).to.be.an.instanceof(Select);
     });
-    
+
     it('should call the tracker callback fn with expected parameters when the multiple select changes it\'s value that doesn\'t have a trackingElement attribute', function() {
       const el = helpers.build(window.__html__['Select.tracking.multiple.html']);
       el.click();
-  
+
       el._elements.list.items.first().click();
       expect(trackerFnSpy.callCount).to.equal(1, 'Tracker should have been called only once.');
-      
+
       var spyCall = trackerFnSpy.getCall(0);
       expect(spyCall.args.length).to.equal(4);
-      
+
       var trackData = spyCall.args[0];
       expect(trackData).to.have.property('targetElement', 'First element name');
       expect(trackData).to.have.property('targetType', 'coral-select-item');
@@ -2347,17 +2385,17 @@ describe('Select', function() {
       expect(spyCall.args[1]).to.be.an.instanceof(CustomEvent);
       expect(spyCall.args[2]).to.be.an.instanceof(Select);
     });
-    
+
     it.skip('should call the tracker callback fn with expected parameters when the multiple select adds a new tag and then removes it', function() {
       const el = helpers.build(window.__html__['Select.tracking.multiple.html']);
       el.click();
-  
+
       const listItem = el._elements.list.items.first().click();
       listItem.click();
-      
+
       var tagItemCloseBtn = el.querySelector('coral-taglist coral-tag button[coral-close]');
       tagItemCloseBtn.click();
-      
+
       expect(trackerFnSpy.callCount).to.equal(2, 'Tracker should have been called twice.');
       var spyCall = trackerFnSpy.getCall(1);
       expect(spyCall.args.length).to.equal(4);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

For the bug CQ-4273031 we were needed to migrate attribute "disabled" to "readOnly" in supertype form fields (/libs/granite/ui/components/coral/foundation/form/field). This was done to make all the inheriting fields of form field accessible  based on following conditions:

1.            Able to make field displayable but not editable (read-only).
2.            User should be able to copy the text written underneath.
3.            User should be able to access the field with click(mouse) and tab(keyboard).

This was achieved by adding a new attribute "readOnly" in /libs/granite/ui/components/coral/foundation/form/field and leveraging it but apparently following components still didn't honour the attribute so to fix them we had to create the PRs [0] and [1]. And to honour them in coral-spectrum I created this PR.
1. coralui-component-datepicker
2. coralui-component-select

[0] https://git.corp.adobe.com/Coral/coralui-component-datepicker/pull/72/files
[1] https://git.corp.adobe.com/Coral/coralui-component-select/pull/104/files


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.


As in coral spectrum PRs redundant whitespaces are getting injested so I added the exact link of code changes for easy reference.

coral-component-datepicker/src/scripts/Datepicker.js 

1. https://github.com/adobe/coral-spectrum/pull/68/files#diff-acaf0592ec5664bc5dae8cde518870d6L464-R464
2. https://github.com/adobe/coral-spectrum/pull/68/files#diff-acaf0592ec5664bc5dae8cde518870d6L515-R518

coral-component-datepicker/src/tests/test.Datepicker.js 

1. https://github.com/adobe/coral-spectrum/pull/68/files#diff-62f3fd1bc96606e09b7016415768c45dL303-L310

coral-component-select/src/scripts/Select.js

1. https://github.com/adobe/coral-spectrum/pull/68/files#diff-34540f7f47417594812fbcc3b50f3e33L429-L432
2. https://github.com/adobe/coral-spectrum/pull/68/files#diff-34540f7f47417594812fbcc3b50f3e33L482-L485
3. https://github.com/adobe/coral-spectrum/pull/68/files#diff-34540f7f47417594812fbcc3b50f3e33L1001-L1002
4. https://github.com/adobe/coral-spectrum/pull/68/files#diff-34540f7f47417594812fbcc3b50f3e33L1037-L1038

coral-component-select/src/tests/test.Select.js

1. https://github.com/adobe/coral-spectrum/pull/68/files#diff-7f38e98a680c4b36aa72c375e86c0694L1455-R1493