### PR TITLE
CUI-7382 Coral.Table: fix unit test for accessibilityState

### DIFF
--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -2232,9 +2232,9 @@ describe('Table', function() {
                   expect(accessibilityState.textContent).to.equal(index !== 0 ? ', checked' : '');
                 });
                 done();
-              }, 260);
-            }, 60);
-          }, 60);  
+              }, 275);
+            }, 75);
+          }, 75);  
         });
       });
     });


### PR DESCRIPTION
## Description

CQ-4291310 introduced a unit test that fails intermittently. Lengthening the setTimeout delays in tests for "#a11y should add an accessibilityState and announce selection changes to selectable items" will hopefully make the tests more resilient.

## Related Issue
Fixes: https://jira.corp.adobe.com/browse/CUI-7382,
which fixes: https://jira.corp.adobe.com/browse/CQ-4294893,
which was introduced by: https://jira.corp.adobe.com/browse/CQ-4291310.

## Motivation and Context
Fix intermittent failing unit test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
