### PR TITLE
CQ-4294648 [Masonry]: Added WAI-ARIA grid support for accessibility.

### DIFF
--- a/coral-component-masonry/examples/index.html
+++ b/coral-component-masonry/examples/index.html
@@ -98,6 +98,14 @@
         </style>
 
         <label>
+          ariaGrid
+          <span id="ariaGrid">
+            <a href="#" class="coral-Link">off</a> |
+            <a href="#" class="coral-Link">on</a> |
+          </span>
+        </label>
+        <br>
+        <label>
           Selection mode
           <span id="selection">
             <a href="#" class="coral-Link">none</a> |
@@ -130,88 +138,94 @@
           <a href="#" class="coral-Link append" data-count="100">append 100</a> |
         </label>
         <i>(double click on item to remove it)</i>
-
-        <coral-masonry orderable id="masonry" layout="fixed-centered" columnwidth="250" orderable>
-          <coral-masonry-item class="coral-Well">
-            <article>
-              <span coral-masonry-draghandle></span>
-              With image
-              <img src="http://via.placeholder.com/600x300" alt="">
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>
-              <span coral-masonry-draghandle></span>
-              card
-              <br>card
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>
-              <span coral-masonry-draghandle></span>
-              card
-              <br>card
-              <br>card
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>
-              <span coral-masonry-draghandle></span>
-              card
-              <br>card
-              <br>card
-              <br>card
-            </article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well" colspan="2">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-          <coral-masonry-item class="coral-Well">
-            <article>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card
-              <br>card</article>
-          </coral-masonry-item>
-        </coral-masonry>
+        <div>
+          <coral-masonry orderable id="masonry" layout="fixed-centered" columnwidth="250" aria-label="Masonry">
+            <coral-masonry-item class="coral-Well">
+              <article>
+                <span coral-masonry-draghandle></span>
+                With image
+                <img src="http://via.placeholder.com/600x300" alt="">
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>
+                <span coral-masonry-draghandle></span>
+                card
+                <br>card
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>
+                <span coral-masonry-draghandle></span>
+                card
+                <br>card
+                <br>card
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>
+                <span coral-masonry-draghandle></span>
+                card
+                <br>card
+                <br>card
+                <br>card
+              </article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well" colspan="2">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+            <coral-masonry-item class="coral-Well">
+              <article>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card
+                <br>card</article>
+            </coral-masonry-item>
+          </coral-masonry>
+        </div>
         <script>
           window.addEventListener('load', function() {
             const masonry = document.getElementById('masonry');
+
+            const ariaGridSelector = document.getElementById('ariaGrid');
+            ariaGridSelector.addEventListener('click', function(event) {
+              masonry.setAttribute('ariagrid', event.target.textContent);
+            });
 
             const layoutSelector = document.getElementById('layout');
             layoutSelector.addEventListener('click', function(event) {

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -429,22 +429,21 @@ class Masonry extends BaseComponent(HTMLElement) {
   _updateAriaRoleForItem(item, columnIndex, activateAriaGrid) {
     if (activateAriaGrid === ariaGrid.ON) {
       item.setAttribute('role','gridcell');
-      item.setAttribute('aria-colindex', transform.string(columnIndex));
+      item.setAttribute('aria-colindex', columnIndex);
     }
     else {
       item.removeAttribute('role');
       item.removeAttribute('aria-colindex');
-
     }
   }
 
   /** @private */
   _updateAriaColumnCountForParent(activateAriaGrid) {
     if (activateAriaGrid === ariaGrid.ON) {
-      this.parentNode.setAttribute('aria-colcount', transform.string(this.items.length));
+      this.parentNode.setAttribute('aria-colcount', this.items.length);
     }
     else {
-      this.parentNode.setAttribute('aria-colcount', transform.string(this.items.length));
+      this.parentNode.setAttribute('aria-colcount', this.items.length);
     }
   }
 

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -394,26 +394,26 @@ class Masonry extends BaseComponent(HTMLElement) {
 
   /** @private */
   _updateAriaRoleForParent(activateAriaGrid) {
-    if (!this.parentNode) {
+    if (!this.parentElement) {
       return;
     }
 
     if (activateAriaGrid === ariaGrid.ON) {
       // Save/set role for the parent as grid
-      this._preservedParentAriaRole = this.parentNode.getAttribute('role');
-      this.parentNode.setAttribute('role', 'grid');
+      this._preservedParentAriaRole = this.parentElement.getAttribute('role');
+      this.parentElement.setAttribute('role', 'grid');
     }
     else {
       // Restore/remove role of the parent element
       if (this._preservedParentAriaRole) {
-        this.parentNode.setAttribute('role', this._preservedParentAriaRole);
+        this.parentElement.setAttribute('role', this._preservedParentAriaRole);
       }
       else {
-        this.parentNode.removeAttribute('role');
+        this.parentElement.removeAttribute('role');
       }
 
       // Remove aria-colcount
-      this.parentNode.removeAttribute('aria-colcount');
+      this.parentElement.removeAttribute('aria-colcount');
     }
   }
 
@@ -439,15 +439,15 @@ class Masonry extends BaseComponent(HTMLElement) {
 
   /** @private */
   _updateAriaColumnCountForParent(activateAriaGrid) {
-    if (!this.parentNode) {
+    if (!this.parentElement) {
       return;
     }
     
     if (activateAriaGrid === ariaGrid.ON) {
-      this.parentNode.setAttribute('aria-colcount', this.items.length);
+      this.parentElement.setAttribute('aria-colcount', this.items.length);
     }
     else {
-      this.parentNode.removeAttribute('aria-colcount');
+      this.parentElement.removeAttribute('aria-colcount');
     }
   }
 

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -56,6 +56,21 @@ const layouts = {
   DASHBOARD: 'dashboard'
 };
 
+/**
+ Enumeration values to enable/disable aria grid support for {@link Masonry}.
+
+ @typedef {Object} MasonryAriaGridEnum
+
+ @property {String} ON
+ Turn on auto aria grid roles.
+ @property {String} OFF
+ OFF is default. Turn off auto aria grid roles.
+ */
+const ariaGrid = {
+  ON: 'on',
+  OFF: 'off'
+};
+
 // IE does not set the complete property to true if an image cannot be loaded. This code must be outside of the
 // masonry to make sure that the listener catches images which fail loading before the masonry is initalized.
 // @polyfill ie11
@@ -113,6 +128,13 @@ class Masonry extends BaseComponent(HTMLElement) {
     this._newItems = [];
     this._tabbableItem = null;
     
+    //a11y
+    this._defaultAriaRole = "group";
+
+    this._ariaGrid = ariaGrid.OFF;
+    this._preservedAriaRole = this._defaultAriaRole;
+    this._preservedParentAriaRole = null;
+
     this._delegateEvents({
       'global:resize': '_onWindowResize',
   
@@ -313,6 +335,119 @@ class Masonry extends BaseComponent(HTMLElement) {
     }
   }
   
+  /**
+   Attribute to enable/disable auto aria grid role assignment. Value must be one of {@link MasonryAriaGridEnum}.
+   Setting this property to {@link MasonryAriaGridEnum.ON} will do following to enable support for accessibility:
+    - Preserve current role attribute of the parent element of {@link Masonry}, and set new role as grid.
+    - Preserve current role attribute of the {@link Masonry}, and set new role as row.
+    - Set role attribute of all child {@link MasonryItem} to gridcell.
+
+   Setting the property to {@link MasonryAriaGridEnum.OFF} will do following:
+    - Restore preserved (if any) role attribute of the parent element of {@link Masonry}.
+    - Restore preserved role attribute of the {@link Masonry}.
+    - Remove role attribute of all child {@link MasonryItem}.
+
+   Setting the attribute to other than allowed values will fallback to {@link MasonryAriaGridEnum.OFF}.
+
+   @type {String}
+   @default {@link MasonryAriaGridEnum.OFF}
+   @htmlattribute ariagrid
+   @htmlattributereflected
+   */
+  get ariaGrid() {
+    return this._ariaGrid || ariaGrid.OFF;
+  }
+  set ariaGrid (value) {
+    value = transform.string(value);
+
+    // Ensure correct values
+    if (value !== ariaGrid.ON && value !== ariaGrid.OFF) {
+      console.warn('Coral.Masonry: Unsupported ariaGrid value: ', value, '. Will fallback to ', ariaGrid.OFF);
+      value = ariaGrid.OFF;
+    }
+
+    //update current state
+    this._ariaGrid = value;
+    this._reflectAttribute('ariagrid', this._ariaGrid);
+
+    // Update role for this masonry
+    if (this._ariaGrid === ariaGrid.ON) {
+      // Preserve existing role and set new role
+      this._preservedAriaRole = this.getAttribute('role');
+      this.setAttribute('role', 'row');
+    }
+    else if (this._ariaGrid == ariaGrid.OFF) {
+      // Restore or remove role
+      if (this._preservedAriaRole) {
+        this.setAttribute('role', this._preservedAriaRole);
+      }
+      else {
+        this.removeAttribute('role');
+      }
+    }
+
+    // Update parent and child item roles based on current state
+    this._updateAriaRoleForParent(this._ariaGrid);
+    this._updateAriaColumnCountForParent(this._ariaGrid);
+    this._updateAriaRoleForItems(this._ariaGrid);
+  }
+
+  /** @private */
+  _updateAriaRoleForParent(activateAriaGrid) {
+    if (!this.parentNode) {
+      return;
+    }
+
+    if (activateAriaGrid === ariaGrid.ON) {
+      // Save/set role for the parent as grid
+      this._preservedParentAriaRole = this.parentNode.getAttribute('role');
+      this.parentNode.setAttribute('role', 'grid');
+    }
+    else {
+      // Restore/remove role of the parent element
+      if (this._preservedParentAriaRole) {
+        this.parentNode.setAttribute('role', this._preservedParentAriaRole);
+      }
+      else {
+        this.parentNode.removeAttribute('role');
+      }
+
+      // Remove aria-colcount
+      this.parentNode.removeAttribute('aria-colcount');
+    }
+  }
+
+  /** @private */
+  _updateAriaRoleForItems(activateAriaGrid) {
+    let columnIndex = 1;
+    this.items.getAll().forEach((item) => {
+      this._updateAriaRoleForItem(item, columnIndex++, activateAriaGrid);
+    });
+  }
+
+  /** @private */
+  _updateAriaRoleForItem(item, columnIndex, activateAriaGrid) {
+    if (activateAriaGrid === ariaGrid.ON) {
+      item.setAttribute('role','gridcell');
+      item.setAttribute('aria-colindex', transform.string(columnIndex));
+    }
+    else {
+      item.removeAttribute('role');
+      item.removeAttribute('aria-colindex');
+
+    }
+  }
+
+  /** @private */
+  _updateAriaColumnCountForParent(activateAriaGrid) {
+    if (activateAriaGrid === ariaGrid.ON) {
+      this.parentNode.setAttribute('aria-colcount', transform.string(this.items.length));
+    }
+    else {
+      this.parentNode.setAttribute('aria-colcount', transform.string(this.items.length));
+    }
+  }
+
   _validateSelection(item) {
     const selectedItems = this.selectedItems;
     
@@ -517,6 +652,10 @@ class Masonry extends BaseComponent(HTMLElement) {
       }
     }
     
+    // Update items, so that column indexes are correctly set
+    this._updateAriaRoleForItems(this.ariaGrid);
+    this._updateAriaColumnCountForParent(this.ariaGrid);
+
     // Prevent endless observation loop (skip mutations which have been caused by the layout)
     this._observer.takeRecords();
   }
@@ -734,6 +873,9 @@ class Masonry extends BaseComponent(HTMLElement) {
       commons.transitionEnd(item, () => {
         item.classList.remove('is-dropping');
       });
+
+      // Update items, so that column indexes are correctly set
+      this._updateAriaRoleForItems(this.ariaGrid);
     }
     item._oldBefore = null;
     item._dropPlaceholder = null;
@@ -783,7 +925,8 @@ class Masonry extends BaseComponent(HTMLElement) {
   
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
-      selectionmode: 'selectionMode'
+      selectionmode: 'selectionMode',
+      ariagrid: 'ariaGrid'
     });
   }
   
@@ -793,7 +936,8 @@ class Masonry extends BaseComponent(HTMLElement) {
       'selectionmode',
       'layout',
       'spacing',
-      'orderable'
+      'orderable',
+      'ariagrid'
     ]);
   }
   
@@ -803,8 +947,11 @@ class Masonry extends BaseComponent(HTMLElement) {
     
     this.classList.add(CLASSNAME);
     
+    // Keep the default behavior when ariaGrid is not enabled
+    if (this._ariaGrid === ariaGrid.OFF) {
     // a11y
-    this.setAttribute('role', 'group');
+      this.setAttribute('role', this._defaultAriaRole);
+    }
     
     // Default reflected attributes
     if (!this._layout) { this.layout = layouts.FIXED_CENTERED; }

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -439,11 +439,15 @@ class Masonry extends BaseComponent(HTMLElement) {
 
   /** @private */
   _updateAriaColumnCountForParent(activateAriaGrid) {
+    if (!this.parentNode) {
+      return;
+    }
+    
     if (activateAriaGrid === ariaGrid.ON) {
       this.parentNode.setAttribute('aria-colcount', this.items.length);
     }
     else {
-      this.parentNode.setAttribute('aria-colcount', this.items.length);
+      this.parentNode.removeAttribute('aria-colcount');
     }
   }
 

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -392,6 +392,68 @@ class Masonry extends BaseComponent(HTMLElement) {
     this._updateAriaRoleForItems(this._ariaGrid);
   }
 
+  /**
+   Specifies aria-label value
+   
+   @type {?String}
+   @htmlattribute aria-label
+   @htmlattributereflected
+   */
+  get ariaLabel() {
+    return this.getAttribute('aria-label');
+  }
+  set ariaLabel(value) {
+    value = transform.string(value);
+    if (value === '') {
+      this.removeAttribute('aria-label');
+    }
+    else {
+      this._reflectAttribute('aria-label', value);
+    }
+
+    if (!this.parentElement || this._ariaGrid === ariaGrid.OFF) {
+      return;
+    }
+    
+    if (this.ariaLabel) {
+      this.parentElement.setAttribute('aria-label', this.ariaLabel);
+    }
+    else {
+      this.parentElement.removeAttribute('aria-label');
+    }
+  }
+
+  /**
+   Specifies aria-labelledby value
+   
+   @type {?String}
+   @htmlattribute aria-labelledby
+   @htmlattributereflected
+   */
+  get ariaLabelledby() {
+    return this.getAttribute('aria-labelledby');
+  }
+  set ariaLabelledby(value) {
+    value = transform.string(value);
+    if (value === '') {
+      this.removeAttribute('aria-labelledby');
+    }
+    else {
+      this._reflectAttribute('aria-labelledby', value);
+    }
+
+    if (!this.parentElement || this._ariaGrid === ariaGrid.OFF) {
+      return;
+    }
+    
+    if (this.ariaLabelledby) {
+      this.parentElement.setAttribute('aria-labelledby', this.ariaLabelledby);
+    }
+    else {
+      this.parentElement.removeAttribute('aria-labelledby');
+    }
+  }
+
   /** @private */
   _updateAriaRoleForParent(activateAriaGrid) {
     if (!this.parentElement) {
@@ -402,6 +464,17 @@ class Masonry extends BaseComponent(HTMLElement) {
       // Save/set role for the parent as grid
       this._preservedParentAriaRole = this.parentElement.getAttribute('role');
       this.parentElement.setAttribute('role', 'grid');
+
+      // parent grid should be labelled the same as coral-masonry
+      if (this.ariaLabel && this.parentElement.getAttribute('aria-label') !== this.ariaLabel) {
+        this._preservedParentAriaLabel = this.parentElement.getAttribute('aria-label');
+        this.parentElement.setAttribute('aria-label', this.ariaLabel);
+      }
+
+      if (this.ariaLabelledby && this.parentElement.getAttribute('aria-labelledby') !== this.ariaLabelledby) {
+        this._preservedParentAriaLabelledby = this.parentElement.getAttribute('aria-labelledby');
+        this.parentElement.setAttribute('aria-labelledby', this.ariaLabelledby);
+      }
     }
     else {
       // Restore/remove role of the parent element
@@ -410,6 +483,22 @@ class Masonry extends BaseComponent(HTMLElement) {
       }
       else {
         this.parentElement.removeAttribute('role');
+      }
+
+      // restore the aria-label or aria-labelledby values as well
+      if (this._preservedParentAriaLabel) {
+        this.parentElement.setAttribute('aria-label', this._preservedParentAriaLabel);
+        this._preservedParentAriaLabel = undefined;
+      }
+      else {
+        this.parentElement.removeAttribute('aria-label');
+      }
+
+      if (this._preservedParentAriaLabelledby !== undefined) {
+        this.parentElement.setAttribute('aria-labelledby', this._preservedParentAriaLabelledby);
+      }
+      else {
+        this.parentElement.removeAttribute('aria-labelledby');
       }
 
       // Remove aria-colcount
@@ -929,7 +1018,9 @@ class Masonry extends BaseComponent(HTMLElement) {
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
       selectionmode: 'selectionMode',
-      ariagrid: 'ariaGrid'
+      ariagrid: 'ariaGrid',
+      'aria-label': 'ariaLabel',
+      'aria-labelledby': 'ariaLabelledby',
     });
   }
   
@@ -940,7 +1031,9 @@ class Masonry extends BaseComponent(HTMLElement) {
       'layout',
       'spacing',
       'orderable',
-      'ariagrid'
+      'ariagrid',
+      'aria-label',
+      'aria-labelledby'
     ]);
   }
   

--- a/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
+++ b/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
@@ -1,5 +1,5 @@
-<div>
-  <coral-masonry role="region" ariagrid="on">
+<div aria-label="Parent Label" aria-labelledby="Parent Labelledby">
+  <coral-masonry role="region" ariagrid="on" aria-label="Masonry Label" aria-labelledby="Masonry Labelledby">
     <coral-masonry-item>item1</coral-masonry-item>
     <coral-masonry-item>item2</coral-masonry-item>
     <coral-masonry-item>item3</coral-masonry-item>

--- a/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
+++ b/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
@@ -1,0 +1,7 @@
+<div>
+  <coral-masonry role="previous" ariagrid="on">
+    <coral-masonry-item>item1</coral-masonry-item>
+    <coral-masonry-item>item2</coral-masonry-item>
+    <coral-masonry-item>item3</coral-masonry-item>
+  </coral-masonry>
+</div>

--- a/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
+++ b/coral-component-masonry/src/tests/snippets/Masonry.ariagrid.html
@@ -1,5 +1,5 @@
 <div>
-  <coral-masonry role="previous" ariagrid="on">
+  <coral-masonry role="region" ariagrid="on">
     <coral-masonry-item>item1</coral-masonry-item>
     <coral-masonry-item>item2</coral-masonry-item>
     <coral-masonry-item>item3</coral-masonry-item>

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -513,7 +513,7 @@ describe('Masonry.Layout', function() {
       expect(el.parentNode.getAttribute('aria-colcount'))
         .to.equal(null,'Parent node should not have aria-colcount after deactivating ariagrid');
       expect(el.getAttribute('role'))
-        .to.equal('previous','<coral-masonry> should have role="previous" after deactivating ariagrid');
+        .to.equal('region','<coral-masonry> should have role="region" after deactivating ariagrid');
       expect(el.items.first().getAttribute('role'))
         .to.equal(null,'<coral-masonry-item> should have no role"');
       expect(el.items.first().getAttribute('aria-colindex'))

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -12,6 +12,7 @@
 
 import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {Masonry} from '../../../coral-component-masonry';
+import MasonryItem from "../scripts/MasonryItem";
 
 describe('Masonry.Layout', function() {
   
@@ -490,5 +491,27 @@ describe('Masonry.Layout', function() {
       el.selectionMode = 'multiple';
       expect(el.getAttribute('aria-multiselectable')).to.equal('true');
     });
+  });
+
+  describe('Accessibility with auto aria grid', function() {
+    it('parent node and masonry nodes should have proper grid roles and attributes', function() {
+      const container = helpers.build(window.__html__['Masonry.ariagrid.html']);
+      const el = container.querySelector('coral-masonry');
+
+      expect(el.parentNode.getAttribute('role')).to.equal('grid','Parent node should have role="grid"');
+      expect(el.parentNode.getAttribute('aria-colcount')).to.equal('3','Parent node should have correct aria-colcount');
+      expect(el.getAttribute('role')).to.equal('row','<coral-masonry> should have role="row"');
+      expect(el.items.first().getAttribute('role'))
+        .to.equal('gridcell','<coral-masonry-item> should have role="gridcell"');
+      expect(el.items.last().getAttribute('aria-colindex'))
+        .to.equal('3','last <coral-masonry-item> should have aria-colindex="3"');
+
+      el.ariaGrid = "off";
+      expect(el.parentNode.getAttribute('role'))
+        .to.equal(null,'Parent node should have role=null after deactivating ariagrid');
+      expect(el.getAttribute('role'))
+        .to.equal('previous','<coral-masonry> should have role="previous" after deactivating ariagrid');
+    });
+
   });
 });

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -493,13 +493,13 @@ describe('Masonry.Layout', function() {
   });
 
   describe('Accessibility with auto aria grid', function() {
-    it('parent node and masonry nodes should have proper grid roles and attributes', function() {
+    it('parent element and masonry elements should have proper grid roles and attributes', function() {
       // Aria grid is enabled in the HTML
       const container = helpers.build(window.__html__['Masonry.ariagrid.html']);
       const el = container.querySelector('coral-masonry');
       
-      expect(el.parentNode.getAttribute('role')).to.equal('grid','Parent node should have role="grid"');
-      expect(el.parentNode.getAttribute('aria-colcount')).to.equal('3','Parent node should have correct aria-colcount');
+      expect(el.parentElement.getAttribute('role')).to.equal('grid','Parent element should have role="grid"');
+      expect(el.parentElement.getAttribute('aria-colcount')).to.equal('3','Parent element should have correct aria-colcount');
       expect(el.getAttribute('role')).to.equal('row','<coral-masonry> should have role="row"');
       expect(el.items.first().getAttribute('role'))
         .to.equal('gridcell','<coral-masonry-item> should have role="gridcell"');
@@ -508,10 +508,10 @@ describe('Masonry.Layout', function() {
 
       // Disable aria grid dynamically
       el.ariaGrid = "off";
-      expect(el.parentNode.getAttribute('role'))
-        .to.equal(null,'Parent node should have role=null after deactivating ariagrid');
-      expect(el.parentNode.getAttribute('aria-colcount'))
-        .to.equal(null,'Parent node should not have aria-colcount after deactivating ariagrid');
+      expect(el.parentElement.getAttribute('role'))
+        .to.equal(null,'Parent element should have role=null after deactivating ariagrid');
+      expect(el.parentElement.getAttribute('aria-colcount'))
+        .to.equal(null,'Parent element should not have aria-colcount after deactivating ariagrid');
       expect(el.getAttribute('role'))
         .to.equal('region','<coral-masonry> should have role="region" after deactivating ariagrid');
       expect(el.items.first().getAttribute('role'))
@@ -521,8 +521,8 @@ describe('Masonry.Layout', function() {
 
       // Enable aria grid dynamically
       el.ariaGrid = "on";
-      expect(el.parentNode.getAttribute('role')).to.equal('grid','Parent node should have role="grid"');
-      expect(el.parentNode.getAttribute('aria-colcount')).to.equal('3','Parent node should have correct aria-colcount');
+      expect(el.parentElement.getAttribute('role')).to.equal('grid','Parent element should have role="grid"');
+      expect(el.parentElement.getAttribute('aria-colcount')).to.equal('3','Parent element should have correct aria-colcount');
     });
 
   });

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -500,6 +500,9 @@ describe('Masonry.Layout', function() {
       
       expect(el.parentElement.getAttribute('role')).to.equal('grid','Parent element should have role="grid"');
       expect(el.parentElement.getAttribute('aria-colcount')).to.equal('3','Parent element should have correct aria-colcount');
+      expect(el.parentElement.getAttribute('aria-label')).to.equal('Masonry Label', 'Masonry parent element should receive same aria-label as Masonry');
+      expect(el.parentElement.getAttribute('aria-labelledby')).to.equal('Masonry Labelledby', 'Masonry parent element should receive same aria-labelledby as Masonry');
+
       expect(el.getAttribute('role')).to.equal('row','<coral-masonry> should have role="row"');
       expect(el.items.first().getAttribute('role'))
         .to.equal('gridcell','<coral-masonry-item> should have role="gridcell"');
@@ -512,7 +515,10 @@ describe('Masonry.Layout', function() {
         .to.equal(null,'Parent element should have role=null after deactivating ariagrid');
       expect(el.parentElement.getAttribute('aria-colcount'))
         .to.equal(null,'Parent element should not have aria-colcount after deactivating ariagrid');
-      expect(el.getAttribute('role'))
+      expect(el.parentElement.getAttribute('aria-label')).to.equal('Parent Label', 'Masonry parent element should restore cached aria-label when ariaGrid is set to "off".');
+      expect(el.parentElement.getAttribute('aria-labelledby')).to.equal('Parent Labelledby', 'Masonry parent element should restore cached aria-labelledby when ariaGrid is set to "off".');
+  
+        expect(el.getAttribute('role'))
         .to.equal('region','<coral-masonry> should have role="region" after deactivating ariagrid');
       expect(el.items.first().getAttribute('role'))
         .to.equal(null,'<coral-masonry-item> should have no role"');
@@ -523,6 +529,8 @@ describe('Masonry.Layout', function() {
       el.ariaGrid = "on";
       expect(el.parentElement.getAttribute('role')).to.equal('grid','Parent element should have role="grid"');
       expect(el.parentElement.getAttribute('aria-colcount')).to.equal('3','Parent element should have correct aria-colcount');
+      expect(el.parentElement.getAttribute('aria-label')).to.equal('Masonry Label', 'Masonry parent element should receive same aria-label as Masonry');
+      expect(el.parentElement.getAttribute('aria-labelledby')).to.equal('Masonry Labelledby', 'Masonry parent element should receive same aria-labelledby as Masonry');
     });
 
   });

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -494,9 +494,10 @@ describe('Masonry.Layout', function() {
 
   describe('Accessibility with auto aria grid', function() {
     it('parent node and masonry nodes should have proper grid roles and attributes', function() {
+      // Aria grid is enabled in the HTML
       const container = helpers.build(window.__html__['Masonry.ariagrid.html']);
       const el = container.querySelector('coral-masonry');
-
+      
       expect(el.parentNode.getAttribute('role')).to.equal('grid','Parent node should have role="grid"');
       expect(el.parentNode.getAttribute('aria-colcount')).to.equal('3','Parent node should have correct aria-colcount');
       expect(el.getAttribute('role')).to.equal('row','<coral-masonry> should have role="row"');
@@ -505,11 +506,23 @@ describe('Masonry.Layout', function() {
       expect(el.items.last().getAttribute('aria-colindex'))
         .to.equal('3','last <coral-masonry-item> should have aria-colindex="3"');
 
+      // Disable aria grid dynamically
       el.ariaGrid = "off";
       expect(el.parentNode.getAttribute('role'))
         .to.equal(null,'Parent node should have role=null after deactivating ariagrid');
+      expect(el.parentNode.getAttribute('aria-colcount'))
+        .to.equal(null,'Parent node should not have aria-colcount after deactivating ariagrid');
       expect(el.getAttribute('role'))
         .to.equal('previous','<coral-masonry> should have role="previous" after deactivating ariagrid');
+      expect(el.items.first().getAttribute('role'))
+        .to.equal(null,'<coral-masonry-item> should have no role"');
+      expect(el.items.first().getAttribute('aria-colindex'))
+        .to.equal(null,'<coral-masonry-item> should have no aria-colindex"');
+
+      // Enable aria grid dynamically
+      el.ariaGrid = "on";
+      expect(el.parentNode.getAttribute('role')).to.equal('grid','Parent node should have role="grid"');
+      expect(el.parentNode.getAttribute('aria-colcount')).to.equal('3','Parent node should have correct aria-colcount');
     });
 
   });

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -12,7 +12,6 @@
 
 import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {Masonry} from '../../../coral-component-masonry';
-import MasonryItem from "../scripts/MasonryItem";
 
 describe('Masonry.Layout', function() {
   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 - Enables better accessibility support for Masonry component by adding WAI-ARIA grid roles, enabled setting a new attribute.
 -  When enabled (`ariagrid="on"`), `role` and related attribute are added as follows:
 -- Preserve current `role` attribute of the parent element of `<coral-masonry>` and set its new `role` as `grid`.
 -- Preserve current `role` attribute of `<coral-masonry>`, and set new `role` as `row`.
 -- Set `role` attribute of all child `<coral-masonry-item>` as `gridcell`.
 -  When disabled (`ariagrid="off"`):
 -- Restore preserved (if any) `role` attribute of the parent element of `<coral-masonry>`.
 -- Restore preserved `role` attribute of the `<coral-masonry>`.
 -- Remove `role` attribute of all child `<coral-masonry-item>`.
 - Setting the attribute to other than allowed values will fallback to be `off`.
 - If `ariagrid` property is not set, above changes are not done (default)

## Related Issue
- https://jira.corp.adobe.com/browse/CQ-4294648

## Motivation and Context
Adds better accessibility support for the Masonry component.

## How Has This Been Tested?
Test through unit tests, and manual testing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
