### PR TITLE
CUI-7375 : [Coral-Table]Provide a provision such that solutions can forced layout

### DIFF
--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -2168,7 +2168,32 @@ class Table extends BaseComponent(HTMLTableElement) {
   _onSelectPreviousItem() {
     this._selectSiblingItem(false);
   }
-  
+
+  /**
+  * Call the layout method of table component
+  *
+  * @param {Boolean} forced
+  * If true call the layout method immediately, else wait for timeout
+  */
+  resetLayout(forced) {
+    forced = transform.boolean(forced);
+    if (forced === true) {
+      this._doResetLayout();
+      this._preventResetLayout = false;
+    }
+    else {
+      this._resetLayout();
+    }
+  }
+
+  /** @private */
+  _doResetLayout() {
+    this.classList.add(IS_LAYOUTING);
+    this._resizeStickyHead();
+    this._resizeContainer();
+    this.classList.remove(IS_LAYOUTING);
+  }
+
   /** @private */
   _resetLayout() {
     if (this._preventResetLayout) {
@@ -2181,14 +2206,8 @@ class Table extends BaseComponent(HTMLTableElement) {
     }
     
     this._timeout = window.setTimeout(() => {
-      this.classList.add(IS_LAYOUTING);
-      
       this._timeout = null;
-      this._resizeStickyHead();
-      this._resizeContainer();
-      
-      this.classList.remove(IS_LAYOUTING);
-      
+      this._doResetLayout();
       // Mark table as ready
       this.classList.add(IS_READY);
     }, this._wait);

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -783,6 +783,30 @@ describe('Table', function() {
         expect(lastItem.selected).to.be.true;
       });
     });
+
+    describe('#layout', function() {
+      it('should layout the table correctly when reset layout forced', function(done) {
+        var table = helpers.build(window.__html__['Table.sticky.html'])
+        var methodSpy = sinon.spy(table, '_doResetLayout');
+        table.resetLayout(true);
+        // method call immediately
+        expect(methodSpy.callCount).to.equal(1);
+        done();
+      });
+
+      it('should layout the table correctly when reset layout not forced', function(done) {
+        var table = helpers.build(window.__html__['Table.sticky.html'])
+        var methodSpy = sinon.spy(table, '_doResetLayout');
+        table.resetLayout();
+        //method will get executed after timeout
+        expect(methodSpy.callCount).to.equal(0);
+        //waiting for 200ms to ensure that debounced layout has been called once
+        window.setTimeout(function (){
+          expect(methodSpy.callCount).to.be.greaterThan(0);
+          done();
+        }, 200);
+      });
+    });
   });
   
   describe('Events', function() {


### PR DESCRIPTION
[Coral-Table]Provide a provision such that solutions can forced layout

## Description
Coral-Table: When large number of items are present inside table, then it takes time to load the items and call the debounced layout function. As a result, initially the client height of the table wrapper is wrong.Since there is no provision such that solutions can forced the layout. This is required because in Foundation when large items are loaded in table.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://jira.corp.adobe.com/browse/CUI-7375

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
