### PR TITLE
CUI-7375 : [Coral-Table]Provide a provision such that solutions can forced layout

### DIFF
--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -2176,23 +2176,21 @@ class Table extends BaseComponent(HTMLTableElement) {
   * If true call the layout method immediately, else wait for timeout
   */
   resetLayout(forced){
-    var self = this;
     if(forced === true){
-      self._doResetLayout();
-      self._preventResetLayout = false;
+      this._doResetLayout();
+      this._preventResetLayout = false;
     }
     else{
-      self._resetLayout();
+      this._resetLayout();
     }
   }
 
   /** @private */
   _doResetLayout() {
-    var self = this;
-    self.classList.add(IS_LAYOUTING);
-    self._resizeStickyHead();
-    self._resizeContainer();
-    self.classList.remove(IS_LAYOUTING);
+    this.classList.add(IS_LAYOUTING);
+    this._resizeStickyHead();
+    this._resizeContainer();
+    this.classList.remove(IS_LAYOUTING);
   }
 
   /** @private */

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -2180,7 +2180,8 @@ class Table extends BaseComponent(HTMLTableElement) {
     if(forced === true){
       self._doResetLayout();
       self._preventResetLayout = false;
-    }else{
+    }
+    else{
       self._resetLayout();
     }
   }

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -2168,7 +2168,32 @@ class Table extends BaseComponent(HTMLTableElement) {
   _onSelectPreviousItem() {
     this._selectSiblingItem(false);
   }
-  
+
+  /**
+  * Call the layout method of table component
+  *
+  * @param {Boolean} forced
+  * If true call the layout method immediately, else wait for timeout
+  */
+  resetLayout(forced){
+    var self = this;
+    if(forced === true){
+      self._doResetLayout();
+      self._preventResetLayout = false;
+    }else{
+      self._resetLayout();
+    }
+  }
+
+  /** @private */
+  _doResetLayout() {
+    var self = this;
+    self.classList.add(IS_LAYOUTING);
+    self._resizeStickyHead();
+    self._resizeContainer();
+    self.classList.remove(IS_LAYOUTING);
+  }
+
   /** @private */
   _resetLayout() {
     if (this._preventResetLayout) {
@@ -2181,14 +2206,8 @@ class Table extends BaseComponent(HTMLTableElement) {
     }
     
     this._timeout = window.setTimeout(() => {
-      this.classList.add(IS_LAYOUTING);
-      
       this._timeout = null;
-      this._resizeStickyHead();
-      this._resizeContainer();
-      
-      this.classList.remove(IS_LAYOUTING);
-      
+      this._doResetLayout();
       // Mark table as ready
       this.classList.add(IS_READY);
     }, this._wait);


### PR DESCRIPTION
 [Coral-Table]Provide a provision such that solutions can forced layout
@review @icaraps @indra2gurjar 
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/CUI-7375

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Coral-Table: When large number of items are present inside table, then it takes time to load the items and call the debounced layout function. As a result, initially the client height of the table wrapper is wrong.Since there is no provision such that solutions can forced the layout. This is required because in Foundation when large items are loaded in table.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
