### PR TITLE
CUI-7385 Coral.Panel should not have role="tabpanel" in use cases other than Tabs

### DIFF
--- a/coral-component-autocomplete/src/tests/test.Autocomplete.js
+++ b/coral-component-autocomplete/src/tests/test.Autocomplete.js
@@ -1945,7 +1945,9 @@ describe('Autocomplete', function() {
 
           el.on('coral-overlay:close', function() {
             helpers.next(function() {
-              expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+              if (trigger) {
+                expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+              }
               done();
             });
           });

--- a/coral-component-panelstack/src/scripts/Panel.js
+++ b/coral-component-panelstack/src/scripts/Panel.js
@@ -88,8 +88,10 @@ class Panel extends BaseComponent(HTMLElement) {
     
     this.classList.add(CLASSNAME);
     
-    // adds the role to support accessibility
-    this.setAttribute('role', 'tabpanel');
+    // Adds the role to support accessibility when role is not already defined.
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'region');
+    }
   
     // Fetch the content zone elements
     const content = this._elements.content;

--- a/coral-component-panelstack/src/tests/test.Panel.js
+++ b/coral-component-panelstack/src/tests/test.Panel.js
@@ -63,7 +63,7 @@ describe('Panel', function() {
   describe('Implementation Details', function() {
     it('should have a role', function() {
       const el = helpers.build(new Panel());
-      expect(el.getAttribute('role')).to.equal('tabpanel');
+      expect(el.getAttribute('role')).to.equal('region');
     });
   })
 });

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -213,6 +213,9 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
         // creates a 2 way binding for accessibility
         this.setAttribute('aria-controls', realTarget.id);
         realTarget.setAttribute('aria-labelledby', this.id);
+
+        // adds role to panel to support accessibility
+        realTarget.setAttribute('role', 'tabpanel');
       }
     }
   }

--- a/coral-component-tablist/src/scripts/TabList.js
+++ b/coral-component-tablist/src/scripts/TabList.js
@@ -179,6 +179,9 @@ class TabList extends BaseComponent(HTMLElement) {
               // creates a 2 way binding for accessibility
               tab.setAttribute('aria-controls', panel.id);
               panel.setAttribute('aria-labelledby', tab.id);
+
+              // adds role to panel to support accessibility
+              panel.setAttribute('role', 'tabpanel');
             }
             else if (tab) {
               // cleans the aria since there is no matching panel

--- a/coral-component-tablist/src/tests/test.TabList.js
+++ b/coral-component-tablist/src/tests/test.TabList.js
@@ -319,6 +319,8 @@ describe('TabList', function() {
         helpers.next(function() {
           expect(targetItem.hasAttribute('selected')).to.be.true;
           expect(targetItem.getAttribute('aria-labelledby')).to.equal(tabItem.id);
+          expect(targetItem.getAttribute('role')).to.equal('tabpanel');
+          expect(tabItem.getAttribute('aria-controls')).to.equal(targetItem.id);
           done();
         });
       });


### PR DESCRIPTION
CUI-7385 Coral.Panel should not have role="tabpanel" in use cases other than Tabs

## Description
By default Coral.Panel regions have role="tabpanel", which is inappropriate for use cases where a Panel is not used as part of Coral.TabView.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7385

## Motivation and Context
Migrating Coral.StepList away from an implementation that uses the Tabs WAI-ARIA design pattern revealed that Coral.PanelStack is used outside of TabView, where `role="tabpanel"` is  inappropriate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
