### PR TITLE
CUI-7368 AlertDialog should have support for labelledBy and describedBy properties

### DIFF
--- a/coral-component-autocomplete/src/tests/test.Autocomplete.js
+++ b/coral-component-autocomplete/src/tests/test.Autocomplete.js
@@ -1945,9 +1945,7 @@ describe('Autocomplete', function() {
 
           el.on('coral-overlay:close', function() {
             helpers.next(function() {
-              if (trigger) {
-                expect(trigger.getAttribute('aria-expanded')).to.equal('false');
-              }
+              expect(trigger.getAttribute('aria-expanded')).to.equal('false');
               done();
             });
           });

--- a/coral-component-autocomplete/src/tests/test.Autocomplete.js
+++ b/coral-component-autocomplete/src/tests/test.Autocomplete.js
@@ -1945,7 +1945,9 @@ describe('Autocomplete', function() {
 
           el.on('coral-overlay:close', function() {
             helpers.next(function() {
-              expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+              if (trigger) {
+                expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+              }
               done();
             });
           });

--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -298,6 +298,44 @@ class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
       // ARIA
       this.setAttribute('role', 'alertdialog');
     }
+
+    const hasHeader = this.header && this.header.textContent !== '';
+
+    // If the dialog has a header and is not otherwise labelled,
+    if (hasHeader && !(this.hasAttribute('aria-labelledby') || this.hasAttribute('aria-label'))) {
+      this.header.id = this.header.id || commons.getUID();
+
+      // label the dialog with a reference to the header
+      this.setAttribute('aria-labelledby', this.header.id);
+    }
+
+    const hasContent = this.content && this.content.textContent !== '';
+
+    // If the dialog has a content,
+    if (hasContent) {
+      this.content.id = this.content.id || commons.getUID();
+
+      // In an alertdialog with a content region, if the alertdialog is not otherwise described.
+      if (this._variant !== variant.DEFAULT) {
+
+        // with no header, 
+        if (!hasHeader) {
+
+          // label the alertdialog with a reference to the content
+          this.setAttribute('aria-labelledby', this.content.id);
+        }
+
+        // otherwise, if the alertdialog is not otherwise described,
+        else if (!this.hasAttribute('aria-describedby')) {
+
+          // ensure that the alertdialog is described by the content.
+          this.setAttribute('aria-describedby', this.content.id);
+        }
+      }
+      else if (this.getAttribute('aria-labelledby') === this.content.id) {
+        this.removeAttribute('aria-labelledby');
+      }
+    }
   }
   
   /**
@@ -464,7 +502,7 @@ class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
   _hideHeaderIfEmpty() {
     const header = this._elements.header;
   
-    if (this._elements.header) {
+    if (header) {
       const headerWrapper = this._elements.headerWrapper;
   
       // If it's empty and has no non-textnode children, hide the header
@@ -474,6 +512,8 @@ class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
       if (hiddenValue !== headerWrapper.hidden) {
         headerWrapper.hidden = hiddenValue;
       }
+
+      this.variant = this.variant;
     }
   }
   

--- a/coral-component-dialog/src/tests/test.Dialog.js
+++ b/coral-component-dialog/src/tests/test.Dialog.js
@@ -688,4 +688,97 @@ describe('Dialog', function() {
       });
     });
   });
+
+  describe('Accessibility', function() {
+    let el;
+  
+    beforeEach(function() {
+      el = helpers.build(window.__html__['Dialog.fromElements.html']);
+    });
+    describe('#variant', function() {
+      it('should add aria-labelledby to default variant when a header but no other label is provided', function() {
+        expect(el.getAttribute('role')).to.equal('dialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.header.id);
+        expect(el.hasAttribute('aria-describedby')).to.be.false;
+
+        el = helpers.build(window.__html__['Dialog.contentOnly.html']);
+        expect(el.getAttribute('role')).to.equal('dialog');
+        expect(el.hasAttribute('aria-labelledby')).to.be.false;
+        expect(el.hasAttribute('aria-describedby')).to.be.false;
+      });
+      it('should add aria-labelledby and aria-describedby to error variant when a header but no other label is provided', function() {
+        el.variant = Dialog.variant.ERROR;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.header.id);
+        expect(el.getAttribute('aria-describedby')).to.equal(el.content.id);
+
+        el = helpers.build(window.__html__['Dialog.contentOnly.html']);
+        el.variant = Dialog.variant.ERROR;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.content.id);
+        expect(el.hasAttribute('aria-describedby')).to.be.false;
+      });
+      it('should add aria-labelledby and aria-describedby to warning variant when a header but no other label is provided', function() {
+        el.variant = Dialog.variant.WARNING;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.header.id);
+        expect(el.getAttribute('aria-describedby')).to.equal(el.content.id);
+
+        el = helpers.build(window.__html__['Dialog.contentOnly.html']);
+        el.variant = Dialog.variant.WARNING;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.content.id);
+        expect(el.hasAttribute('aria-describedby')).to.be.false;
+      });
+      it('should add aria-labelledby and aria-describedby to success variant when a header but no other label is provided', function() {
+        el.variant = Dialog.variant.SUCCESS;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.header.id);
+        expect(el.getAttribute('aria-describedby')).to.equal(el.content.id);
+
+        el = helpers.build(window.__html__['Dialog.contentOnly.html']);
+        el.variant = Dialog.variant.SUCCESS;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.content.id);
+        expect(el.hasAttribute('aria-describedby')).to.be.false;
+      });
+      it('should add aria-labelledby and aria-describedby to help variant when a header but no other label is provided', function() {        
+        el.variant = Dialog.variant.HELP;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.header.id);
+        expect(el.getAttribute('aria-describedby')).to.equal(el.content.id);
+
+        el = helpers.build(window.__html__['Dialog.contentOnly.html']);
+        el.variant = Dialog.variant.HELP;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.content.id);
+        expect(el.hasAttribute('aria-describedby')).to.be.false;
+      });
+      it('should add aria-labelledby and aria-describedby to info variant when a header but no other label is provided', function() {
+        el.variant = Dialog.variant.INFO;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.header.id);
+        expect(el.getAttribute('aria-describedby')).to.equal(el.content.id);
+
+        el = helpers.build(window.__html__['Dialog.contentOnly.html']);
+        el.variant = Dialog.variant.INFO;
+        expect(el.getAttribute('role')).to.equal('alertdialog');
+        expect(el.getAttribute('aria-labelledby')).to.equal(el.content.id);
+        expect(el.hasAttribute('aria-describedby')).to.be.false;
+      });
+      it('should preserve aria-label or aria-labelledby on dialog', function() {
+        el.variant = Dialog.variant.INFO;
+        el.setAttribute('aria-labelledby', 'header-id');
+        el.header.innerHTML = '<span id="header-id">My Special Header</span>';
+        expect(el.getAttribute('aria-labelledby')).to.equal('header-id');
+        expect(el.getAttribute('aria-describedby')).to.equal(el.content.id);
+        el.setAttribute('aria-label', 'boo');
+        el.removeAttribute('aria-labelledby');
+        el.header.innerHTML = '';
+        expect(el.hasAttribute('aria-labelledby')).to.be.false;
+        expect(el.getAttribute('aria-label')).to.equal('boo');
+        expect(el.getAttribute('aria-describedby')).to.equal(el.content.id);
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Description
As per discussion in CQ-4292426 [0], coral-dialog component [1] needs support for aria-labelledBy and aria-describedBy properties, at least for the alertDialog so that the title of the dialog and description present in the body can be announced by screen readers.

[0] https://jira.corp.adobe.com/browse/CQ-4292426?focusedCommentId=21075521&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21075521
[1] https://git.corp.adobe.com/Coral/coralui-component-dialog/blob/master/scripts/Coral.Dialog.js

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7368, https://jira.corp.adobe.com/browse/CQ-4292426

## Motivation and Context
Improve screen reader announcement of `role=alertdialog` variants when the Cancel or Ok button receives focus.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
