### PR TITLE
CQ-4291308 Port to Spectrum: Column View: the checkboxes in the grid all lack programmatic names (AEM Sites)

### DIFF
--- a/coral-component-checkbox/src/scripts/Checkbox.js
+++ b/coral-component-checkbox/src/scripts/Checkbox.js
@@ -217,6 +217,18 @@ class Checkbox extends BaseFormField(BaseComponent(HTMLElement)) {
     
     this._hideLabelIfEmpty();
   }
+
+    /**
+   Inherited from {@link BaseFormField#labelledBy}.
+   */
+  get labelledBy() {
+    return super.labelledBy;
+  }
+  set labelledBy(value) {
+    super.labelledBy = value;
+    
+    this._hideLabelIfEmpty();
+  }
   
   /**
    Inherited from {@link BaseComponent#trackingElement}.
@@ -319,7 +331,7 @@ class Checkbox extends BaseFormField(BaseComponent(HTMLElement)) {
 
     // Toggle the screen reader text
     this._elements.labelWrapper.style.margin = !hiddenValue ? '0' : '';
-    this._elements.screenReaderOnly.hidden = hiddenValue || this.labelled;
+    this._elements.screenReaderOnly.hidden = !!hiddenValue || !!this.labelledBy || !!this.labelled;
   }
   
   /**

--- a/coral-component-columnview/examples/index.html
+++ b/coral-component-columnview/examples/index.html
@@ -415,17 +415,21 @@
           });
 
           document.addEventListener('coral-columnview:navigate', function(event) {
-            const li = document.createElement('li');
-            li.innerHTML = '<b>navigate</b>: new: "' + event.detail.activeItem.textContent + '" old: "' + (event.detail.oldActiveItem && event.detail.oldActiveItem.textContent);
-            log.insertBefore(li, log.firstChild);
+            if (event.detail.activeItem) {
+              const li = document.createElement('li');
+              li.innerHTML = '<b>navigate</b>: new: "' + (event.detail.activeItem ? event.detail.activeItem.textContent : '') + '" old: "' + (event.detail.oldActiveItem && event.detail.oldActiveItem.textContent);
+              log.insertBefore(li, log.firstChild);
+            }
           });
 
           document.addEventListener('coral-columnview:activeitemchange', function(event) {
-            const li = document.createElement('li');
-            li.innerHTML = '<b>active</b>: new: "' + event.detail.activeItem.textContent + '" old: "' + (event.detail.oldActiveItem && event.detail.oldActiveItem.textContent);
-            log.insertBefore(li, log.firstChild);
+            if (event.detail.activeItem) {
+              const li = document.createElement('li');
+              li.innerHTML = '<b>active</b>: new: "' + (event.detail.activeItem ? event.detail.activeItem.content.textContent : '') + '" old: "' + (event.detail.oldActiveItem && event.detail.oldActiveItem.content.textContent);
+              log.insertBefore(li, log.firstChild);
+            }
 
-            document.getElementById('active_item').innerHTML = event.detail.activeItem ? event.detail.activeItem.textContent : '';
+            document.getElementById('active_item').innerHTML = event.detail.activeItem ? event.detail.activeItem.content.textContent : '';
           });
 
           document.addEventListener('coral-columnview:loaditems', function(event) {

--- a/coral-component-columnview/examples/index.html
+++ b/coral-component-columnview/examples/index.html
@@ -119,13 +119,13 @@
               </coral-columnview-item>
               <coral-columnview-item data-src="small-image.html">
                 <coral-columnview-item-thumbnail>
-                  <img alt="" src="https://placeimg.com/100/100/any">
+                  <img alt="" src="//placeimg.com/100/100/any">
                 </coral-columnview-item-thumbnail>
                 <coral-columnview-item-content>Small Image</coral-columnview-item-content>
               </coral-columnview-item>
               <coral-columnview-item data-src="huge-image.html">
                 <coral-columnview-item-thumbnail>
-                  <img alt="" src="https://placeimg.com/400/600/any">
+                  <img alt="" src="//placeimg.com/400/600/any">
                 </coral-columnview-item-thumbnail>
                 <coral-columnview-item-content>Huge Image with a really really long name</coral-columnview-item-content>
               </coral-columnview-item>
@@ -176,7 +176,7 @@
           <coral-columnview-preview lang="en">
             <coral-columnview-preview-content>
               <coral-columnview-preview-asset>
-                <img alt="" src="https://placeimg.com/1000/1000/any">
+                <img alt="" src="//placeimg.com/1000/1000/any">
               </coral-columnview-preview-asset>
               <coral-columnview-preview-label>This is a really really really long name</coral-columnview-preview-label>
               <coral-columnview-preview-value>document.txt</coral-columnview-preview-value>
@@ -206,7 +206,7 @@
           <coral-columnview-preview lang="en">
             <coral-columnview-preview-content>
               <coral-columnview-preview-asset>
-                <img alt="" src="https://placeimg.com/640/480/any">
+                <img alt="" src="//placeimg.com/640/480/any">
               </coral-columnview-preview-asset>
               <coral-columnview-preview-label>Title</coral-columnview-preview-label>
               <coral-columnview-preview-value>File2</coral-columnview-preview-value>
@@ -221,7 +221,7 @@
         <script type="text/html" id="huge-image.html">
           <coral-columnview-preview lang="en">
             <coral-columnview-preview-asset>
-              <img alt="" src="https://placeimg.com/1000/1000/any">
+              <img alt="" src="//placeimg.com/1000/1000/any">
             </coral-columnview-preview-asset>
             <coral-columnview-preview-label>Name</coral-columnview-preview-label>
             <coral-columnview-preview-value>Huge Image</coral-columnview-preview-value>
@@ -239,7 +239,7 @@
         <script type="text/html" id="small-image.html">
           <coral-columnview-preview lang="en">
             <coral-columnview-preview-asset>
-              <img alt="" src="https://placeimg.com/60/60/any">
+              <img alt="" src="//placeimg.com/60/60/any">
             </coral-columnview-preview-asset>
             <coral-columnview-preview-label>Name</coral-columnview-preview-label>
             <coral-columnview-preview-value>small_image.jpeg</coral-columnview-preview-value>

--- a/coral-component-columnview/examples/index.html
+++ b/coral-component-columnview/examples/index.html
@@ -108,7 +108,7 @@
               <coral-columnview-item variant="drilldown" data-src="content/en.html" icon="folder">
                 <coral-columnview-item-content>English</coral-columnview-item-content>
               </coral-columnview-item>
-              <coral-columnview-item variant="drilldown" data-src="content/fr.html" icon="folder">
+              <coral-columnview-item lang="fr" variant="drilldown" data-src="content/fr.html" icon="folder">
                 <coral-columnview-item-content>Français</coral-columnview-item-content>
               </coral-columnview-item>
               <coral-columnview-item variant="drilldown" data-src="content/levels.html" icon="folder">
@@ -143,7 +143,7 @@
         </script>
 
         <script type="text/html" id="file.icon.html">
-          <coral-columnview-preview>
+          <coral-columnview-preview lang="en">
             <coral-columnview-preview-content>
               <coral-columnview-preview-asset>
                 <coral-icon icon="document" size="L"></coral-icon>
@@ -173,7 +173,7 @@
         </script>
 
         <script type="text/html" id="file1.html">
-          <coral-columnview-preview>
+          <coral-columnview-preview lang="en">
             <coral-columnview-preview-content>
               <coral-columnview-preview-asset>
                 <img alt="" src="https://placeimg.com/1000/1000/any">
@@ -203,7 +203,7 @@
         </script>
 
         <script type="text/html" id="file2.html">
-          <coral-columnview-preview>
+          <coral-columnview-preview lang="en">
             <coral-columnview-preview-content>
               <coral-columnview-preview-asset>
                 <img alt="" src="https://placeimg.com/640/480/any">
@@ -219,7 +219,7 @@
         </script>
 
         <script type="text/html" id="huge-image.html">
-          <coral-columnview-preview>
+          <coral-columnview-preview lang="en">
             <coral-columnview-preview-asset>
               <img alt="" src="https://placeimg.com/1000/1000/any">
             </coral-columnview-preview-asset>
@@ -237,7 +237,7 @@
         </script>
 
         <script type="text/html" id="small-image.html">
-          <coral-columnview-preview>
+          <coral-columnview-preview lang="en">
             <coral-columnview-preview-asset>
               <img alt="" src="https://placeimg.com/60/60/any">
             </coral-columnview-preview-asset>
@@ -256,7 +256,7 @@
         </script>
 
         <script type="text/html" id="content/en/products.html">
-          <coral-columnview-column>
+          <coral-columnview-column lang="en">
             <coral-columnview-column-content>
               <coral-columnview-item data-src="file1.html" icon="document">
                 <coral-columnview-item-content>Product 1</coral-columnview-item-content>
@@ -269,7 +269,7 @@
         </script>
 
         <script type="text/html" id="content/en/services.html">
-          <coral-columnview-column>
+          <coral-columnview-column lang="en">
             <coral-columnview-column-content>
               <coral-columnview-item data-src="file1.html" icon="document">
                 <coral-columnview-item-content>Service 1</coral-columnview-item-content>
@@ -285,7 +285,7 @@
         </script>
 
         <script type="text/html" id="content/fr/products.html">
-          <coral-columnview-column>
+          <coral-columnview-column lang="fr">
             <coral-columnview-column-content>
               <coral-columnview-item data-src="file1.html" icon="document">
                 <coral-columnview-item-content>Produits 1</coral-columnview-item-content>
@@ -298,7 +298,7 @@
         </script>
 
         <script type="text/html" id="content/fr/services.html">
-          <coral-columnview-column>
+          <coral-columnview-column lang="fr">
             <coral-columnview-column-content>
               <coral-columnview-item data-src="file1.html" icon="document">
                 <coral-columnview-item-content>Service 1</coral-columnview-item-content>
@@ -311,7 +311,7 @@
         </script>
 
         <script type="text/html" id="content/en.html">
-          <coral-columnview-column>
+          <coral-columnview-column lang="en">
             <coral-columnview-column-content>
               <coral-columnview-item variant="drilldown" data-src="content/en/products.html" icon="folder">
                 <coral-columnview-item-content>Products</coral-columnview-item-content>
@@ -327,7 +327,7 @@
         </script>
 
         <script type="text/html" id="content/fr.html">
-          <coral-columnview-column>
+          <coral-columnview-column lang="fr">
             <coral-columnview-column-content>
               <coral-columnview-item variant="drilldown" data-src="content/fr/products.html" icon="folder">
                 <coral-columnview-item-content>Produits</coral-columnview-item-content>
@@ -343,7 +343,7 @@
         </script>
 
         <script type="text/html" id="content/levels.html">
-          <coral-columnview-column>
+          <coral-columnview-column lang="en">
             <coral-columnview-column-content>
               <coral-columnview-item variant="drilldown" data-src="content.html" icon="folder">
                 <coral-columnview-item-content>Infinite Levels</coral-columnview-item-content>

--- a/coral-component-columnview/i18n/translations.js
+++ b/coral-component-columnview/i18n/translations.js
@@ -12,46 +12,57 @@
 
 export default {
   "en-US": {
+    "Column View": "Column View",
     ", checked": ", checked",
     ", unchecked": ", unchecked"
   },
   "de-DE": {
+    "Column View": "Column View",
     ", checked": ", markiert",
     ", unchecked": ", nicht markiert"
   },
   "fr-FR": {
+    "Column View": "Column View",
     ", checked": ", cochée",
     ", unchecked": ", pas cochée"
   },
   "it-IT": {
+    "Column View": "Column View",
     ", checked": ", selezionata",
     ", unchecked": ", non selezionata"
   },
   "ja-JP": {
+    "Column View": "Column View",
     ", checked": "、チェック",
     ", unchecked": "、未チェック"
   },
   "es-ES": {
+    "Column View": "Column View",
     ", checked": ", marcada",
     ", unchecked": ", desmarcada"
   },
   "ko-KR": {
+    "Column View": "Column View",
     ", checked": ", 선택됨",
     ", unchecked": ", 선택되지 않은"
   },
   "zh-CN": {
+    "Column View": "Column View",
     ", checked": "，选中",
     ", unchecked": "，未选中"
   },
   "zh-TW": {
+    "Column View": "Column View",
     ", checked": "，選中",
     ", unchecked": "，未選中"
   },
   "pt-BR": {
+    "Column View": "Column View",
     ", checked": ", marcada",
     ", unchecked": ", desmarcada"
   },
   "nl-NL": {
+    "Column View": "Column View",
     ", checked": ", geselecteerd",
     ", unchecked": ", neit geselecteerd"
   },
@@ -60,30 +71,37 @@ export default {
     ", unchecked": ", ikke valgt"
   },
   "fi-FI": {
+    "Column View": "Column View",
     ", checked": ", valittu",
     ", unchecked": ", valittuna"
   },
   "nb-NO": {
+    "Column View": "Column View",
     ", checked": ", valgt",
     ", unchecked": ", ikke valgt"
   },
   "sv-SE": {
+    "Column View": "Column View",
     ", checked": ", markerad",
     ", unchecked": ", avmarkerad"
   },
   "cs-CZ": {
+    "Column View": "Column View",
     ", checked": ", vybráno",
     ", unchecked": ", není vybráno"
   },
   "pl-PL": {
+    "Column View": "Column View",
     ", checked": ", zaznaczone",
     ", unchecked": ", nie zaznaczone"
   },
   "ru-RU": {
+    "Column View": "Column View",
     ", checked": ", выбранный",
     ", unchecked": ", неотобранный"
   },
   "tr-TR": {
+    "Column View": "Column View",
     ", checked": ", seçilmiş",
     ", unchecked": ", seçilmemiş"
   }

--- a/coral-component-columnview/i18n/translations.js
+++ b/coral-component-columnview/i18n/translations.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export default {
+  "en-US": {
+    ", checked": ", checked",
+    ", unchecked": ", unchecked"
+  },
+  "de-DE": {
+    ", checked": ", markiert",
+    ", unchecked": ", nicht markiert"
+  },
+  "fr-FR": {
+    ", checked": ", cochée",
+    ", unchecked": ", pas cochée"
+  },
+  "it-IT": {
+    ", checked": ", selezionata",
+    ", unchecked": ", non selezionata"
+  },
+  "ja-JP": {
+    ", checked": "、チェック",
+    ", unchecked": "、未チェック"
+  },
+  "es-ES": {
+    ", checked": ", marcada",
+    ", unchecked": ", desmarcada"
+  },
+  "ko-KR": {
+    ", checked": ", 선택됨",
+    ", unchecked": ", 선택되지 않은"
+  },
+  "zh-CN": {
+    ", checked": "，选中",
+    ", unchecked": "，未选中"
+  },
+  "zh-TW": {
+    ", checked": "，選中",
+    ", unchecked": "，未選中"
+  },
+  "pt-BR": {
+    ", checked": ", marcada",
+    ", unchecked": ", desmarcada"
+  },
+  "nl-NL": {
+    ", checked": ", geselecteerd",
+    ", unchecked": ", neit geselecteerd"
+  },
+  "da-DK": {
+    ", checked": ", valgte",
+    ", unchecked": ", ikke valgt"
+  },
+  "fi-FI": {
+    ", checked": ", valittu",
+    ", unchecked": ", valittuna"
+  },
+  "nb-NO": {
+    ", checked": ", valgt",
+    ", unchecked": ", ikke valgt"
+  },
+  "sv-SE": {
+    ", checked": ", markerad",
+    ", unchecked": ", avmarkerad"
+  },
+  "cs-CZ": {
+    ", checked": ", vybráno",
+    ", unchecked": ", není vybráno"
+  },
+  "pl-PL": {
+    ", checked": ", zaznaczone",
+    ", unchecked": ", nie zaznaczone"
+  },
+  "ru-RU": {
+    ", checked": ", выбранный",
+    ", unchecked": ", неотобранный"
+  },
+  "tr-TR": {
+    ", checked": ", seçilmiş",
+    ", unchecked": ", seçilmemiş"
+  }
+}

--- a/coral-component-columnview/index.js
+++ b/coral-component-columnview/index.js
@@ -30,7 +30,13 @@ import ColumnViewPreviewValue from './src/scripts/ColumnViewPreviewValue';
 
 import './src/styles/index.css';
 
-import {commons} from '../coral-utils';
+import translations from './i18n/translations';
+import {strings, commons} from '../coral-utils';
+
+// i18n
+commons.extend(strings, {
+  'coral-component-columnview': translations
+});
 
 // Expose component on the Coral namespace
 commons._define('coral-columnview-preview', ColumnViewPreview);

--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -10,10 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+import accessibilityState from '../templates/accessibilityState';
 import {BaseComponent} from '../../../coral-base-component';
 import ColumnViewCollection from './ColumnViewCollection';
 import selectionMode from './selectionMode';
-import {transform, validate, commons} from '../../../coral-utils';
+import {transform, validate, commons, i18n} from '../../../coral-utils';
 
 const CLASSNAME = '_coral-MillerColumns';
 
@@ -53,6 +54,15 @@ class ColumnView extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
+
+    // Content zone
+    this._elements = {};
+
+    // Templates
+    accessibilityState.call(this._elements, {commons});
+    this._elements.accessibilityState.removeAttribute('aria-hidden');
+    this._elements.accessibilityState.hidden = true;
+    this.insertBefore(this._elements.accessibilityState, this.firstChild);
     
     // Events
     this._delegateEvents({
@@ -67,6 +77,13 @@ class ColumnView extends BaseComponent(HTMLElement) {
       'key:shift+up': '_onKeyShiftAndUp',
       'key:shift+down': '_onKeyShiftAndDown',
       'key:space': '_onKeySpace',
+      'key:control+a': '_onKeyCtrlA',
+      'key:command+a': '_onKeyCtrlA',
+      'key:control+shift+a': '_onKeyCtrlShiftA',
+      'key:command+shift+a': '_onKeyCtrlShiftA',
+      'key:esc': '_onKeyCtrlShiftA',
+
+      'capture:focus coral-columnview-item': '_onItemFocus',
   
       // column events
       'coral-columnview-column:_loaditems': '_onColumnLoadItems',
@@ -247,12 +264,69 @@ class ColumnView extends BaseComponent(HTMLElement) {
   _onColumnLoadItems(event) {
     // this is a private event and should not leave the column view
     event.stopImmediatePropagation();
+
+    this._updateAriaLevel(event.target);
+    this._ensureTabbableItem();
     
     // triggers an event to indicate more data could be loaded
     this.trigger('coral-columnview:loaditems', {
       column: event.target,
       start: event.detail.start,
       item: event.detail.item
+    });
+  }
+
+  /**
+    Handle when first selectable item is added and make sure it is tabbable.
+    @param {HTMLElement} [item]
+    @private
+  */
+  _onItemAdd() {
+    this._ensureTabbableItem();
+  }
+
+  /**
+    Handle when item is removed, make sure that at least one element is tabbable, or if there are no items, and add listener to handle when item is added.
+    @param {HTMLElement} [item]
+      Item that was removed.
+    @private
+  */
+  _onItemRemoved() {
+    this._ensureTabbableItem();
+  }
+
+  /* @private */
+  _ensureTabbableItem() {
+    this._vent.off('coral-collection:add', this._onItemAdd);
+    this._vent.off('coral-collection:remove', this._onItemRemoved);
+    if (this._timeout) {
+      cancelAnimationFrame(this._timeout);
+      clearTimeout(this._timeout);
+    }
+    this._timeout = commons.nextFrame(() => {
+      // Ensures that item will receive focus
+      if (!this.selectedItem && !this.activeItem) {
+        const selectableItems = this.items._getSelectableItems();
+        // If there are no selectable items, stop listening for items being removed and start listening for the next item added.
+        if (!selectableItems.length) {
+          this._vent.off('coral-collection:remove', this._onItemRemoved);
+          this._vent.on('coral-collection:add', this._onItemAdd);
+        }
+        else {
+          // Otherwise, if there is a selectable item, make sure it has a tabIndex.
+          selectableItems[0].tabIndex = 0;
+          // Listen for item removal so that we can handle the edge case where all items have been removed.
+          this._vent.on('coral-collection:remove', this._onItemRemoved);
+        }
+      }
+      else if (this.selectedItem && this.selectedItem.tabIndex !== 0) {
+        // If the selectedItem is not tabbable, make sure that it has tabIndex === 0
+        this.selectedItem.tabIndex = 0;
+      }
+      else if (this.activeItem && this.activeItem.tabIndex !== 0) {
+        // If the activeItem is not tabbable, make sure that it has tabIndex === 0
+        this.activeItem.tabIndex = 0;
+      }
     });
   }
   
@@ -298,6 +372,17 @@ class ColumnView extends BaseComponent(HTMLElement) {
   /** @private */
   _onKeyShiftAndUp(event) {
     event.preventDefault();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    // don't select items when focus is within the preview
+    if (matchedTarget.closest('coral-columnview-preview')) {
+      return;
+    }
+
+    if (this.selectionMode === selectionMode.NONE) {
+      this._onKeyUp(event);
+      return;
+    }
     
     // using _oldSelection since it should be equivalent to this.items._getSelectedItems() but faster
     const oldSelectedItems = this._oldSelection;
@@ -361,6 +446,10 @@ class ColumnView extends BaseComponent(HTMLElement) {
         lastSelected.firstSelectedItem :
         selectedItem.nextElementSibling
     };
+
+    if (selectedItem && selectedItem !== document.activeElement) {
+      selectedItem.focus();
+    }
     
     this._isKeyBoardMultiselect = false;
   }
@@ -368,6 +457,17 @@ class ColumnView extends BaseComponent(HTMLElement) {
   /** @private */
   _onKeyShiftAndDown(event) {
     event.preventDefault();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    // don't select items when focus is within the preview
+    if (matchedTarget.closest('coral-columnview-preview')) {
+      return;
+    }
+
+    if (this.selectionMode === selectionMode.NONE) {
+      this._onKeyDown(event);
+      return;
+    }
     
     // using _oldSelection since it should be equivalent to this.items._getSelectedItems() but faster
     const oldSelectedItems = this._oldSelection;
@@ -432,6 +532,10 @@ class ColumnView extends BaseComponent(HTMLElement) {
         lastSelected.firstSelectedItem :
         selectedItem.previousElementSibling
     };
+
+    if (selectedItem && selectedItem !== document.activeElement) {
+      selectedItem.focus();
+    }
     
     this._isKeyBoardMultiselect = false;
   }
@@ -439,6 +543,12 @@ class ColumnView extends BaseComponent(HTMLElement) {
   /** @private */
   _onKeyUp(event) {
     event.preventDefault();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    // don't navigate items when focus is within the preview
+    if (matchedTarget.closest('coral-columnview-preview')) {
+      return;
+    }
     
     // selection will win over active buttons, because they are the right most item. using _oldSelection since it
     // should be equivalent to this.items._getSelectedItems() but faster
@@ -446,10 +556,10 @@ class ColumnView extends BaseComponent(HTMLElement) {
     
     let item;
     if (selectedItems.length !== 0) {
-      const selectedItem = selectedItems[0];
+      const selectedItem = matchedTarget;
       
       item = selectedItem.previousElementSibling;
-      if (item) {
+      if (!item) {
         item = selectedItem;
       }
     }
@@ -461,14 +571,25 @@ class ColumnView extends BaseComponent(HTMLElement) {
     else {
       item = this._oldActiveItem.previousElementSibling;
     }
-    
+
     // we use click instead of selected to force the deselection of the other items
-    item.click();
+    if (item && item !== document.activeElement) {
+      item.focus();
+      if (this.selectionMode === selectionMode.NONE || selectedItems.length === 0) {
+        item.click();
+      }
+    }
   }
   
   /** @private */
   _onKeyDown(event) {
     event.preventDefault();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    // don't navigate items when focus is within the preview
+    if (matchedTarget.closest('coral-columnview-preview')) {
+      return;
+    }
     
     // selection will win over active buttons, because they are the right most item. using _oldSelection since it
     // should be equivalent to this.items._getSelectedItems() but faster
@@ -476,13 +597,13 @@ class ColumnView extends BaseComponent(HTMLElement) {
     
     let item;
     if (selectedItems.length !== 0) {
-      const selectedItem = selectedItems[selectedItems.length - 1];
+      const selectedItem = matchedTarget;
       
       item = selectedItem.nextElementSibling;
       
       // when
       if (!item) {
-        item = selectedItem;
+        item = matchedTarget;
       }
     }
     // when there is no active item to select, we get the first item of the column. this way users can interact with
@@ -495,17 +616,28 @@ class ColumnView extends BaseComponent(HTMLElement) {
     }
     
     // we use click instead of selected to force the deselection of the other items
-    item.click();
+    if (item && item !== document.activeElement) {
+      item.focus();
+      if (this.selectionMode === selectionMode.NONE || selectedItems.length === 0) {
+        item.click();
+      }
+    }
   }
   
   /** @private */
   _onKeyRight(event) {
     event.preventDefault();
-    
-    const nextColumn = this.activeItem.closest('coral-columnview-column').nextElementSibling;
-    
-    if (nextColumn) {
-      nextColumn.items._getFirstSelectable().click();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    if (matchedTarget.variant !== ColumnView.Item.variant.DRILLDOWN) {
+      return false;
+    }
+
+    const nextColumn = (this.activeItem && this.activeItem.closest('coral-columnview-column').nextElementSibling);
+      
+    if (nextColumn && nextColumn.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
+      // we need to make sure the column is initialized
+      commons.ready(nextColumn, () => this._focusAndActivateFirstSelectableItem(nextColumn));
     }
   }
   
@@ -523,25 +655,17 @@ class ColumnView extends BaseComponent(HTMLElement) {
       previousColumn = selectedItems[0].closest('coral-columnview-column').previousElementSibling;
     }
     // otherwise we use the activeItems as a reference
-    else {
-      previousColumn = this.activeItem.closest('coral-columnview-column').previousElementSibling;
+    else if (this.activeItem) {
+      const col = this.activeItem.closest('coral-columnview-column');
+      previousColumn = event.target.closest('coral-columnview-preview') ? col : col.previousElementSibling;
     }
-    
-    if (previousColumn) {
-      if (previousColumn.activeItem) {
-        // if there is an active item simply click it again
-        previousColumn.activeItem.click();
-      }
-      else {
-        // we need to find a candicate for activation
-        const firstSelectedItem = previousColumn.items._getFirstSelected();
-        
-        if (firstSelectedItem) {
-          firstSelectedItem.click();
-        }
-        else {
-          previousColumn.items._getFirstSelectable().click();
-        }
+
+    if (previousColumn && previousColumn.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
+      // we need to make sure the column is initialized
+      const activeDescendant = previousColumn.activeItem || previousColumn.items._getFirstSelected() || previousColumn.items._getFirstSelectable();
+      if (activeDescendant && activeDescendant !== document.activeElement) {
+        activeDescendant.focus();
+        activeDescendant.click();
       }
     }
   }
@@ -549,24 +673,130 @@ class ColumnView extends BaseComponent(HTMLElement) {
   /** @private */
   _onKeySpace(event) {
     event.preventDefault();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    // don't select item when focus is within the preview
+    if (matchedTarget.closest('coral-columnview-preview')) {
+      return;
+    }
     
     // using _oldSelection since it should be equivalent to this.items._getSelectedItems() but faster
     const selectedItems = this._oldSelection;
+    let activeDescendant;
     
     // when there is a selection, we need to activate the first item of the selection
     if (selectedItems.length !== 0) {
-      selectedItems[0].setAttribute('active', '');
+      activeDescendant = matchedTarget;
+      if (activeDescendant.hasAttribute('selected', '')) {
+        if (selectedItems.length === 1) {
+          activeDescendant.setAttribute('active', '');
+        }
+        else {
+          activeDescendant.removeAttribute('selected', '');
+        }
+      }
+      else {
+        activeDescendant.setAttribute('selected', '');
+      }
     }
     else {
-      const activeItem = this.activeItem;
+      const activeItem = this.activeItem || matchedTarget;
       // toggles the selection between active and selected
-      if (activeItem) {
+      if (activeItem && this.selectionMode !== selectionMode.NONE) {
         // select the item
         activeItem.setAttribute('selected', '');
+        activeDescendant = activeItem;
       }
     }
   }
-  
+
+  /** @private */
+  _onKeyCtrlA(event) {
+    event.preventDefault();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    // don't select item when focus is within the preview
+    if (matchedTarget.closest('coral-columnview-preview')) {
+      return;
+    }
+
+    if (this.selectionMode === selectionMode.MULTIPLE) {
+      const currentColumn = matchedTarget.closest('coral-columnview-column');
+      currentColumn.items._selectAll();
+    }
+    else if (this.selectionMode === selectionMode.SINGLE) {
+      if (!matchedTarget.hasAttribute('selected')) {
+        matchedTarget.setAttribute('selected', '');
+      }
+    }
+  }
+
+  /** @private */
+  _onKeyCtrlShiftA(event) {
+    event.preventDefault();
+    const matchedTarget = this._getRealMatchedTarget(event);
+
+    // don't select item when focus is within the preview
+    if (matchedTarget.closest('coral-columnview-preview')) {
+      return;
+    }
+
+    if (this.selectionMode !== selectionMode.NONE) {
+      const currentColumn = matchedTarget.closest('coral-columnview-column');
+      currentColumn.items._deselectAndDeactivateAllExcept(matchedTarget);
+      if (!matchedTarget.hasAttribute('active')) {
+        matchedTarget.setAttribute('active', '');
+      }
+    }
+  }
+
+  /** @private */
+  _onItemFocus(event) {
+    const matchedTarget = this._getRealMatchedTarget(event);
+    if (!matchedTarget.hasAttribute('active') && !this._oldSelection.length) {
+      matchedTarget.setAttribute('active', '');
+    }
+    this.items._getSelectableItems().forEach(item => {
+      item.tabIndex = item === matchedTarget ? 0 : -1;
+    });
+
+    if (matchedTarget.contains(document.activeElement)) {
+      matchedTarget.focus();
+    }
+  }
+
+  /** @ignore */
+  _updateAriaLevel(column) {
+    const colIndex = this.columns.getAll().indexOf(column);
+    const level = colIndex + 1;
+    if (column.items) {
+      column.items.getAll().filter((item, index) => {
+        item.setAttribute('aria-posinset', index + 1);
+        item.setAttribute('aria-setsize', column.items.length);
+        return !item.hasAttribute('aria-level');
+      }).forEach((item) => {
+        item.setAttribute('aria-level', level);
+      });
+    }
+
+    // root column has role="presentation"
+    if (colIndex === 0) {
+      column.setAttribute('role', 'presentation');
+      // and should not be labeled.
+      return;
+    }
+
+    // Make sure the column group has a label so that it can be navigated with VoiceOver
+    if (!column.hasAttribute('aria-labelledby')) {
+      if (!column.hasAttribute('aria-label')) {
+        column.setAttribute('aria-label', (this.getAttribute('aria-label') || '…'));
+      }
+    }
+    else if (column.getAttribute('aria-label') === (this.getAttribute('aria-label') || '…')) {
+      column.removeAttribute('aria-label');
+    }
+  }
+
   /** @private */
   _arraysAreDifferent(selection, oldSelection) {
     let diff = [];
@@ -707,10 +937,24 @@ class ColumnView extends BaseComponent(HTMLElement) {
     const addedNodesCount = addedNodes.length;
     for (let i = 0; i < addedNodesCount; i++) {
       item = addedNodes[i];
+      if (this.activeItem) {
+        // @a11y add aria-owns attribute to active item to express relationship of added column to the active item
+        this.activeItem.setAttribute('aria-owns', item.id);
+
+        // @a11y column or preview should be labelled by active item
+        item.setAttribute('aria-labelledby', this.activeItem.content.id);
+
+        // @a11y preview should provide description for active item
+        if (item.tagName === 'CORAL-COLUMNVIEW-PREVIEW') {
+          this.activeItem.setAttribute('aria-describedby', item.id);
+        }
+      }
+
       if (item.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
         // we use the property since the item may not be ready
         item.setAttribute('_selectionmode', this.selectionMode);
         this.trigger('coral-collection:add', {item});
+        this._updateAriaLevel(item);
       }
     }
     
@@ -731,6 +975,17 @@ class ColumnView extends BaseComponent(HTMLElement) {
     // initial state of the columnview
     this._oldActiveItem = this.activeItem;
     this._oldSelection = this.selectedItems;
+
+    if (!this._oldActiveItem && !this._oldSelection.length) {
+      const selectableItems = this.items._getSelectableItems();
+      if (selectableItems.length) {
+        selectableItems[0].tabIndex = 0;
+      }
+    }
+
+    if (this.columns && this.columns.first()) {
+      this._updateAriaLevel(this.columns.first());
+    }
   }
   
   /** @private */
@@ -787,6 +1042,9 @@ class ColumnView extends BaseComponent(HTMLElement) {
       
       // changes the old selection array since we selected something new
       this._oldSelection = newSelection;
+
+      // announce the selection state for the focused item
+      this._announceActiveElementState();
     }
   }
   
@@ -813,12 +1071,103 @@ class ColumnView extends BaseComponent(HTMLElement) {
       column: column
     });
   }
-  
+
+  /* @private */
+  _announceActiveElementState() {
+    const accessibilityState = this._elements.accessibilityState;
+
+    // utility method to clean up accessibility state
+    function resetAccessibilityState() {
+      accessibilityState.hidden = true;
+      accessibilityState.setAttribute('aria-live', 'off');
+      accessibilityState.innerHTML = '';
+    }
+    resetAccessibilityState();
+
+    if (this._addTimeout || this._removeTimeout) {
+      clearTimeout(this._addTimeout);
+      clearTimeout(this._removeTimeout);
+    }
+
+    // we use setTimeout instead of nextFrame to give screen reader 
+    // more time to respond to live region update in order to announce 
+    // complete text content when the state changes.
+    this._addTimeout = window.setTimeout(() => {
+      const activeElement = document.activeElement.closest('coral-columnview-item') || document.activeElement;
+
+      if (!this.contains(activeElement)) {
+        return;
+      }
+
+      const span = document.createElement('span');
+      const contentSpan = document.createElement('span');
+      const lang = !activeElement.hasAttribute('lang') && activeElement.closest('[lang]') ? activeElement.closest('[lang]').getAttribute('lang') : activeElement.getAttribute('lang');
+      if (lang && lang !== i18n.locale) {
+        contentSpan.setAttribute('lang', lang);
+      }
+      contentSpan.innerHTML = activeElement._elements.content.innerText;
+      span.appendChild(contentSpan);
+      span.appendChild(
+        document.createTextNode(
+          i18n.get(activeElement.selected ? ', checked' : ', unchecked')
+        )
+      );
+      accessibilityState.hidden = false;
+      accessibilityState.setAttribute('aria-live', 'assertive');
+      accessibilityState.appendChild(span);
+
+      // give screen reader 2 secs before clearing the live region, to provide enough time for announcement
+      this._removeTimeout = window.setTimeout(resetAccessibilityState, 2000);
+    }, 20);
+  }
+
+  /**
+   * Helper function to extract the correct matchedTarget from the event.
+   *
+   * Tests can interact with ColumnView directly where the key events are triggered on
+   * the ColumnView itself. In that case the event.matchedTarget point to the ColumnView
+   * instead of the ColumnViewItem, in other word the active or selected element.
+   *
+   * @private
+   **/
+  _getRealMatchedTarget(event) {
+    if (event.matchedTarget.nodeName !== 'CORAL-COLUMNVIEW') {
+      return event.matchedTarget;
+    }
+    if (event.matchedTarget.contains(document.activeElement) && document.activeElement.nodeName === 'CORAL-COLUMNVIEW-ITEM') {
+      return document.activeElement;
+    }
+    if (event.matchedTarget.selectedItem) {
+      return event.matchedTarget.selectedItem;
+    }
+    if (event.matchedTarget.activeItem) {
+      return event.matchedTarget.activeItem;
+    }
+  }
+
+  _focusAndActivateFirstSelectableItem(column) {
+    let item;
+
+    if (column.items) {
+      item = column.items._getFirstSelectable();
+    }
+    else if (column.tagName === 'CORAL-COLUMNVIEW-PREVIEW') {
+      item = this.selectedItems[0] || this.activeItem;
+    }
+
+    if (item && item !== document.activeElement) {
+      item.focus();
+      if (this.selectionMode === selectionMode.NONE || this._oldSelection.length === 0) {
+        item.click();
+      }
+    }
+  }
+
   /** @ignore */
   focus() {
     // selected items go first because there is no active item in a column with selection
     const item = this.selectedItems[0] || this.activeItem;
-    if (item) {
+    if (item && item !== document.activeElement) {
       item.focus();
     }
   }
@@ -842,6 +1191,8 @@ class ColumnView extends BaseComponent(HTMLElement) {
     scrollToColumn = typeof scrollToColumn === 'undefined' || scrollToColumn;
     
     const column = referenceColumn || null;
+
+    let columnReplacedContainedFocus = false;
     
     // handles the case where the first column needs to be added
     if (column === null || !this.contains(column)) {
@@ -851,6 +1202,7 @@ class ColumnView extends BaseComponent(HTMLElement) {
       const nextColumn = column.nextElementSibling;
       
       if (nextColumn) {
+        columnReplacedContainedFocus = nextColumn.contains(document.activeElement);
         this._emptyColumnsNextToColumn(column);
         const before = nextColumn.nextElementSibling;
         this.removeChild(nextColumn);
@@ -860,14 +1212,22 @@ class ColumnView extends BaseComponent(HTMLElement) {
         this.appendChild(newColumn);
       }
     }
-    
-    if (scrollToColumn) {
-      // event is not triggered because it is handled separately
-      this._scrollColumnIntoView(newColumn, true, false);
-    }
-    
-    // we notify that the columnview navigated and it is ready to be used
-    this._validateNavigation(newColumn);
+
+    // if we want to scroll to it, we need for it to be ready due to measurements
+    commons.ready(newColumn, () => {
+      if (scrollToColumn) {
+        // event is not triggered because it is handled separately
+        this._scrollColumnIntoView(newColumn, true, false);
+      }
+
+      // we notify that the columnview navigated and it is ready to be used
+      this._validateNavigation(newColumn);
+
+      // if the column the newColumn replaces contained focus, restore focus to an item in the newColumn
+      if (columnReplacedContainedFocus && !newColumn.contains(document.activeElement)) {
+        this._focusAndActivateFirstSelectableItem(newColumn);
+      }
+    });
   }
   
   /**
@@ -896,8 +1256,10 @@ class ColumnView extends BaseComponent(HTMLElement) {
     
     this.classList.add(CLASSNAME);
     
+    // @a11y
+    this.setAttribute('role', 'tree');
     // @a11y: the columnview needs to be focusable to handle a11y properly
-    this.setAttribute('tabindex', '0');
+    this.tabIndex = -1;
     
     // Default reflect attributes
     if (!this._selectionMode) { this._selectionMode = selectionMode.NONE; }

--- a/coral-component-columnview/src/scripts/ColumnViewCollection.js
+++ b/coral-component-columnview/src/scripts/ColumnViewCollection.js
@@ -42,6 +42,16 @@ class ColumnViewCollection extends SelectableCollection {
   _getAllActive() {
     return this._getAllSelected('active');
   }
+
+  _selectAll() {
+    this
+      .getAll()
+      .forEach((el) => {
+        if (!el.hasAttribute('selected')) {
+          el.setAttribute('selected', '');
+        }
+      });
+  }
 }
 
 export default ColumnViewCollection;

--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -218,39 +218,42 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
       // toggles the selection of the item
       const isSelected = item.hasAttribute('selected');
       
-      if (!isSelected) {
-        // Handle multi-selection with shiftKey
-         if (event.shiftKey && this._selectionMode === selectionMode.MULTIPLE) {
-          const lastSelectedItem = this._lastSelectedItems[this._lastSelectedItems.length - 1];
+      // Handle multi-selection with shiftKey
+      if (!isSelected && event.shiftKey && this._selectionMode === selectionMode.MULTIPLE) {
+        const lastSelectedItem = this._lastSelectedItems[this._lastSelectedItems.length - 1];
+  
+        if (lastSelectedItem) {
+          const items = this.items.getAll();
+          const lastSelectedItemIndex = items.indexOf(lastSelectedItem);
+          const selectedItemIndex = items.indexOf(item);
     
-          if (lastSelectedItem) {
-            const items = this.items.getAll();
-            const lastSelectedItemIndex = items.indexOf(lastSelectedItem);
-            const selectedItemIndex = items.indexOf(item);
-      
-            // true : selection goes up, false : selection goes down
-            const direction = selectedItemIndex < lastSelectedItemIndex;
-            const selectionRange = [];
-            let selectionIndex = lastSelectedItemIndex;
-      
-            // Retrieve all items in the range
-            while (selectedItemIndex !== selectionIndex) {
-              selectionIndex = direction ? selectionIndex - 1 : selectionIndex + 1;
-              selectionRange.push(items[selectionIndex]);
-            }
-      
-            // Select all items in the range silently
-            selectionRange.forEach((rangeItem) => {
-              // Except for item which is needed to trigger the selection change event
-              if (rangeItem !== item) {
-                rangeItem.set('selected', true, true);
-              }
-            });
+          // true : selection goes up, false : selection goes down
+          const direction = selectedItemIndex < lastSelectedItemIndex;
+          const selectionRange = [];
+          let selectionIndex = lastSelectedItemIndex;
+    
+          // Retrieve all items in the range
+          while (selectedItemIndex !== selectionIndex) {
+            selectionIndex = direction ? selectionIndex - 1 : selectionIndex + 1;
+            selectionRange.push(items[selectionIndex]);
           }
+    
+          // Select all items in the range silently
+          selectionRange.forEach((rangeItem) => {
+            // Except for item which is needed to trigger the selection change event
+            if (rangeItem !== item) {
+              rangeItem.set('selected', true, true);
+            }
+          });
         }
       }
       
       item[isSelected ? 'removeAttribute' : 'setAttribute']('selected', '');
+
+      // if item was selected, make it active
+      if (isSelected && !this._lastSelectedItems.length) {
+        item.setAttribute('active', '');
+      }
     }
   }
   
@@ -555,6 +558,8 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
   
     // @a11y
     this.setAttribute('role', 'group');
+
+    this.id = this.id || commons.getUID();
   
     // @todo: initial collection items needs to be triggered
   
@@ -568,6 +573,9 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
         content.appendChild(this.firstChild);
       }
     }
+
+    // @a11y
+    content.setAttribute('role', 'presentation');
     
     // Call content zone insert
     this.content = content;

--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -10,11 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
+import accessibilityState from '../templates/accessibilityState';
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseLabellable} from '../../../coral-base-labellable';
 import {Icon} from '../../../coral-component-icon';
 import {Checkbox} from '../../../coral-component-checkbox';
-import {transform, validate} from '../../../coral-utils';
+import {commons, i18n, transform, validate} from '../../../coral-utils';
 
 const CLASSNAME = '_coral-AssetList-item';
 
@@ -50,6 +51,9 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
       content: this.querySelector('coral-columnview-item-content') || document.createElement('coral-columnview-item-content'),
       thumbnail: this.querySelector('coral-columnview-item-thumbnail') || document.createElement('coral-columnview-item-thumbnail')
     };
+
+    // Templates
+    accessibilityState.call(this._elements, {commons});
   
     super._observeLabel();
   }
@@ -120,9 +124,13 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
       }
       
       this.classList.add('is-branch');
+
+      // @a11y Update aria-expanded. Active drilldowns should be expanded.
+      this.setAttribute('aria-expanded', this.active);
     }
     else {
       this.classList.remove('is-branch');
+      this.removeAttribute('aria-expanded');
     }
   }
   
@@ -178,7 +186,28 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
     this._reflectAttribute('selected', this._selected);
   
     this.classList.toggle('is-selected', this._selected);
-    this.setAttribute('aria-selected', this._selected || this.active);
+    this.setAttribute('aria-selected', this._selected);
+
+    // @a11y Update aria-expanded. Active drilldowns should be expanded.
+    if (this.variant === variant.DRILLDOWN) {
+      this.setAttribute('aria-expanded', this.active);
+    }
+
+    if (this.selected) {
+
+      // @a11y Panels to right of selected item are removed, so remove aria-owns and aria-describedby attributes.
+      this.removeAttribute('aria-owns');
+      this.removeAttribute('aria-describedby');
+
+      // @a11y Update content to ensure that checked state is announced by assistive technology when the item receives focus
+      this._elements.accessibilityState.innerHTML = i18n.get(', checked');
+    }
+    // @a11y If deselecting from checked state,
+    else {
+
+      // @a11y Update content to remove checked state
+      this._elements.accessibilityState.innerHTML = '';
+    }
   
     // Sync checkbox item selector
     const itemSelector = this.querySelector('coral-checkbox[coral-columnview-itemselect]');
@@ -205,7 +234,18 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
     this._reflectAttribute('active', this._active);
   
     this.classList.toggle('is-navigated', this._active);
-    this.setAttribute('aria-selected', this._active || this.selected);
+    this.setAttribute('aria-selected', this._active);
+
+    // @a11y Update aria-expanded. Active drilldowns should be expanded.
+    if (this.variant === variant.DRILLDOWN) {
+      this.setAttribute('aria-expanded', this._active);
+    }
+
+    if (!this._active) {
+      // @a11y Inactive items are not expanded, so remove aria-owns and aria-describedby attributes.
+      this.removeAttribute('aria-owns');
+      this.removeAttribute('aria-describedby');
+    }
     
     this.trigger('coral-columnview-item:_activechanged');
   }
@@ -233,6 +273,8 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
         if (!itemSelector) {
           itemSelector = new Checkbox();
           itemSelector.setAttribute('coral-columnview-itemselect', '');
+          itemSelector._elements.input.tabIndex = -1;
+          itemSelector.setAttribute('labelledby', this.content.id);
       
           // Add the item selector as first child
           this.insertBefore(itemSelector, this.firstChild);
@@ -270,6 +312,10 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
   
     // @a11y
     this.setAttribute('role', 'treeitem');
+
+    this.id = this.id || Coral.commons.getUID();
+
+    this.tabIndex = this.active || this.selected ? 0 : -1;
     
     // Default reflected attributes
     if (!this._variant) { this.variant = variant.DEFAULT; }
@@ -289,6 +335,31 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
     // Assign content zones
     this.content = content;
     this.thumbnail = thumbnail;
+
+    // @a11y thumbnail img element should have alt attribute
+    const thumbnailImg = thumbnail.querySelector('img:not([alt])');
+    if (thumbnailImg) {
+      thumbnailImg.setAttribute('alt', '');
+    }
+
+    // @ally add aria-labelledby so that JAWS/IE announces item correctly
+    thumbnail.id = thumbnail.id || Coral.commons.getUID();
+
+    content.id = content.id || Coral.commons.getUID();
+
+    // @a11y Add live region element to ensure announcement of selected state
+    const accessibilityState = this._elements.accessibilityState;
+
+    // @a11y accessibility state string should announce in document lang, rather than item lang.
+    accessibilityState.setAttribute('lang', i18n.locale);
+
+    // @a11y append live region content element
+    if (!this.contains(accessibilityState)) {
+      this.appendChild(accessibilityState);
+    }
+
+    // @a11y Item should be labelled by thumbnail, content, and accessibility state.
+    this.setAttribute('aria-labelledby', thumbnail.id + ' ' + content.id + ' ' + accessibilityState.id);
   }
 }
 

--- a/coral-component-columnview/src/scripts/ColumnViewPreview.js
+++ b/coral-component-columnview/src/scripts/ColumnViewPreview.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {commons} from '../../../coral-utils';
 
 const CLASSNAME = '_coral-MillerColumns-item';
 
@@ -57,6 +58,10 @@ class ColumnViewPreview extends BaseComponent(HTMLElement) {
   /** @ignore */
   render() {
     super.render();
+
+    this.setAttribute('role', 'group');
+
+    this.id = this.id || commons.getUID();
     
     this.classList.add(CLASSNAME);
     
@@ -73,6 +78,50 @@ class ColumnViewPreview extends BaseComponent(HTMLElement) {
     
     // Call content zone insert
     this.content = content;
+
+    this._makeAccessible();
+  }
+
+  /** @ignore */
+  _makeAccessible() {
+    
+    // @a11y For item values with a label, identify the value as a focusable, readOnly textbox labeled by the label. 
+    let elements = this.content.querySelectorAll('coral-columnview-preview-label + coral-columnview-preview-value');
+    let length = elements.length;
+    let i;
+    let element;
+    let elementLabel;
+    for (i = 0; i < length; i++) {
+      element = elements[i];
+      elementLabel = element.previousElementSibling;
+      elementLabel.id = elementLabel.id || commons.getUID();
+      element.setAttribute('aria-labelledby', elementLabel.id);
+      element.setAttribute('role', 'textbox');
+      element.setAttribute('tabindex', '0');
+      element.setAttribute('aria-readonly', 'true');
+
+      // force ChromeVox to read value of textbox
+      if (window.cvox) {
+        element.setAttribute('aria-valuetext', element.textContent);
+      }
+    }
+
+    // @a11y Expose separator as a horizontally-oriented separator.
+    elements = this.content.querySelectorAll('coral-columnview-preview-separator');
+    length = elements.length;
+    for (i = 0; i < length; i++) {
+      element = elements[i];
+      element.setAttribute('role', 'separator');
+      element.setAttribute('aria-orientation', 'horizontal');
+    }
+
+    // @a11y If the preview asset image does not include an alt attribute, set alt="", so that screen readers do not announce the image url. 
+    elements = this.content.querySelectorAll('coral-columnview-preview-asset > img:not([alt])');
+    length = elements.length;
+    for (i = 0; i < length; i++) {
+      element = elements[i];
+      element.setAttribute('alt', '');
+    }
   }
 }
 

--- a/coral-component-columnview/src/styles/dark.styl
+++ b/coral-component-columnview/src/styles/dark.styl
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+ 
+@require '../../../coral-theme-spectrum/src/styles/vars.css';
+
+$columnview-preview-value-border-color = var(--spectrum-dark-textfield-quiet-border-color-key-focus);
+$columnview-preview-value-shadow-color = var(--spectrum-dark-textfield-quiet-border-color-key-focus);
+
+.coral--dark {
+  @import 'skin.styl'
+}

--- a/coral-component-columnview/src/styles/darkest.styl
+++ b/coral-component-columnview/src/styles/darkest.styl
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+ 
+@require '../../../coral-theme-spectrum/src/styles/vars.css';
+
+$columnview-preview-value-border-color = var(--spectrum-darkest-textfield-quiet-border-color-key-focus);
+$columnview-preview-value-shadow-color = var(--spectrum-darkest-textfield-quiet-border-color-key-focus);
+
+.coral--darkest {
+  @import 'skin.styl'
+}

--- a/coral-component-columnview/src/styles/index.styl
+++ b/coral-component-columnview/src/styles/index.styl
@@ -56,6 +56,10 @@
   }
 }
 
+coral-columnview-preview._coral-MillerColumns-item {
+  padding-bottom: var(--spectrum-medium-textfield-quiet-border-size-key-focus);
+}
+
 coral-columnview-preview-asset {
 // contains the image
   position: relative;
@@ -112,6 +116,15 @@ coral-columnview-preview-value {
   > coral-icon {
     margin-right: 5px;
   }
+
+  &:focus {
+    outline: 0;
+    &.focus-ring {
+      margin-bottom: -var(--spectrum-medium-textfield-quiet-border-size-key-focus);
+      border-bottom-style: solid;
+      border-bottom-width: var(--spectrum-medium-textfield-quiet-border-size-key-focus);
+    }
+  }
 }
 
 coral-columnview-preview-separator {
@@ -128,4 +141,10 @@ coral-columnview-preview-content {
 
 coral-columnview-preview-content.coral-Body--small {
   margin-bottom: 0;
+  padding-bottom: var(--spectrum-medium-textfield-quiet-border-size-key-focus);
 }
+
+@require 'light';
+@require 'lightest';
+@require 'dark';
+@require 'darkest';

--- a/coral-component-columnview/src/styles/light.styl
+++ b/coral-component-columnview/src/styles/light.styl
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+@require '../../../coral-theme-spectrum/src/styles/vars.css';
+
+
+$columnview-preview-value-border-color = var(--spectrum-light-textfield-quiet-border-color-key-focus);
+$columnview-preview-value-shadow-color = var(--spectrum-light-textfield-quiet-border-color-key-focus);
+
+.coral--light {
+  @import 'skin.styl';
+}

--- a/coral-component-columnview/src/styles/lightest.styl
+++ b/coral-component-columnview/src/styles/lightest.styl
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+ 
+@require '../../../coral-theme-spectrum/src/styles/vars.css';
+
+$columnview-preview-value-border-color = var(--spectrum-lightest-textfield-quiet-border-color-key-focus);
+$columnview-preview-value-shadow-color = var(--spectrum-lightest-textfield-quiet-border-color-key-focus);
+
+.coral--lightest {
+  @import 'skin.styl'
+}

--- a/coral-component-columnview/src/styles/skin.styl
+++ b/coral-component-columnview/src/styles/skin.styl
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+coral-columnview-preview-value:focus.focus-ring {
+  border-color: $columnview-preview-value-border-color;
+}

--- a/coral-component-columnview/src/templates/accessibilityState.html
+++ b/coral-component-columnview/src/templates/accessibilityState.html
@@ -1,1 +1,1 @@
-<span handle="accessibilityState" class="u-coral-screenReaderOnly" aria-hidden="true" id="{{data.commons.getUID()}}"></span>
+<span handle="accessibilityState" class="u-coral-screenReaderOnly" aria-hidden="true" id="{{data.commons.getUID()}}" role="presentation" aria-live="off" aria-atomic="true"></span>

--- a/coral-component-columnview/src/templates/accessibilityState.html
+++ b/coral-component-columnview/src/templates/accessibilityState.html
@@ -1,0 +1,1 @@
+<span handle="accessibilityState" class="u-coral-screenReaderOnly" aria-hidden="true" id="{{data.commons.getUID()}}"></span>

--- a/coral-component-columnview/src/tests/snippets/ColumnView.Preview.content.html
+++ b/coral-component-columnview/src/tests/snippets/ColumnView.Preview.content.html
@@ -1,7 +1,7 @@
 <coral-columnview-preview>
   <coral-columnview-preview-content>
     <coral-columnview-preview-asset>
-      <img src="http://lorempixel.com/60/60">
+      <img src="//placeimg.com/60/60/any" alt="FPO asset image" />
     </coral-columnview-preview-asset>
     <coral-columnview-preview-label>Name</coral-columnview-preview-label>
     <coral-columnview-preview-value>small_image.jpeg</coral-columnview-preview-value>

--- a/coral-component-columnview/src/tests/snippets/ColumnView.Preview.content.implicit.html
+++ b/coral-component-columnview/src/tests/snippets/ColumnView.Preview.content.implicit.html
@@ -1,6 +1,6 @@
 <coral-columnview-preview>
   <coral-columnview-preview-asset>
-    <img src="http://lorempixel.com/60/60">
+    <img src="//placeimg.com/60/60/any" />
   </coral-columnview-preview-asset>
   <coral-columnview-preview-label>Name</coral-columnview-preview-label>
   <coral-columnview-preview-value>small_image.jpeg</coral-columnview-preview-value>

--- a/coral-component-columnview/src/tests/snippets/examples/content.en.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.en.html
@@ -1,4 +1,4 @@
-<coral-columnview-column>
+<coral-columnview-column lang="en">
   <coral-columnview-column-content>
     <coral-columnview-item variant="drilldown" data-src="content.en.products.html" icon="folder">
       <coral-columnview-item-content>Products</coral-columnview-item-content>

--- a/coral-component-columnview/src/tests/snippets/examples/content.en.products.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.en.products.html
@@ -1,4 +1,4 @@
-<coral-columnview-column>
+<coral-columnview-column lang="en">
   <coral-columnview-column-content>
     <coral-columnview-item data-src="file1.html" icon="document">
       <coral-columnview-item-content>Product 1</coral-columnview-item-content>

--- a/coral-component-columnview/src/tests/snippets/examples/content.en.services.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.en.services.html
@@ -1,4 +1,4 @@
-<coral-columnview-column>
+<coral-columnview-column lang="en">
   <coral-columnview-column-content>
     <coral-columnview-item data-src="file1.html" icon="document">
       <coral-columnview-item-content>Service 1</coral-columnview-item-content>

--- a/coral-component-columnview/src/tests/snippets/examples/content.fr.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.fr.html
@@ -1,4 +1,4 @@
-<coral-columnview-column>
+<coral-columnview-column lang="fr">
   <coral-columnview-column-content>
     <coral-columnview-item variant="drilldown" data-src="content.fr.products.html" icon="folder">
       <coral-columnview-item-content>Produits</coral-columnview-item-content>

--- a/coral-component-columnview/src/tests/snippets/examples/content.fr.products.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.fr.products.html
@@ -1,4 +1,4 @@
-<coral-columnview-column>
+<coral-columnview-column lang="fr">
   <coral-columnview-column-content>
     <coral-columnview-item data-src="file1.html" icon="document">
       <coral-columnview-item-content>Produits 1</coral-columnview-item-content>

--- a/coral-component-columnview/src/tests/snippets/examples/content.fr.services.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.fr.services.html
@@ -1,4 +1,4 @@
-<coral-columnview-column>
+<coral-columnview-column lang="fr">
   <coral-columnview-column-content>
     <coral-columnview-item data-src="file1.html" icon="document">
       <coral-columnview-item-content>Service 1</coral-columnview-item-content>

--- a/coral-component-columnview/src/tests/snippets/examples/content.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.html
@@ -14,13 +14,13 @@
     </coral-columnview-item>
     <coral-columnview-item data-src="small-image.html">
       <coral-columnview-item-thumbnail>
-        <img src="http://lorempixel.com/100/100">
+        <img src="//placeimg.com/100/100/any">
       </coral-columnview-item-thumbnail>
       <coral-columnview-item-content>Small Image</coral-columnview-item-content>
     </coral-columnview-item>
     <coral-columnview-item data-src="huge-image.html">
       <coral-columnview-item-thumbnail>
-        <img src="http://lorempixel.com/400/600">
+        <img src="//placeimg.com/400/600/any">
       </coral-columnview-item-thumbnail>
       <coral-columnview-item-content>Huge Image with a really really long name</coral-columnview-item-content>
     </coral-columnview-item>

--- a/coral-component-columnview/src/tests/snippets/examples/content.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.html
@@ -3,7 +3,7 @@
     <coral-columnview-item variant="drilldown" data-src="content.en.html" icon="folder">
       <coral-columnview-item-content>English</coral-columnview-item-content>
     </coral-columnview-item>
-    <coral-columnview-item variant="drilldown" data-src="content.fr.html" icon="folder">
+    <coral-columnview-item lang="fr" variant="drilldown" data-src="content.fr.html" icon="folder">
       <coral-columnview-item-content>Français</coral-columnview-item-content>
     </coral-columnview-item>
     <coral-columnview-item variant="drilldown" data-src="content.levels.html" icon="folder">

--- a/coral-component-columnview/src/tests/snippets/examples/content.levels.html
+++ b/coral-component-columnview/src/tests/snippets/examples/content.levels.html
@@ -1,4 +1,4 @@
-<coral-columnview-column>
+<coral-columnview-column lang="en">
   <coral-columnview-column-content>
     <coral-columnview-item variant="drilldown" data-src="content.html" icon="folder">
       <coral-columnview-item-content>Infinite Levels</coral-columnview-item-content>

--- a/coral-component-columnview/src/tests/snippets/examples/file.icon.html
+++ b/coral-component-columnview/src/tests/snippets/examples/file.icon.html
@@ -1,4 +1,4 @@
-<coral-columnview-preview>
+<coral-columnview-preview lang="en">
   <coral-columnview-preview-content>
     <coral-columnview-preview-asset>
       <coral-icon icon="document" size="L"></coral-icon>

--- a/coral-component-columnview/src/tests/snippets/examples/file1.html
+++ b/coral-component-columnview/src/tests/snippets/examples/file1.html
@@ -1,4 +1,4 @@
-<coral-columnview-preview>
+<coral-columnview-preview lang="en">
   <coral-columnview-preview-content>
     <coral-columnview-preview-asset>
       <img src="http://lorempixel.com/1000/1000">

--- a/coral-component-columnview/src/tests/snippets/examples/file1.html
+++ b/coral-component-columnview/src/tests/snippets/examples/file1.html
@@ -1,7 +1,7 @@
 <coral-columnview-preview lang="en">
   <coral-columnview-preview-content>
     <coral-columnview-preview-asset>
-      <img src="http://lorempixel.com/1000/1000">
+      <img src="//placeimg.com/1000/1000/any">
     </coral-columnview-preview-asset>
     <coral-columnview-preview-label>This is a really really really long name</coral-columnview-preview-label>
     <coral-columnview-preview-value>document.txt</coral-columnview-preview-value>

--- a/coral-component-columnview/src/tests/snippets/examples/file2.html
+++ b/coral-component-columnview/src/tests/snippets/examples/file2.html
@@ -1,4 +1,4 @@
-<coral-columnview-preview>
+<coral-columnview-preview lang="en">
   <coral-columnview-preview-content>
     <coral-columnview-preview-asset>
       <img src="http://lorempixel.com/640/480">

--- a/coral-component-columnview/src/tests/snippets/examples/file2.html
+++ b/coral-component-columnview/src/tests/snippets/examples/file2.html
@@ -1,7 +1,7 @@
 <coral-columnview-preview lang="en">
   <coral-columnview-preview-content>
     <coral-columnview-preview-asset>
-      <img src="http://lorempixel.com/640/480">
+      <img src="//placeimg.com/640/480/any">
     </coral-columnview-preview-asset>
     <coral-columnview-preview-label>Title</coral-columnview-preview-label>
     <coral-columnview-preview-value>File2</coral-columnview-preview-value>

--- a/coral-component-columnview/src/tests/snippets/examples/huge-image.html
+++ b/coral-component-columnview/src/tests/snippets/examples/huge-image.html
@@ -1,4 +1,4 @@
-<coral-columnview-preview>
+<coral-columnview-preview lang="en">
   <coral-columnview-preview-asset>
     <img src="http://lorempixel.com/1000/1000">
   </coral-columnview-preview-asset>

--- a/coral-component-columnview/src/tests/snippets/examples/huge-image.html
+++ b/coral-component-columnview/src/tests/snippets/examples/huge-image.html
@@ -1,6 +1,6 @@
 <coral-columnview-preview lang="en">
   <coral-columnview-preview-asset>
-    <img src="http://lorempixel.com/1000/1000">
+    <img src="//placeimg.com/1000/1000/any">
   </coral-columnview-preview-asset>
   <coral-columnview-preview-label>Name</coral-columnview-preview-label>
   <coral-columnview-preview-value>Huge Image</coral-columnview-preview-value>

--- a/coral-component-columnview/src/tests/snippets/examples/small-image.html
+++ b/coral-component-columnview/src/tests/snippets/examples/small-image.html
@@ -1,4 +1,4 @@
-<coral-columnview-preview>
+<coral-columnview-preview lang="en">
   <coral-columnview-preview-asset>
     <img src="http://lorempixel.com/60/60">
   </coral-columnview-preview-asset>

--- a/coral-component-columnview/src/tests/snippets/examples/small-image.html
+++ b/coral-component-columnview/src/tests/snippets/examples/small-image.html
@@ -1,6 +1,6 @@
 <coral-columnview-preview lang="en">
   <coral-columnview-preview-asset>
-    <img src="http://lorempixel.com/60/60">
+    <img src="//placeimg.com/60/60/any">
   </coral-columnview-preview-asset>
   <coral-columnview-preview-label>Name</coral-columnview-preview-label>
   <coral-columnview-preview-value>small_image.jpeg</coral-columnview-preview-value>

--- a/coral-component-columnview/src/tests/test.ColumnView.Preview.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.Preview.js
@@ -12,6 +12,7 @@
 
 import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {ColumnView} from '../../../coral-component-columnview';
+import {commons} from '../../../coral-utils';
 
 describe('ColumnView.Preview', function() {
   describe('Namespace', function() {
@@ -45,5 +46,49 @@ describe('ColumnView.Preview', function() {
 
   describe('Events', function() {});
   describe('User Interaction', function() {});
+  describe('Accessibility', function() {
+    it('should add alt="" to asset img tag when no alt text is provided', function() {
+      const el = helpers.build(window.__html__['ColumnView.Preview.content.implicit.html']);
+      const img = el.querySelector('img');
+      expect(img.hasAttribute('alt')).to.be.true;
+      expect(img.getAttribute('alt')).to.equal('');
+    });
+
+    it('should not add alt="" to asset img tag when alt text is provided', function() {
+      const el = helpers.build(window.__html__['ColumnView.Preview.content.html']);
+      const img = el.querySelector('img');
+      expect(img.hasAttribute('alt')).to.be.true;
+      expect(img.getAttribute('alt')).to.equal('FPO asset image');
+    });
+
+    it('should identify each value as a focusable, readOnly textbox labeled by its label', function() {
+      const el = helpers.build(window.__html__['ColumnView.Preview.content.html']);
+      const elements = el.querySelectorAll('coral-columnview-preview-label + coral-columnview-preview-value');
+      let i;
+      let element;
+      let elementLabel;
+      for (i = 0; i < elements.length; i++) {
+        element = elements[i];
+        elementLabel = element.previousElementSibling;
+        elementLabel.id = elementLabel.id || commons.getUID();
+        expect(element.getAttribute('aria-labelledby')).to.equal(elementLabel.id);
+        expect(element.getAttribute('role')).to.equal('textbox');
+        expect(element.getAttribute('tabindex')).to.equal('0');
+        expect(element.getAttribute('aria-readonly')).to.equal('true');
+      }
+    });
+
+    it('should identify each horizontal separator', function() {
+      const el = helpers.build(window.__html__['ColumnView.Preview.content.html']);
+      const elements = el.querySelectorAll('coral-columnview-preview-separator');
+      let i;
+      let element;
+      for (i = 0; i < elements.length; i++) {
+        element = elements[i];
+        expect(element.getAttribute('role')).to.equal('separator');
+        expect(element.getAttribute('aria-orientation')).to.equal('horizontal');
+      }
+    });
+  });
   describe('Implementation Details', function() {});
 });


### PR DESCRIPTION
## Description
Port accessibility updates from Coral3 ColumnView

Improve WAI-ARIA design pattern to ensure that

1. An element can always receive keyboard focus even after
initialization.
2. non-contiguous elements can be selected when selectionMode is
multiselect
3. State of item is announced by assistive technology on select or
deselect.
4. Command/Control + A and Shift+Command/Control + A can be used to
select or deselect all.
5. Esc deselects all.
6. Navigating using arrow keys sets focus on appropriate item.
7. Add unit tests for keyboard interaction and accessibility
8. When a document item is active, the preview column is added as
description for activeItem.

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4274574,
https://jira.corp.adobe.com/browse/CQ-4291308
https://jira.corp.adobe.com/browse/CQ-4291309

## Motivation and Context
Improve ColumnView accessibility for keyboard and screen reader users.

## How Has This Been Tested?
Unit test, and extensive manual testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
