### PR TITLE
Errors rely on color to communicate that they are errors

### DIFF
--- a/coral-css-formgroup/examples/index.html
+++ b/coral-css-formgroup/examples/index.html
@@ -110,6 +110,14 @@
               <coral-numberinput placeholder="Enter a number" labelledby="fieldLabelExample-stepper"></coral-numberinput>
             </div>
           </div>
+
+          <div class="coral-FormGroup-item">
+            <label class="coral-FormGroup-itemLabel" for="invalid-input">Invalid Field</label>
+            <div class="coral-FormGroup-itemField">
+              <input is="coral-textfield" class="coral-Form-field is-invalid" aria-invalid="true" invalid type="text" placeholder="Enter your e-mail address" id="invalid-input">
+            </div>
+            <label class="coral-Form-errorlabel">Error: Please fill out this field.</label>
+          </div>
         </form>
 
         <br>
@@ -128,6 +136,11 @@
             </div>
             <div class="coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
               <coral-checkbox class="coral-Form-field">Remember me</coral-checkbox>
+            </div>
+            <div class="coral-Form-fieldwrapper">
+              <label class="coral-Form-fieldlabel" for="invalid-input">Invalid Field</label>
+              <input is="coral-textfield" class="coral-Form-field is-invalid" aria-invalid="true" invalid type="text" placeholder="Enter your e-mail address" id="invalid-input">
+              <label class="coral-Form-errorlabel">Error: Please fill out this field.</label>
             </div>
           </fieldset>
         </form>
@@ -196,6 +209,13 @@
               <input is="coral-textfield" class="coral-Form-field" id="password-input-aligned" type="password" aria-describedby="password-input-aligned-info"/>
               <button id="password-input-aligned-info" is="coral-button" type="button" variant="minimal" class="coral-Form-fieldinfo" icon="info" iconSize="XS" aria-label="At least 12 characters" style="height:12px;width:12px;border-radius:6px;border-width:0;padding:0;min-height:0;"></button>
               <coral-tooltip target="_prev" variant="info" placement="right" offset="8">At least 12 characters</coral-tooltip>
+            </div>
+          </fieldset>
+          <fieldset class="coral-Form-fieldset">
+            <div class="coral-Form-fieldwrapper">
+              <label class="coral-Form-fieldlabel" for="invalid-input-aligned">Invalid Field</label>
+              <input is="coral-textfield" class="coral-Form-field is-invalid" aria-invalid="true" invalid type="text" placeholder="Enter your e-mail address" id="invalid-input-aligned">
+              <label class="coral-Form-errorlabel">Error: Please fill out this field.</label>
             </div>
           </fieldset>
         </form>

--- a/coral-css-formgroup/examples/index.html
+++ b/coral-css-formgroup/examples/index.html
@@ -138,8 +138,8 @@
               <coral-checkbox class="coral-Form-field">Remember me</coral-checkbox>
             </div>
             <div class="coral-Form-fieldwrapper">
-              <label class="coral-Form-fieldlabel" for="invalid-input">Invalid Field</label>
-              <input is="coral-textfield" class="coral-Form-field is-invalid" aria-invalid="true" invalid type="text" placeholder="Enter your e-mail address" id="invalid-input">
+              <label class="coral-Form-fieldlabel" for="invalid-input-vertical">Invalid Field</label>
+              <input is="coral-textfield" class="coral-Form-field is-invalid" aria-invalid="true" invalid type="text" placeholder="Enter your e-mail address" id="invalid-input-vertical">
               <label class="coral-Form-errorlabel">Error: Please fill out this field.</label>
             </div>
           </fieldset>

--- a/coral-css-formgroup/examples/index.html
+++ b/coral-css-formgroup/examples/index.html
@@ -210,8 +210,6 @@
               <button id="password-input-aligned-info" is="coral-button" type="button" variant="minimal" class="coral-Form-fieldinfo" icon="info" iconSize="XS" aria-label="At least 12 characters" style="height:12px;width:12px;border-radius:6px;border-width:0;padding:0;min-height:0;"></button>
               <coral-tooltip target="_prev" variant="info" placement="right" offset="8">At least 12 characters</coral-tooltip>
             </div>
-          </fieldset>
-          <fieldset class="coral-Form-fieldset">
             <div class="coral-Form-fieldwrapper">
               <label class="coral-Form-fieldlabel" for="invalid-input-aligned">Invalid Field</label>
               <input is="coral-textfield" class="coral-Form-field is-invalid" aria-invalid="true" invalid type="text" placeholder="Enter your e-mail address" id="invalid-input-aligned">

--- a/coral-css-formgroup/src/styles/dark.styl
+++ b/coral-css-formgroup/src/styles/dark.styl
@@ -12,6 +12,7 @@
 
 $form-label-color = var(--spectrum-dark-fieldlabel-text-color);
 $form-fieldset-legend-color = var(--spectrum-dark-alias-heading-text-color);
+$form-errorlabel-color = var(--spectrum-dark-errorlabel-text-color);
 
 .coral--dark {
   @import 'skin.styl'

--- a/coral-css-formgroup/src/styles/darkest.styl
+++ b/coral-css-formgroup/src/styles/darkest.styl
@@ -12,6 +12,7 @@
 
 $form-label-color = var(--spectrum-darkest-fieldlabel-text-color);
 $form-fieldset-legend-color = var(--spectrum-darkest-alias-heading-text-color);
+$form-errorlabel-color = var(--spectrum-darkest-errorlabel-text-color);
 
 .coral--darkest {
   @import 'skin.styl'

--- a/coral-css-formgroup/src/styles/index.styl
+++ b/coral-css-formgroup/src/styles/index.styl
@@ -79,8 +79,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
     }
   }
 
-  .coral-Form-fieldlabel,
-  .coral-Form-errorlabel {
+  .coral-Form-fieldlabel{
     display: block;
     padding: var(--spectrum-medium-fieldlabel-padding-top) 0 var(--spectrum-medium-fieldlabel-padding-bottom);
   }
@@ -194,10 +193,13 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
       }
     }
 
-    .coral-Form-fieldlabel,
-    .coral-Form-errorlabel {
+    .coral-Form-fieldlabel {
       margin-top: 0;
       margin-bottom: 0;
+    }
+
+    .coral-Form-errorlabel {
+      margin-left: $form-hmargin;
     }
 
     .coral-Form-fieldinfo

--- a/coral-css-formgroup/src/styles/index.styl
+++ b/coral-css-formgroup/src/styles/index.styl
@@ -83,7 +83,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
  */
 .coral-Form--vertical {
   .coral-Form-field {
-    margin: 0 0 0;
+    margin: 0;
 
     // Don't override right checkbox,radio margin
     &._coral-Checkbox,
@@ -155,7 +155,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
   .coral-Form-fieldwrapper {
     clear: left;
     display: block;
-    margin: 0 0 $form-aligned-vmargin-max 0;
+    margin: 0;
 
     &:before,
     &:after {
@@ -213,7 +213,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
     }
 
     .coral-Form-fieldinfo
-    .coral-Form-fielderror{
+    .coral-Form-fielderror {
       float: left;
       margin-left: $form-hmargin;
       margin-top: $form-vmargin;

--- a/coral-css-formgroup/src/styles/index.styl
+++ b/coral-css-formgroup/src/styles/index.styl
@@ -100,6 +100,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
   .coral-Form-fieldwrapper {
     position: relative;
     display: block;
+    margin: 0 0 $form-vertical-vmargin-max;
 
     .coral-Form-fieldinfo,
     .coral-Form-fielderror {
@@ -155,7 +156,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
   .coral-Form-fieldwrapper {
     clear: left;
     display: block;
-    margin: 0;
+    margin: 0 0 $form-aligned-vmargin-max 0;
 
     &:before,
     &:after {

--- a/coral-css-formgroup/src/styles/index.styl
+++ b/coral-css-formgroup/src/styles/index.styl
@@ -70,7 +70,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
  */
 .coral-Form--vertical {
   .coral-Form-field {
-    margin: 0 0 $form-vertical-vmargin-max;
+    margin: 0 0 0;
 
     // Don't override right checkbox,radio margin
     &._coral-Checkbox,
@@ -193,20 +193,22 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
       }
     }
 
-    .coral-Form-fieldlabel {
+    .coral-Form-fieldlabel,
+    .coral-Form-errorlabel {
       margin-top: 0;
       margin-bottom: 0;
     }
 
-    .coral-Form-errorlabel {
-      margin-left: $form-hmargin;
-    }
-
     .coral-Form-fieldinfo
-    .coral-Form-fielderror {
+    .coral-Form-fielderror{
       float: left;
       margin-left: $form-hmargin;
       margin-top: $form-vmargin;
+    }
+
+    .coral-Form-errorlabel {
+      float: left;
+      margin-left: $form-hmargin;
     }
   }
 

--- a/coral-css-formgroup/src/styles/index.styl
+++ b/coral-css-formgroup/src/styles/index.styl
@@ -79,7 +79,8 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
     }
   }
 
-  .coral-Form-fieldlabel {
+  .coral-Form-fieldlabel,
+  .coral-Form-errorlabel {
     display: block;
     padding: var(--spectrum-medium-fieldlabel-padding-top) 0 var(--spectrum-medium-fieldlabel-padding-bottom);
   }
@@ -193,7 +194,8 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
       }
     }
 
-    .coral-Form-fieldlabel {
+    .coral-Form-fieldlabel,
+    .coral-Form-errorlabel {
       margin-top: 0;
       margin-bottom: 0;
     }

--- a/coral-css-formgroup/src/styles/index.styl
+++ b/coral-css-formgroup/src/styles/index.styl
@@ -65,6 +65,19 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
   }
 }
 
+.coral-Form-errorlabel {
+  box-sizing: border-box;
+  font-weight: var(--spectrum-medium-fieldlabel-text-font-weight);
+  font-size: var(--spectrum-medium-fieldlabel-text-size);
+  line-height: var(--spectrum-medium-fieldlabel-text-line-height);
+  -webkit-font-smoothing: subpixel-antialiased;
+  -moz-osx-font-smoothing: auto;
+  font-smoothing: subpixel-antialiased;
+  vertical-align: top;
+  display: block;
+  padding-top: var(--spectrum-medium-fieldlabel-padding-bottom);
+}
+
 /**
  * Indicates that the form is using vertical layout, where the label is placed above the field.
  */

--- a/coral-css-formgroup/src/styles/index.styl
+++ b/coral-css-formgroup/src/styles/index.styl
@@ -79,7 +79,7 @@ $form-aligned-label-min-width = var(--spectrum-medium-global-dimension-size-1600
     }
   }
 
-  .coral-Form-fieldlabel{
+  .coral-Form-fieldlabel {
     display: block;
     padding: var(--spectrum-medium-fieldlabel-padding-top) 0 var(--spectrum-medium-fieldlabel-padding-bottom);
   }

--- a/coral-css-formgroup/src/styles/light.styl
+++ b/coral-css-formgroup/src/styles/light.styl
@@ -12,6 +12,7 @@
 
 $form-label-color = var(--spectrum-light-fieldlabel-text-color);
 $form-fieldset-legend-color = var(--spectrum-light-alias-heading-text-color);
+$form-errorlabel-color = var(--spectrum-light-errorlabel-text-color);
 
 .coral--light {
   @import 'skin.styl'

--- a/coral-css-formgroup/src/styles/lightest.styl
+++ b/coral-css-formgroup/src/styles/lightest.styl
@@ -12,6 +12,7 @@
 
 $form-label-color = var(--spectrum-lightest-fieldlabel-text-color);
 $form-fieldset-legend-color = var(--spectrum-lightest-alias-heading-text-color);
+$form-errorlabel-color = var(--spectrum-lightest-errorlabel-text-color);
 
 .coral--lightest {
   @import 'skin.styl'

--- a/coral-css-formgroup/src/styles/skin.styl
+++ b/coral-css-formgroup/src/styles/skin.styl
@@ -17,3 +17,8 @@
 .coral-Form-fieldset-legend {
   color: $form-fieldset-legend-color;
 }
+
+.coral-Form-errorlabel {
+  color: $form-errorlabel-color;
+  font-style: italic;
+}

--- a/coral-css-formgroup/src/styles/skin.styl
+++ b/coral-css-formgroup/src/styles/skin.styl
@@ -20,5 +20,4 @@
 
 .coral-Form-errorlabel {
   color: $form-errorlabel-color;
-  font-style: italic;
 }

--- a/coral-theme-spectrum/src/styles/vars.css
+++ b/coral-theme-spectrum/src/styles/vars.css
@@ -11746,6 +11746,7 @@
   --spectrum-light-fieldbutton-quiet-validation-icon-color-error-key-focus: rgb(201, 37, 45);
   --spectrum-light-fieldbutton-quiet-border-color-error-mouse-focus: rgb(215, 55, 63);
   --spectrum-light-fieldbutton-quiet-validation-icon-color-error-mouse-focus: rgb(201, 37, 45);
+  --spectrum-light-errorlabel-text-color: rgb(201, 37, 45);
   --spectrum-light-fieldlabel-asterisk-color: rgb(142, 142, 142);
   --spectrum-light-fieldlabel-text-color: rgb(110, 110, 110);
   --spectrum-light-fieldlabel-asterisk-color-disabled: rgb(179, 179, 179);
@@ -14556,6 +14557,7 @@
   --spectrum-lightest-fieldbutton-quiet-validation-icon-color-error-key-focus: rgb(215, 55, 63);
   --spectrum-lightest-fieldbutton-quiet-border-color-error-mouse-focus: rgb(227, 72, 80);
   --spectrum-lightest-fieldbutton-quiet-validation-icon-color-error-mouse-focus: rgb(215, 55, 63);
+  --spectrum-lightest-errorlabel-text-color: rgb(215, 55, 63);
   --spectrum-lightest-fieldlabel-asterisk-color: rgb(149, 149, 149);
   --spectrum-lightest-fieldlabel-text-color: rgb(116, 116, 116);
   --spectrum-lightest-fieldlabel-asterisk-color-disabled: rgb(188, 188, 188);
@@ -17366,6 +17368,7 @@
   --spectrum-dark-fieldbutton-quiet-validation-icon-color-error-key-focus: rgb(247, 109, 116);
   --spectrum-dark-fieldbutton-quiet-border-color-error-mouse-focus: rgb(236, 91, 98);
   --spectrum-dark-fieldbutton-quiet-validation-icon-color-error-mouse-focus: rgb(247, 109, 116);
+  --spectrum-dark-errorlabel-text-color: rgb(247, 109, 116);
   --spectrum-dark-fieldlabel-asterisk-color: rgb(144, 144, 144);
   --spectrum-dark-fieldlabel-text-color: rgb(185, 185, 185);
   --spectrum-dark-fieldlabel-asterisk-color-disabled: rgb(110, 110, 110);
@@ -20176,6 +20179,7 @@
   --spectrum-darkest-fieldbutton-quiet-validation-icon-color-error-key-focus: rgb(236, 91, 98);
   --spectrum-darkest-fieldbutton-quiet-border-color-error-mouse-focus: rgb(227, 72, 80);
   --spectrum-darkest-fieldbutton-quiet-validation-icon-color-error-mouse-focus: rgb(236, 91, 98);
+  --spectrum-darkest-errorlabel-text-color: rgb(236, 91, 98);
   --spectrum-darkest-fieldlabel-asterisk-color: rgb(124, 124, 124);
   --spectrum-darkest-fieldlabel-text-color: rgb(162, 162, 162);
   --spectrum-darkest-fieldlabel-asterisk-color-disabled: rgb(92, 92, 92);


### PR DESCRIPTION
Errors rely on color to communicate that they are errors.

## Description
Adding styles for a new coral-formfield-errorlabel that should
improve accesibility by adding a text that identifies the field
in error.

The text should have the color red and be situated below the input
field.

## Related Issue
N/A

## Motivation and Context
This PR would improve Coral Spectrum accessibility by helping colour blind users to determine what is the message for an invalid field.

## How Has This Been Tested?
The testing of the issue has been done using the examples page of the Coral Spectrum FormGroup component.

## Screenshots (if appropriate):
<img width="951" alt="Screenshot 2020-05-05 at 14 56 13" src="https://user-images.githubusercontent.com/53038821/81065141-a4b0ec00-8ee3-11ea-907d-c7ffde7e0d5f.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
