### PR TITLE
CUI-7386 Coral.QuickActions: dismissing items with Esc key should restore focus to last focused element

### DIFF
--- a/coral-component-quickactions/examples/index.html
+++ b/coral-component-quickactions/examples/index.html
@@ -134,6 +134,73 @@
           <coral-quickactions-item icon="print">Print</coral-quickactions-item>
         </coral-quickactions>
       </div>
+
+      <h2 class="coral--Heading--S">Open on parent focus</h2>
+      <div class="markup">
+        <div class="box" role="link" tabindex="0">
+          Focus me
+          <coral-quickactions target="_parent" threshold="-1">
+            <coral-quickactions-item icon="copy">Copy</coral-quickactions-item>
+            <coral-quickactions-item icon="move">Move</coral-quickactions-item>
+            <coral-quickactions-item icon="download">Download</coral-quickactions-item>
+            <coral-quickactions-item icon="share">Share</coral-quickactions-item>
+            <coral-quickactions-item icon="assetsPublished">Publish</coral-quickactions-item>
+            <coral-quickactions-item icon="copy">Copy</coral-quickactions-item>
+            <coral-quickactions-item icon="lockClosed">Lock</coral-quickactions-item>
+            <coral-quickactions-item icon="lockOpen">Unlock</coral-quickactions-item>
+            <coral-quickactions-item icon="note">Annotate</coral-quickactions-item>
+            <coral-quickactions-item icon="paste">Paste</coral-quickactions-item>
+            <coral-quickactions-item icon="pinOn">Add Pin</coral-quickactions-item>
+            <coral-quickactions-item icon="pinOff">Remove Pin</coral-quickactions-item>
+            <coral-quickactions-item icon="print">Print</coral-quickactions-item>
+          </coral-quickactions>
+        </a>
+        <script>
+          (function (document, window) {
+
+            // opens descendant coral-quickactions when parent element receives focus
+            function handleQuickActionsTargetFocus(event) {
+              var currentTarget = event.currentTarget;
+              var quickActions = currentTarget.querySelector('coral-quickactions');
+              if (quickActions && !quickActions.open && !currentTarget._justClosed) {
+                quickActions.open = true;
+                currentTarget.addEventListener('blur', handleQuickActionsTargetBlur, true);
+                currentTarget.addEventListener('coral-overlay:beforeclose', handleQuickActionsBeforeClose, true);
+              }
+              else if (currentTarget._justClosed) {
+                currentTarget._justClosed = undefined;
+              }
+            }
+
+            // flags when quickactions were just closed, so that we don't reopen them when focus is restored to the target
+            function handleQuickActionsBeforeClose(event) {
+              event.currentTarget._justClosed = true;
+              event.currentTarget.removeEventListener('coral-overlay:beforeclose', handleQuickActionsBeforeClose, true);
+            }
+
+            // closes descendant coral-quickactions on focus outside of parent element
+            function handleQuickActionsTargetBlur(event) {
+              var currentTarget = event.currentTarget;
+              var quickActions = currentTarget.querySelector('coral-quickactions');
+              window.requestAnimationFrame(function() {
+                if (quickActions.open && !currentTarget.contains(document.activeElement)) {
+                  quickActions.open = false;
+                  currentTarget.removeEventListener('blur', handleQuickActionsTargetBlur, true);
+                  currentTarget.removeEventListener('coral-overlay:beforeclose', handleQuickActionsBeforeClose, true);
+                  currentTarget._justClosed = undefined;
+                }
+              });
+            }
+
+            // find focusable box elements
+            var focusables = document.querySelectorAll('.box[tabindex="0"]');
+            for (var i = 0; i < focusables.length; i++) {
+              var focusable = focusables[i];
+              focusable.addEventListener('focus', handleQuickActionsTargetFocus, true);
+            }
+          }(document, window));
+        </script>
+      </div>
     </main>
   </body>
 </html>

--- a/coral-component-quickactions/src/templates/base.html
+++ b/coral-component-quickactions/src/templates/base.html
@@ -1,4 +1,4 @@
-<button tracking="off" class="_coral-QuickActions-item _coral-QuickActions-item-more" variant="quietaction" is="coral-button" type="button" icon="more" iconsize="S" handle="moreButton" title="{{data.i18n.get('More actions')}}" role="menuitem" aria-haspopup="true" aria-label="{{data.i18n.get('More actions')}}"></button>
-<coral-popover class="_coral-QuickActions-moreOverlay" tracking="off" smart id="{{data.commons.getUID()}}" breadthoffset="50%p - 50%" placement="bottom" handle="overlay">
-  <coral-buttonlist tracking="off" id="{{data.commons.getUID()}}" class="_coral-QuickActions-buttonList" handle="buttonList" tabindex="-1"></coral-buttonlist>
+<button tracking="off" class="_coral-QuickActions-item _coral-QuickActions-item-more" variant="quietaction" is="coral-button" type="button" icon="more" iconsize="S" handle="moreButton" title="{{data.i18n.get('More actions')}}" role="menuitem" aria-haspopup="menu" aria-expanded="false" aria-label="{{data.i18n.get('More actions')}}"></button>
+<coral-popover class="_coral-QuickActions-moreOverlay" tracking="off" smart id="{{data.commons.getUID()}}" breadthoffset="50%p - 50%" placement="bottom" handle="overlay" role="presentation">
+  <coral-buttonlist tracking="off" id="{{data.commons.getUID()}}" class="_coral-QuickActions-buttonList" handle="buttonList" role="menu" tabindex="-1"></coral-buttonlist>
 </coral-popover>

--- a/coral-component-quickactions/src/tests/test.QuickActions.js
+++ b/coral-component-quickactions/src/tests/test.QuickActions.js
@@ -394,16 +394,18 @@ describe('QuickActions', function() {
       // Wait until opened
       el.on('coral-overlay:open', () => {
         var buttons = el.querySelectorAll(BUTTON_SELECTOR);
-        expect(document.activeElement).to.equal(el, 'QuickAction focused');
-        
-        helpers.keypress('down', el);
-        expect(document.activeElement).to.equal(buttons[0], 'First QuickAction item focused');
-        
-        helpers.keypress('right', buttons[0]);
-        expect(document.activeElement).to.equal(buttons[1], 'Second QuickAction item focused');
+        expect(document.activeElement).to.not.equal(el, 'QuickActions should not automatically focus when shown');
 
-        helpers.keypress('pagedown', buttons[1]);
-        expect(document.activeElement).to.equal(buttons[2], 'Third QuickAction item focused');
+        buttons[0].focus();
+        
+        helpers.keypress('down', buttons[0]);
+        expect(document.activeElement).to.equal(buttons[1], 'First QuickAction item focused');
+        
+        helpers.keypress('right', buttons[1]);
+        expect(document.activeElement).to.equal(buttons[2], 'Second QuickAction item focused');
+
+        helpers.keypress('pagedown', buttons[2]);
+        expect(document.activeElement).to.equal(buttons[3], 'Third QuickAction item focused');
 
         done();
       });
@@ -444,7 +446,7 @@ describe('QuickActions', function() {
       el.on('coral-overlay:open', () => {
         var buttons = el.querySelectorAll(BUTTON_SELECTOR);
       
-        expect(document.activeElement).to.equal(el, 'QuickAction focused initially');
+        expect(document.activeElement).to.not.equal(el, 'QuickActions should not automatically focus when shown');
 
         helpers.keypress('end', buttons[0]);
         expect(document.activeElement).to.equal(buttons[3], 'Last QuickAction item focused for end keypress');
@@ -524,7 +526,7 @@ describe('QuickActions', function() {
         var buttons = el.querySelectorAll(BUTTON_SELECTOR);
 
         helpers.next(function() {
-          expect(document.activeElement).to.equal(el, 'QuickAction focused');
+          expect(document.activeElement).to.equal(buttons[0], 'First QuickAction button focused');
 
           // Hit tab key
           helpers.keypress('tab', el);


### PR DESCRIPTION
## Description
1. QuickActions should not trap focus on hover
2. When opened using a keyboard shortcut, Shift+F10 or Ctrl+Space, QuickAction should trap focus and navigate as a menu.
3. Provide an example of displaying QuickActions when an ancestor receives focus, as in AEM Masonry.

## Related Issue
[CUI-7386](https://jira.corp.adobe.com/browse/CUI-7386),
[CQ-4293554](https://jira.corp.adobe.com/browse/CQ-4293554)

## Motivation and Context
Coral.QuickActions in AEM currently steal focus by default when opened on hover, and focus is lost to the document.body when the QuickActions overlay is closed using the Esc key. This is extremely problematic for accessibility, because focus is stolen and never returned to where it was originally forcing a keyboard or screen reader user to navigate back through the web page to get back to the element with which they were interacting.

## How Has This Been Tested?
Tested thoroughly on example page to ensure that.
1. QuickActions doesn't steal focus on hover,
2. but, the QuickActions menu can still be reached using tab key, even if it opened on hover.
3. When focus is within QuickActions that opened on hover, pressing Esc will restore focus to the target.
4. QuickActions opened with keyboard shortcut will trapFocus and behave like a context menu.
5. Esc key will restore focus to the target, or whatever element had focus before the QuickActions were opened.
6. I added an example of QuickActions that appear when focus lands on an ancestor element, which can be used as an example for how QuickActions on Cards within a CoralMasonry component should behave.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
