### PR TITLE
CQ-4373015 [coral-steplist] Inappropriate "tab", "tablist", "tabpanel" roles given to inactive progress indicators

### DIFF
--- a/coral-component-steplist/examples/index.html
+++ b/coral-component-steplist/examples/index.html
@@ -112,6 +112,17 @@
           <coral-step>My text is short</coral-step>
         </coral-steplist>
       </div>
+
+      <h2 class="coral-Heading--S">Disabled not completed items)</h2>
+      <div class="markup">
+        <coral-steplist interaction="on">
+          <coral-step>Step 1</coral-step>
+          <coral-step selected>Step 2</coral-step>
+          <coral-step disabled>Step 3</coral-step>
+          <coral-step disabled>Step 4</coral-step>
+          <coral-step disabled>Step 5</coral-step>
+        </coral-steplist>
+      </div>
     </main>
   </body>
 </html>

--- a/coral-component-steplist/i18n/translations.js
+++ b/coral-component-steplist/i18n/translations.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export default {
+  "en-US": {
+    "Step List": "Step List",
+    "completed: ": "completed: ",
+    "current: ": "current: ",
+    "not completed: ": "not completed: "
+  },
+  "de-DE": {
+	  "Step List": "Schrittliste",
+    "completed: ": "abgeschlossen: ",
+    "current: ": "aktuell: ",
+    "not completed: ": "nicht abgeschlossen: "
+  },
+  "fr-FR": {
+    "Step List": "Liste des étapes",
+    "completed: ": "terminé : ",
+    "current: ": "actuel : ",
+    "not completed: ": "non terminé : "  
+  },
+  "it-IT": {
+    "Step List": "Elenco passi",
+    "completed: ": "completato: ",
+    "current: ": "corrente: ",
+    "not completed: ": "non completato: "
+  },
+  "ja-JP": {
+	  "Step List": "手順リスト",
+    "completed: ": "完了: ",
+    "current: ": "現在: ",
+    "not completed: ": "未完了: "
+  },
+  "es-ES": {
+    "Step List": "Lista de pasos",
+    "completed: ": "completado: ",
+    "current: ": "actual: ",
+    "not completed: ": "no completado: "
+  },
+  "ko-KR": {
+    "Step List": "단계 목록",
+    "completed: ": "완료됨: ",
+    "current: ": "현재: ",
+    "not completed: ": "미완료: "
+  },
+  "zh-CN": {
+    "Step List": "步骤列表",
+    "completed: ": "已完成: ",
+    "current: ": "当前: ",
+    "not completed: ": "未完成: "
+  },
+  "zh-TW": {
+    "Step List": "步驟清單",
+    "completed: ": "已完成: ",
+    "current: ": "目前: ",
+    "not completed: ": "未完成: "
+  },
+  "pt-BR": {
+	  "Step List": "Lista de passos",
+    "completed: ": "concluído: ",
+    "current: ": "atual: ",
+    "not completed: ": "não concluído: "
+  },
+  "nl-NL": {
+    "Step List": "Stappenlijst",
+    "completed: ": "voltooid: ",
+    "current: ": "huidige: ",
+    "not completed: ": "niet voltooid: "
+  },
+  "da-DK": {
+	  "Step List": "Trin liste",
+    "completed: ": "Afsluttet: ",
+    "current: ": "aktuelt: ",
+    "not completed: ": "Ikke afsluttet: "
+  },
+  "fi-FI": {
+    "Step List": "Vaihe luettelo",
+    "completed: ": "Valmis: ",
+    "current: ": "nykyinen: ",
+    "not completed: ": "Ei valmis: "
+  },
+  "nb-NO": {
+    "Step List": "Trinn liste",
+    "completed: ": "fullført: ",
+    "current: ": "gjeldende: ",
+    "not completed: ": "ikke fullført: "
+  },
+  "sv-SE": {
+	  "Step List": "Steg lista",
+    "completed: ": "slutförd: ",
+    "current: ": "aktuell: ",
+    "not completed: ": "inte slutförd: "
+  },
+  "cs-CZ": {
+    "Step List": "Seznam kroků",
+    "completed: ": "dokončeno: ",
+    "current: ": "aktuální: ",
+    "not completed: ": "nedokončeno: "
+  },
+  "pl-PL": {
+    "Step List": "Lista kroków",
+    "completed: ": "zakończone: ",
+    "current: ": "bieżący: ",
+    "not completed: ": "nieukończone: "
+  },
+  "ru-RU": {
+	  "Step List": "Список шагов",
+    "completed: ": "завершено: ",
+    "current: ": "текущий: ",
+    "not completed: ": "не завершено: "
+  },
+  "tr-TR": {
+    "Step List": "Adım listesi",
+    "completed: ": "tamamlandı: ",
+    "current: ": "geçerli: ",
+    "not completed: ": "tamamlanmadı: "
+  }
+}

--- a/coral-component-steplist/src/scripts/StepList.js
+++ b/coral-component-steplist/src/scripts/StepList.js
@@ -12,7 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {SelectableCollection} from '../../../coral-collection';
-import {transform, validate, commons} from '../../../coral-utils';
+import {transform, validate, commons, i18n} from '../../../coral-utils';
 import getTarget from './getTarget';
 
 /**
@@ -63,25 +63,23 @@ class StepList extends BaseComponent(HTMLElement) {
     super();
     
     this._delegateEvents({
-      'click > coral-step > [handle="stepMarkerContainer"]': '_onStepClick',
-      'click > coral-step > coral-step-label': '_onStepClick',
-      'click > coral-step': '_onStepClick',
+      'click > coral-step > [handle="link"]': '_onStepClick',
   
       'capture:focus > coral-step': '_onStepMouseEnter',
-      'capture:mouseenter > coral-step > [handle="stepMarkerContainer"]': '_onStepMouseEnter',
+      'capture:mouseenter > coral-step > [handle="link"]': '_onStepMouseEnter',
       'capture:blur > coral-step': '_onStepMouseLeave',
-      'capture:mouseleave > coral-step > [handle="stepMarkerContainer"]': '_onStepMouseLeave',
+      'capture:mouseleave > coral-step > [handle="link"]': '_onStepMouseLeave',
   
-      'key:enter > coral-step': '_onStepKeyboardSelect',
-      'key:space > coral-step': '_onStepKeyboardSelect',
-      'key:home > coral-step': '_onHomeKey',
-      'key:end > coral-step': '_onEndKey',
-      'key:pagedown > coral-step': '_selectNextItem',
-      'key:right > coral-step': '_selectNextItem',
-      'key:down > coral-step': '_selectNextItem',
-      'key:pageup > coral-step': '_selectPreviousItem',
-      'key:left > coral-step': '_selectPreviousItem',
-      'key:up > coral-step': '_selectPreviousItem',
+      'key:enter > coral-step > [handle="link"]': '_onStepKeyboardSelect',
+      'key:space > coral-step > [handle="link"]': '_onStepKeyboardSelect',
+      'key:home > coral-step > [handle="link"]': '_onHomeKey',
+      'key:end > coral-step > [handle="link"]': '_onEndKey',
+      'key:pagedown > coral-step > [handle="link"]': '_selectNextItem',
+      'key:right > coral-step > [handle="link"]': '_selectNextItem',
+      'key:down > coral-step > [handle="link"]': '_selectNextItem',
+      'key:pageup > coral-step > [handle="link"]': '_selectPreviousItem',
+      'key:left > coral-step > [handle="link"]': '_selectPreviousItem',
+      'key:up > coral-step > [handle="link"]': '_selectPreviousItem',
       
       // private
       'coral-step:_selectedchanged': '_onItemSelectedChanged'
@@ -163,6 +161,10 @@ class StepList extends BaseComponent(HTMLElement) {
             if (step && step.target && step.target.trim() !== '') {
               continue;
             }
+
+            if (panel) {
+              panel.setAttribute('role', 'region');
+            }
       
             if (step && panel) {
               // sets the required ids
@@ -206,6 +208,35 @@ class StepList extends BaseComponent(HTMLElement) {
     this._reflectAttribute('size', this._size);
   
     this.classList.toggle(`${CLASSNAME}--small`, this._size === size.SMALL);
+
+    if (!this.items.length) {
+      return;
+    }
+
+    // update aria-label for all children
+    const _syncItemLabelled = () => {
+      const steps = this.items.getAll();
+      const stepsCount = steps.length;
+
+      for (let i = 0; i < stepsCount; i++) {
+        const step = steps[i];
+        if (step._elements.label.textContent.trim() !== '') {
+          if (this.size === size.SMALL) {
+            step.setAttribute('labelled', step._elements.label.textContent);
+          }
+          else {
+            step.removeAttribute('labelled');
+          }
+        }
+      }
+    };
+
+    if (typeof this.items.last()._syncTabIndex === 'function') {
+      _syncItemLabelled();
+    }
+    else {
+      commons.ready(this.items.last(), _syncItemLabelled);
+    }
   }
   
   /**
@@ -227,26 +258,35 @@ class StepList extends BaseComponent(HTMLElement) {
   
     const isInteractive = this._interaction === interaction.ON;
     this.classList.toggle(`${CLASSNAME}--interactive`, isInteractive);
-  
-    const steps = this.items.getAll();
-    const stepsCount = steps.length;
+
+    if (!this.items.length) {
+      return;
+    }
   
     // update tab index for all children
-    for (let i = 0; i < stepsCount; i++) {
-      this._syncItemTabIndex(steps[i]);
+    const _syncItemProps = () => {
+      const steps = this.items.getAll();
+      const stepsCount = steps.length;
+
+      for (let i = 0; i < stepsCount; i++) {
+        // update tab index for all children
+        steps[i]._syncTabIndex(isInteractive);
+        //update posin set and total size for all steps
+        steps[i]._syncSizeAndCurrentIndex(i + 1, stepsCount);
+      }
+    };
+
+    if (typeof this.items.last()._syncTabIndex === 'function') {
+      _syncItemProps();
+    }
+    else {
+      commons.ready(this.items.last(), _syncItemProps);
     }
   }
   
   /** @private */
   _syncItemTabIndex(item) {
-    // when interaction is on, we enable the tabindex so users can tab into the items
-    if (this.interaction === interaction.ON) {
-      item.setAttribute('tabindex', item.hasAttribute('selected') ? '0' : '-1');
-    }
-    else {
-      // when off, removing the tabindex allows the component to never get focus
-      item.removeAttribute('tabindex');
-    }
+    item._syncTabIndex(this.interaction === interaction.ON);
   }
   
   /** @private */
@@ -324,6 +364,22 @@ class StepList extends BaseComponent(HTMLElement) {
     
       // Add/remove classes based on index
       item.classList.toggle('is-complete', index < selectedItemIndex);
+
+      if (!item._elements) {
+        return;
+      }
+
+      // Set accessibilityState text label
+      var accessibilityLabel = i18n.get('not completed: ');
+
+      if (index < selectedItemIndex) {
+        accessibilityLabel = i18n.get('completed: ');
+      }
+      else if (index === selectedItemIndex) {
+        accessibilityLabel = i18n.get('current: ');
+      }
+
+      item._elements.accessibilityLabel.innerHTML = accessibilityLabel;
     });
   }
   
@@ -333,8 +389,10 @@ class StepList extends BaseComponent(HTMLElement) {
       event.preventDefault();
       event.stopPropagation();
       
-      const item = event.matchedTarget;
+      const item = event.matchedTarget.closest('coral-step');
       this._selectAndFocusItem(item);
+
+      this._trackEvent('click', 'coral-steplist-item', event, item);
     }
   }
   
@@ -345,6 +403,12 @@ class StepList extends BaseComponent(HTMLElement) {
       event.stopPropagation();
       
       const item = event.matchedTarget.closest('coral-step');
+
+      // Disabled item should not get selected
+      if (item.disabled) {
+        return;
+      }
+
       this._selectAndFocusItem(item);
   
       this._trackEvent('click', 'coral-steplist-item', event, item);
@@ -355,7 +419,7 @@ class StepList extends BaseComponent(HTMLElement) {
   _onStepMouseEnter() {
     if (this.size === size.SMALL) {
       const step = event.target.closest('coral-step');
-      
+
       // we only show the tooltip if we have a label to show
       if (step._elements.label.innerHTML.trim() !== '') {
         step._elements.overlay.content.innerHTML = step._elements.label.innerHTML;
@@ -472,8 +536,12 @@ class StepList extends BaseComponent(HTMLElement) {
     if (!this._size) { this.size = size.LARGE; }
     
     // A11y
-    this.setAttribute('role', 'tablist');
-    this.setAttribute('aria-multiselectable', 'false');
+    this.setAttribute('role', 'list');
+
+    // provide accessibility label for the list
+    if (!this.hasAttribute('aria-label') && !this.hasAttribute('aria-labelledby')) {
+      this.setAttribute('aria-label', i18n.get('Step List'));
+    }
   
     // Don't trigger events once connected
     this._preventTriggeringEvents = true;

--- a/coral-component-steplist/src/scripts/StepList.js
+++ b/coral-component-steplist/src/scripts/StepList.js
@@ -231,11 +231,13 @@ class StepList extends BaseComponent(HTMLElement) {
       }
     };
 
-    if (typeof this.items.last()._syncTabIndex === 'function') {
+    const lastItem = this.items.last();
+
+    if (typeof lastItem._syncTabIndex === 'function') {
       _syncItemLabelled();
     }
     else {
-      commons.ready(this.items.last(), _syncItemLabelled);
+      commons.ready(lastItem, _syncItemLabelled);
     }
   }
   
@@ -276,11 +278,13 @@ class StepList extends BaseComponent(HTMLElement) {
       }
     };
 
-    if (typeof this.items.last()._syncTabIndex === 'function') {
+    const lastItem = this.items.last();
+
+    if (typeof lastItem._syncTabIndex === 'function') {
       _syncItemProps();
     }
     else {
-      commons.ready(this.items.last(), _syncItemProps);
+      commons.ready(lastItem, _syncItemProps);
     }
   }
   

--- a/coral-component-steplist/src/styles/dark.styl
+++ b/coral-component-steplist/src/styles/dark.styl
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Adobe. All rights reserved.
+ * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/coral-component-steplist/src/styles/dark.styl
+++ b/coral-component-steplist/src/styles/dark.styl
@@ -10,29 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import '../coral-theme-spectrum';
+$steplist-marker-focus-ring-color = var(--spectrum-dark-alias-focus-color);
 
-import '../coral-externals';
-import '../coral-compat';
-
-import StepList from './src/scripts/StepList';
-import Step from './src/scripts/Step';
-import StepLabel from './src/scripts/StepLabel';
-
-import './src/styles/index.css';
-
-import translations from './i18n/translations';
-import {commons, strings} from '../coral-utils';
-
-// i18n
-commons.extend(strings, {
-  'coral-component-steplist': translations
-});
-
-// Expose component on the Coral namespace
-commons._define('coral-step', Step);
-commons._define('coral-steplist', StepList);
-
-Step.Label = StepLabel;
-
-export {StepList, Step};
+.coral--dark {
+  @import 'skin.styl'
+}

--- a/coral-component-steplist/src/styles/darkest.styl
+++ b/coral-component-steplist/src/styles/darkest.styl
@@ -10,29 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import '../coral-theme-spectrum';
+$steplist-marker-focus-ring-color = var(--spectrum-darkest-alias-focus-color);
 
-import '../coral-externals';
-import '../coral-compat';
-
-import StepList from './src/scripts/StepList';
-import Step from './src/scripts/Step';
-import StepLabel from './src/scripts/StepLabel';
-
-import './src/styles/index.css';
-
-import translations from './i18n/translations';
-import {commons, strings} from '../coral-utils';
-
-// i18n
-commons.extend(strings, {
-  'coral-component-steplist': translations
-});
-
-// Expose component on the Coral namespace
-commons._define('coral-step', Step);
-commons._define('coral-steplist', StepList);
-
-Step.Label = StepLabel;
-
-export {StepList, Step};
+.coral--darkest {
+  @import 'skin.styl'
+}

--- a/coral-component-steplist/src/styles/index.styl
+++ b/coral-component-steplist/src/styles/index.styl
@@ -17,6 +17,8 @@
 @require '@adobe/spectrum-css/dist/components/steplist/multiStops/dark.css';
 @require '@adobe/spectrum-css/dist/components/steplist/multiStops/darkest.css';
 
+@require '../../../coral-theme-spectrum/src/styles/vars.css';
+
 // @compat
 ._coral-Steplist--small {
   ._coral-Steplist-item:first-child,
@@ -41,3 +43,42 @@
     display: none;
   }
 }
+
+._coral-Steplist-item[disabled] {
+  ._coral-Steplist-label,
+  ._coral-Steplist-markerContainer {
+    // Don't shoe cursor when the item is disabled.
+    cursor: default;
+  }
+}
+
+._coral-Steplist-accessibilityLabel {
+  bottom: 2.2rem;
+  font-size: 1px;
+}
+
+._coral-Steplist-item,
+._coral-Steplist-link {
+  &:focus {
+    outline: none;
+    &.focus-ring {
+      ._coral-Steplist-marker{ 
+        &:after {
+          content: '';
+          margin: -2px;
+          position: absolute;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          top: 0;
+          border-radius: 8px;
+        }
+      }
+    }
+  }
+}
+
+@require 'dark.styl';
+@require 'darkest.styl';
+@require 'light.styl';
+@require 'lightest.styl';

--- a/coral-component-steplist/src/styles/index.styl
+++ b/coral-component-steplist/src/styles/index.styl
@@ -62,7 +62,7 @@
   &:focus {
     outline: none;
     &.focus-ring {
-      ._coral-Steplist-marker{ 
+      ._coral-Steplist-marker { 
         &:after {
           content: '';
           margin: -2px;

--- a/coral-component-steplist/src/styles/light.styl
+++ b/coral-component-steplist/src/styles/light.styl
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Adobe. All rights reserved.
+ * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/coral-component-steplist/src/styles/light.styl
+++ b/coral-component-steplist/src/styles/light.styl
@@ -10,29 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import '../coral-theme-spectrum';
+$steplist-marker-focus-ring-color = var(--spectrum-light-alias-focus-color);
 
-import '../coral-externals';
-import '../coral-compat';
-
-import StepList from './src/scripts/StepList';
-import Step from './src/scripts/Step';
-import StepLabel from './src/scripts/StepLabel';
-
-import './src/styles/index.css';
-
-import translations from './i18n/translations';
-import {commons, strings} from '../coral-utils';
-
-// i18n
-commons.extend(strings, {
-  'coral-component-steplist': translations
-});
-
-// Expose component on the Coral namespace
-commons._define('coral-step', Step);
-commons._define('coral-steplist', StepList);
-
-Step.Label = StepLabel;
-
-export {StepList, Step};
+.coral--light {
+  @import 'skin.styl'
+}

--- a/coral-component-steplist/src/styles/lightest.styl
+++ b/coral-component-steplist/src/styles/lightest.styl
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Adobe. All rights reserved.
+ * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/coral-component-steplist/src/styles/lightest.styl
+++ b/coral-component-steplist/src/styles/lightest.styl
@@ -10,29 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import '../coral-theme-spectrum';
+$steplist-marker-focus-ring-color = var(--spectrum-lightest-alias-focus-color);
 
-import '../coral-externals';
-import '../coral-compat';
-
-import StepList from './src/scripts/StepList';
-import Step from './src/scripts/Step';
-import StepLabel from './src/scripts/StepLabel';
-
-import './src/styles/index.css';
-
-import translations from './i18n/translations';
-import {commons, strings} from '../coral-utils';
-
-// i18n
-commons.extend(strings, {
-  'coral-component-steplist': translations
-});
-
-// Expose component on the Coral namespace
-commons._define('coral-step', Step);
-commons._define('coral-steplist', StepList);
-
-Step.Label = StepLabel;
-
-export {StepList, Step};
+.coral--lightest {
+  @import 'skin.styl'
+}

--- a/coral-component-steplist/src/styles/skin.styl
+++ b/coral-component-steplist/src/styles/skin.styl
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Adobe. All rights reserved.
+ * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/coral-component-steplist/src/styles/skin.styl
+++ b/coral-component-steplist/src/styles/skin.styl
@@ -10,29 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-import '../coral-theme-spectrum';
-
-import '../coral-externals';
-import '../coral-compat';
-
-import StepList from './src/scripts/StepList';
-import Step from './src/scripts/Step';
-import StepLabel from './src/scripts/StepLabel';
-
-import './src/styles/index.css';
-
-import translations from './i18n/translations';
-import {commons, strings} from '../coral-utils';
-
-// i18n
-commons.extend(strings, {
-  'coral-component-steplist': translations
-});
-
-// Expose component on the Coral namespace
-commons._define('coral-step', Step);
-commons._define('coral-steplist', StepList);
-
-Step.Label = StepLabel;
-
-export {StepList, Step};
+._coral-Steplist-item,
+._coral-Steplist-link {
+  &:focus {
+    &.focus-ring {
+      ._coral-Steplist-marker { 
+        &:after {
+          box-shadow: 0 0 0 2px $steplist-marker-focus-ring-color;
+        }
+      }
+    }
+  }
+}

--- a/coral-component-steplist/src/templates/step.html
+++ b/coral-component-steplist/src/templates/step.html
@@ -1,5 +1,8 @@
-<span class="_coral-Steplist-markerContainer" handle="stepMarkerContainer">
-  <span class="_coral-Steplist-marker"></span>
-</span>
-<coral-tooltip tracking="off" smart focusonshow="off" handle="overlay" placement="top" variant="inspect" interaction="off" breadthoffset="1"></coral-tooltip>
+<a class="_coral-Steplist-link" handle="link">
+  <span class="u-coral-screenReaderOnly _coral-Steplist-accessibilityLabel" handle="accessibilityLabel"></span>
+  <span class="_coral-Steplist-markerContainer" handle="stepMarkerContainer" role="img" aria-hidden="true">
+    <span class="_coral-Steplist-marker"></span>
+  </span>
+  <coral-tooltip tracking="off" smart focusonshow="off" handle="overlay" placement="top" variant="inspect" interaction="off" breadthoffset="1"></coral-tooltip>
+</a>
 <span class="_coral-Steplist-segment" handle="line"></span>

--- a/coral-component-steplist/src/tests/test.Step.js
+++ b/coral-component-steplist/src/tests/test.Step.js
@@ -75,7 +75,10 @@ describe('Step', function() {
     describe('#selected', function() {
       it('should default to false', function() {
         expect(item.selected).to.be.false;
-        expect(item.tabIndex).to.equal(-1);
+        expect(item.hasAttribute('tabindex')).to.be.false;
+        expect(item._elements.link.hasAttribute('role')).to.be.false;
+        expect(item._elements.link.hasAttribute('tabindex')).to.be.false;
+        expect(item._elements.link.hasAttribute('aria-current')).to.be.false;
       });
 
       it('should be settable to truthy', function() {
@@ -84,16 +87,26 @@ describe('Step', function() {
         expect(item1.selected).to.be.true;
         expect(item1.hasAttribute('selected')).to.be.true;
         expect(item1.classList.contains('is-selected')).to.be.true;
-        expect(item1.tabIndex).to.equal(0);
+        expect(item1.hasAttribute('tabindex')).to.be.false;
+        expect(item1._elements.link.getAttribute('role')).to.equal('link');
+        expect(item1._elements.link.getAttribute('tabindex')).to.equal('0');
+        expect(item1._elements.link.getAttribute('aria-current')).to.equal('step');
       });
     });
   });
 
   describe('Implementation Details', function() {
     it('tabindex should be removed when StepList interaction is OFF', function() {
+      expect(item1.hasAttribute('tabindex')).to.be.false;
+      expect(item1._elements.link.getAttribute('role')).to.equal('link');
+      expect(item1._elements.link.getAttribute('tabindex')).to.equal('0');
+      expect(item1._elements.link.getAttribute('aria-current')).to.equal('step');
+
       el.interaction = StepList.interaction.OFF;
       
-      expect(item1.hasAttribute('tabindex')).to.be.false;
+      expect(item1._elements.link.hasAttribute('role')).to.be.false;
+      expect(item1._elements.link.hasAttribute('tabindex')).to.be.false;
+      expect(item1._elements.link.getAttribute('aria-current')).to.equal('step');
     });
   });
 });

--- a/coral-component-steplist/src/tests/test.StepList.js
+++ b/coral-component-steplist/src/tests/test.StepList.js
@@ -33,7 +33,9 @@ describe('StepList', function() {
   });
 
   function testDefaultInstance(el) {
-    expect(el.getAttribute('aria-multiselectable')).to.equal('false');
+    expect(el.getAttribute('role')).to.equal('list');
+    expect(el.getAttribute('aria-label')).to.equal('Step List');
+    expect(el.hasAttribute('aria-multiselectable')).to.be.false;
     expect(el.classList.contains('_coral-Steplist')).to.be.true;
     expect(el.selectedItem).to.be.null;
   }
@@ -315,7 +317,7 @@ describe('StepList', function() {
       items[1].focus();
 
       // Press the enter key
-      helpers.keypress(13, items[1]);
+      helpers.keypress(13, document.activeElement);
   
       expect(items[0].selected).to.equal(false, 'item[0] is not selected');
       expect(items[0].classList.contains('is-selected')).to.be.false;
@@ -336,12 +338,12 @@ describe('StepList', function() {
 
       // focuses the item before producing the key press
       items[0].focus();
-      expect(document.activeElement).to.equal(items[0]);
+      expect(document.activeElement).to.equal(items[0]._elements.link);
 
-      helpers.keypress('end', items[0]);
+      helpers.keypress('end', document.activeElement);
 
       expect(el.selectedItem).to.equal(items[4]);
-      expect(document.activeElement).to.equal(items[4]);
+      expect(document.activeElement).to.equal(items[4]._elements.link);
     });
 
     it('should select the first step on home press', function() {
@@ -356,12 +358,12 @@ describe('StepList', function() {
 
       // focuses the item before producing the key press
       items[1].focus();
-      expect(document.activeElement).to.equal(items[1]);
+      expect(document.activeElement).to.equal(items[1]._elements.link);
 
-      helpers.keypress('home', items[1]);
+      helpers.keypress('home', document.activeElement);
 
       expect(el.selectedItem).to.equal(items[0]);
-      expect(document.activeElement).to.equal(items[0]);
+      expect(document.activeElement).to.equal(items[0]._elements.link);
     });
 
     it('should select the next step on pagedown, right, and down', function() {
@@ -372,15 +374,15 @@ describe('StepList', function() {
 
       var items = el.items.getAll();
 
-      helpers.keypress('pagedown', items[0]);
+      helpers.keypress('pagedown', items[0]._elements.link);
 
       expect(el.selectedItem).to.equal(items[1]);
 
-      helpers.keypress('right', items[1]);
+      helpers.keypress('right', items[1]._elements.link);
 
       expect(el.selectedItem).to.equal(items[2]);
 
-      helpers.keypress('down', items[2]);
+      helpers.keypress('down', items[2]._elements.link);
 
       expect(el.selectedItem).to.equal(items[3]);
     });
@@ -394,18 +396,18 @@ describe('StepList', function() {
       var items = el.items.getAll();
 
       // forces the selected item to be the last one
-      helpers.keypress('end', items[0]);
+      helpers.keypress('end', items[0]._elements.link);
       expect(el.selectedItem).to.equal(items[4]);
 
-      helpers.keypress('pageup', items[4]);
+      helpers.keypress('pageup', items[4]._elements.link);
 
       expect(el.selectedItem).to.equal(items[3]);
 
-      helpers.keypress('left', items[3]);
+      helpers.keypress('left', items[3]._elements.link);
 
       expect(el.selectedItem).to.equal(items[2]);
 
-      helpers.keypress('up', items[2]);
+      helpers.keypress('up', items[2]._elements.link);
 
       expect(el.selectedItem).to.equal(items[1]);
     });
@@ -415,7 +417,7 @@ describe('StepList', function() {
     it('clicking the step should select the step', function() {
       const el = helpers.build(window.__html__['StepList.selectedItem.html']);
       el.interaction = 'on';
-      var step1 = el.querySelector('[role=tab]');
+      var step1 = el.querySelector('[role=link]');
       step1.click();
   
       let item1 = el.items.first();


### PR DESCRIPTION
## Description

Included fixes

1. coral-steplist should have role="list"
2. Each coral-step should have role="listitem", with aria-setsize set to the total number of coral-step}}s in the {{coral-steplist, and aria-posinset set to the index position of each coral-step within the coral-steplist. These list items are not interactive and should not have a tabindex attribute.
3. Each coral-step should have as its child an a[href] or an element with [role="link"][tabindex="0"] that will receive focus and display the focused style.
4. The link for the current step should have the attribute aria-current="step", and should include a span with .u-coral-screenReaderOnly containing a localized string for "current: " as part of its label.
5. The links for completed steps should include a span with .u-coral-screenReaderOnly containing a localized string for "completed: " as part of its label. It should NOT have the aria-current attribute.
6. The links for not completed steps should include a span with .u-coral-screenReaderOnly containing a localized string for "not completed: " as part of its label. It should NOT have the aria-current attribute.
7. By default, if no other `aria-label` or `aria-labelledby` is provided, the `step-list` should have `aria-label` equal to "Step List".

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4273015

## Motivation and Context
StepList should follow design pattern similar to: https://www.w3.org/WAI/tutorials/forms/multi-page/#using-step-by-step-indicator, rather than the Tab list design pattern. 

This PR is a backport of updates already committed to the to the Coral3 version of the control: https://git.corp.adobe.com/Coral/coralui-component-steplist/pull/19

## How Has This Been Tested?
Manually tested with Chrome/Safari and VoiceOver on macOS and with JAWS and NVDA on Firefox, Chrome and IE11 on Windows 10.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
