### PR TITLE
Adding back changes for Coral Tab invalid Icon

### DIFF
--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -30,10 +30,11 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
-    
+
     // Templates
     this._elements = {
-      label: this.querySelector('coral-tab-label') || document.createElement('coral-tab-label')
+      label: this.querySelector('coral-tab-label') || document.createElement('coral-tab-label'),
+      invalidIcon: this.querySelector('._coral-Tabs-itemInvalidIcon') || this._createInvalidIcon()
     };
     base.call(this._elements);
   
@@ -131,6 +132,12 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     
     this.classList.toggle('is-invalid', this._invalid);
     this.setAttribute('aria-invalid', this._invalid);
+    if (this._invalid) {
+      this._elements.invalidIcon.removeAttribute('hidden');
+    }
+    else {
+      this._elements.invalidIcon.setAttribute('hidden', 'true');
+    }
   }
   
   /**
@@ -269,7 +276,18 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       }
     }
   }
-  
+
+  _createInvalidIcon() {
+    let iconElement = document.createElement('coral-icon');
+    iconElement.icon = 'alert';
+    iconElement.size = Icon.size.EXTRA_SMALL;
+    iconElement.classList.add('_coral-Tabs-itemInvalidIcon');
+    if (!this._invalid) {
+      iconElement.setAttribute('hidden', 'true');
+    }
+    return iconElement;
+  }
+
   get _contentZones() { return {'coral-tab-label': 'label'}; }
   
   /** @ignore */
@@ -307,6 +325,10 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     if (this.icon) {
       frag.appendChild(this._elements.icon);
     }
+
+    if (this._elements.invalidIcon) {
+      frag.append(this._elements.invalidIcon);
+    }
   
     const label = this._elements.label;
   
@@ -326,10 +348,10 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
         this.removeChild(child);
       }
     }
-  
+
     // Add the frag to the component
     this.appendChild(frag);
-  
+
     // Assign the content zones, moving them into place in the process
     this.label = label;
   }

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -37,7 +37,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       invalidIcon: this.querySelector('._coral-Tabs-itemInvalidIcon') || this._createInvalidIcon()
     };
     base.call(this._elements);
-  
+
     // Listen for mutations
     this._observer = new MutationObserver(() => {
       // Change icon size if the label is empty
@@ -45,12 +45,12 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       if (icon) {
         icon.size = this._elements.label.textContent.trim().length ? Icon.size.EXTRA_SMALL : Icon.size.SMALL;
       }
-  
+
       super._toggleIconAriaHidden();
-      
+
       this.trigger('coral-tab:_sizechanged');
     });
-  
+
     // Watch for changes to the label element
     this._observer.observe(this._elements.label, {
       childList: true,
@@ -58,10 +58,10 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       subtree: true
     });
   }
-  
+
   /**
    The label of the tab.
-   
+
    @type {TabLabel}
    @contentzone
    */
@@ -75,15 +75,15 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       insert: function(label) {
         label.classList.add(`${CLASSNAME}Label`);
         this.appendChild(label);
-        
+
         this._toggleEllipsis();
       }
     });
   }
-  
+
   /**
    Specifies the name of the icon used inside the Tab. See {@link Icon} for valid icon names.
-   
+
    @type {String}
    @default ""
    @htmlattribute icon
@@ -95,7 +95,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   set icon(value) {
     const iconElement = this._elements.icon;
     iconElement.icon = value;
-  
+
     // removes the icon element from the DOM.
     if (this.icon === '') {
       iconElement.remove();
@@ -107,17 +107,17 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       if (!this._elements.label.textContent.trim().length) {
         iconElement.size = Icon.size.SMALL;
       }
-      
+
       super._toggleIconAriaHidden();
-      
+
       this.insertBefore(iconElement, this.firstChild);
       this.trigger('coral-tab:_sizechanged');
     }
   }
-  
+
   /**
    Whether the current Tab is invalid.
-   
+
    @type {Boolean}
    @default false
    @htmlattribute invalid
@@ -129,7 +129,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   set invalid(value) {
     this._invalid = transform.booleanAttr(value);
     this._reflectAttribute('invalid', this._invalid);
-    
+
     this.classList.toggle('is-invalid', this._invalid);
     this.setAttribute('aria-invalid', this._invalid);
     if (this._invalid) {
@@ -139,11 +139,11 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       this._elements.invalidIcon.setAttribute('hidden', 'true');
     }
   }
-  
+
   /**
    Whether this Tab is disabled. When set to true, this will prevent every user interacting with the Tab. If
    disabled is set to true for a selected Tab it will be deselected.
-   
+
    @type {Boolean}
    @default false
    @htmlattribute disabled
@@ -155,20 +155,20 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   set disabled(value) {
     this._disabled = transform.booleanAttr(value);
     this._reflectAttribute('disabled', this._disabled);
-  
+
     this.classList.toggle('is-disabled', this._disabled);
     this[this._disabled ? 'setAttribute' : 'removeAttribute']('aria-disabled', this._disabled);
-    
+
     if (this._disabled && this.selected) {
       this.selected = false;
     }
-    
+
     if (!this._disabled && !this.selected) {
       // We inform the parent to verify if this item should be selected because it's the only one left
       this.trigger('coral-tab:_validateselection');
     }
   }
-  
+
   /**
    Whether the tab is selected.
    @type {Boolean}
@@ -181,15 +181,15 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   }
   set selected(value) {
     value = transform.booleanAttr(value);
-    
+
     if (!value || value && !this.disabled) {
       this._selected = value;
       this._reflectAttribute('selected', this.disabled ? false : this._selected);
-  
+
       this.classList.toggle('is-selected', this._selected);
       this.setAttribute('tabindex', this._selected ? '0' : '-1');
       this.setAttribute('aria-selected', this._selected);
-  
+
       // in case the tab is selected, we need to communicate it to the panels.
       if (this._selected) {
         this._selectTarget();
@@ -197,11 +197,11 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       this.trigger('coral-tab:_selectedchanged');
     }
   }
-  
+
   /**
    The target element that will be selected when this Tab is selected. It accepts a CSS selector or a DOM element.
    If a CSS Selector is provided, the first matching element will be used.
-   
+
    @type {?HTMLElement|String}
    @default null
    @htmlattribute target
@@ -212,9 +212,9 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   set target(value) {
     if (value === null || typeof value === 'string' || value instanceof Node) {
       this._target = value;
-  
+
       const realTarget = getTarget(this.target);
-  
+
       // we add proper accessibility if available
       if (realTarget) {
         // creates a 2 way binding for accessibility
@@ -223,7 +223,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
       }
     }
   }
-  
+
   /**
    Inherited from {@link BaseComponent#trackingElement}.
    */
@@ -236,16 +236,16 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   set trackingElement(value) {
     super.trackingElement = value;
   }
-  
+
   _toggleEllipsis() {
     requestAnimationFrame(() => {
       this.classList.toggle('is-overflowing', this._elements.label.clientWidth > this.clientWidth);
     });
   }
-  
+
   /**
    Selects the target item
-   
+
    @ignore
    */
   _selectTarget() {
@@ -257,17 +257,17 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     // otherwise, we use the target defined at the tablist level
     else {
       const tabList = this.parentNode;
-    
+
       if (tabList && tabList.target) {
         realTarget = getTarget(tabList.target);
-      
+
         if (realTarget) {
           // we get the position of this tab inside the tablist
           const currentIndex = tabList.items.getAll().indexOf(this);
-        
+
           // we select the item with the same index
           const targetItem = (realTarget.items ? realTarget.items.getAll() : realTarget.children)[currentIndex];
-        
+
           // we select the item if it exists
           if (targetItem) {
             targetItem.setAttribute('selected', '');
@@ -278,7 +278,7 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   }
 
   _createInvalidIcon() {
-    let iconElement = document.createElement('coral-icon');
+    const iconElement = document.createElement('coral-icon');
     iconElement.icon = 'alert';
     iconElement.size = Icon.size.EXTRA_SMALL;
     iconElement.classList.add('_coral-Tabs-itemInvalidIcon');
@@ -289,38 +289,38 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   }
 
   get _contentZones() { return {'coral-tab-label': 'label'}; }
-  
+
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat(['selected', 'disabled', 'icon', 'invalid', 'target']);
   }
-  
+
   /** @ignore */
   connectedCallback() {
     super.connectedCallback();
-  
+
     // Query the tab target once the tab item is inserted in the DOM
     if (this.selected) {
       this._selectTarget();
     }
   }
-  
+
   /** @ignore */
   render() {
     super.render();
-    
+
     this.classList.add(CLASSNAME);
-  
+
     // adds the role to support accessibility
     this.setAttribute('role', 'tab');
-  
+
     // Generate a unique ID for the tab panel if one isn't already present
     // This will be used for accessibility purposes
     this.setAttribute('id', this.id || commons.getUID());
-  
+
     // Create a fragment
     const frag = document.createDocumentFragment();
-    
+
     // Render the main template
     if (this.icon) {
       frag.appendChild(this._elements.icon);
@@ -329,14 +329,14 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     if (this._elements.invalidIcon) {
       frag.append(this._elements.invalidIcon);
     }
-  
+
     const label = this._elements.label;
-  
+
     // Remove it so we can process children
     if (label.parentNode) {
       label.parentNode.removeChild(label);
     }
-    
+
     while (this.firstChild) {
       const child = this.firstChild;
       if (child.nodeType === Node.TEXT_NODE ||

--- a/coral-component-tablist/src/styles/index.styl
+++ b/coral-component-tablist/src/styles/index.styl
@@ -27,13 +27,13 @@
   ._coral-Tabs-itemLabel:not(:empty) {
     display: inline;
   }
+}
 
-  ._coral-Tabs-itemInvalidIcon {
+._coral-Tabs ._coral-Tabs-itemInvalidIcon {
     display: inline;
     margin-right: 0;
-    margin-left: 5px;
+    margin-left: var(--spectrum-medium-tabs-invalid-icon-margin);
     float: right;
-  }
 }
 
 // @spectrum animation

--- a/coral-component-tablist/src/styles/index.styl
+++ b/coral-component-tablist/src/styles/index.styl
@@ -27,6 +27,13 @@
   ._coral-Tabs-itemLabel:not(:empty) {
     display: inline;
   }
+
+  ._coral-Tabs-itemInvalidIcon {
+    display: inline;
+    margin-right: 0;
+    margin-left: 5px;
+    float: right;
+  }
 }
 
 // @spectrum animation

--- a/coral-component-tablist/src/styles/light.styl
+++ b/coral-component-tablist/src/styles/light.styl
@@ -11,6 +11,7 @@
  */
 
 $tab-color-invalid = var(--spectrum-light-semantic-negative-color-text-small);
+$tab-normal-color = var(--spectrum-tabs-icon-color-key-focus);
 
 .coral--light {
   @import 'skin.styl'

--- a/coral-component-tablist/src/styles/skin.styl
+++ b/coral-component-tablist/src/styles/skin.styl
@@ -12,4 +12,9 @@
 
 ._coral-Tabs-item:not(.is-disabled).is-invalid {
   color: $tab-color-invalid;
+
+  ._coral-Tabs-itemInvalidIcon ._coral-Icon {
+    color: $tab-color-invalid;
+  }
+
 }

--- a/coral-component-tablist/src/tests/test.Tab.js
+++ b/coral-component-tablist/src/tests/test.Tab.js
@@ -145,6 +145,21 @@ describe('Tab', function() {
         expect(item.hasAttribute('invalid')).to.be.false;
         expect(item.classList.contains('is-invalid')).to.be.false;
       });
+
+      it('should show an alert icon when invalid and hide it when valid', function() {
+        // we need to call render so that the icons are attached to the tab
+        item.render();
+
+        item.invalid = true;
+        let invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+        expect(invalidIcon).not.to.be.null;
+        expect(invalidIcon.hasAttribute('hidden')).to.be.false;
+
+        item.invalid = false;
+        invalidIcon = item.querySelector('._coral-Tabs-itemInvalidIcon');
+        expect(invalidIcon).not.to.be.null;
+        expect(invalidIcon.hasAttribute('hidden')).to.be.true;
+      });
     });
 
     describe('#label', function() {

--- a/coral-theme-spectrum/src/styles/vars.css
+++ b/coral-theme-spectrum/src/styles/vars.css
@@ -2578,6 +2578,7 @@
   --spectrum-medium-tabs-text-transform: none;
   --spectrum-medium-tabs-text-size: 14px;
   --spectrum-medium-tabs-icon-size: 18px;
+  --spectrum-medium-tabs-invalid-icon-margin: 5px;
   --spectrum-medium-tabs-baseline: 18px;
   --spectrum-medium-tabs-height: 48px;
   --spectrum-medium-tabs-item-height: 48px;
@@ -7742,6 +7743,7 @@
   --spectrum-large-tabs-text-transform: none;
   --spectrum-large-tabs-text-size: 17px;
   --spectrum-large-tabs-icon-size: 22px;
+  --spectrum-large-tabs-invalid-icon-margin: 5px;
   --spectrum-large-tabs-baseline: 25px;
   --spectrum-large-tabs-height: 60px;
   --spectrum-large-tabs-item-height: 60px;


### PR DESCRIPTION
Reapplying accessibility changes for Coral Tab invalid icon.

## Description
The changes were approved in #49, but were reverted shortly after due to test failures in Travis CI. I've added the changes back and checked that all tests are passing now. To not that Travis CI was failing due to Tooltip test failures:

https://travis-ci.com/github/adobe/coral-spectrum/builds/160158820

## Related Issue
#48 

## Motivation and Context
This PR would improve Coral Spectrum accessibility by helping colour blind users to determine which tabs are invalid or not.

## How Has This Been Tested?
The testing of the issue has been done using the examples page of the Coral Spectrum Tablist component. A unit test has been provided.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/53042848/80966972-42da7e80-8e1e-11ea-9d7f-c74f62798028.png)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
