### PR TITLE
CQ-4294267 [CoralUI, Coral.TagList] Coral TagList to implement WAI-ARIA layout grid design pattern.

### DIFF
--- a/coral-component-taglist/examples/index.html
+++ b/coral-component-taglist/examples/index.html
@@ -143,7 +143,7 @@
           const taglist = taglists[i];
           const h2 = taglist.parentElement.previousElementSibling;
           h2.id = 'coral-taglist-heading-' + i;
-          taglist.setAttribute('aria-labelledby', h2.id);
+          taglist.setAttribute('labelledby', h2.id);
         }
       });
     </script>

--- a/coral-component-taglist/examples/index.html
+++ b/coral-component-taglist/examples/index.html
@@ -135,5 +135,17 @@
         <coral-tag color="green" size="L">Tag 3</coral-tag>
       </div>
     </main>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const taglists = document.body.querySelectorAll('coral-taglist');
+        for (var i = 0; i < taglists.length; i++) {
+          const taglist = taglists[i];
+          const h2 = taglist.parentElement.previousElementSibling;
+          h2.id = 'coral-taglist-heading-' + i;
+          taglist.setAttribute('aria-labelledby', h2.id);
+        }
+      });
+    </script>
   </body>
 </html>

--- a/coral-component-taglist/src/scripts/Tag.js
+++ b/coral-component-taglist/src/scripts/Tag.js
@@ -392,13 +392,18 @@ class Tag extends BaseComponent(HTMLElement) {
     }
 
     buttonCell.setAttribute('role', 'gridcell');
-    label.setAttribute('role', 'gridcell');
+    label.setAttribute('role', this._closable ? 'rowheader' : 'gridcell');
 
     const buttonAriaLabel = button.getAttribute('title');
     const labelTextContent = label.textContent;
   
     // button should be labelled, "Remove: labelTextContent".
     button.setAttribute('aria-label', `${buttonAriaLabel}: ${labelTextContent}`);
+
+    if (!label.id) {
+      label.id = commons.getUID();
+    }
+    this.setAttribute('aria-labelledby', label.id); 
   }
   
   get _contentZones() { return {'coral-tag-label': 'label'}; }

--- a/coral-component-taglist/src/scripts/Tag.js
+++ b/coral-component-taglist/src/scripts/Tag.js
@@ -152,11 +152,9 @@ class Tag extends BaseComponent(HTMLElement) {
     
     // Attach events
     this._delegateEvents({
-      'click': '_onClick',
+      'click [handle="button"]': '_onRemoveButtonClick',
       'key:backspace': '_onRemoveButtonClick',
-      'key:delete': '_onRemoveButtonClick',
-      'key:space': '_onRemoveButtonClick',
-      'mousedown': '_onMouseDown'
+      'key:delete': '_onRemoveButtonClick'
     });
     
     // Prepare templates
@@ -206,12 +204,13 @@ class Tag extends BaseComponent(HTMLElement) {
     // Only tags are closable
     this._toggleTagVariant();
     
-    if (this._closable && !this.contains(this._elements.button)) {
-      // Insert the button if it was not added to the DOM
-      this.appendChild(this._elements.button);
+    if (this._closable && !this.contains(this._elements.buttonCell)) {
+      // Insert the buttonCell if it was not added to the DOM
+      this.appendChild(this._elements.buttonCell);
     }
     
     this._elements.button.hidden = !this._closable;
+    this._elements.buttonCell.hidden = !this._closable;
     this._updateAriaLabel();
   }
   
@@ -358,7 +357,7 @@ class Tag extends BaseComponent(HTMLElement) {
   /** @private */
   _onRemoveButtonClick(event) {
     event.preventDefault();
-    if (this.closable) {
+    if (this.closable && !this._elements.button.disabled) {
       event.stopPropagation();
       this.focus();
       
@@ -371,54 +370,6 @@ class Tag extends BaseComponent(HTMLElement) {
     }
   }
   
-  /** @private */
-  _onClick(event) {
-    if (this._elements.button.disabled) {
-      return;
-    }
-    
-    // If the click event originated from a screen reader's event sequence or the remove button, trigger the removal
-    // of the tag.
-    if (event.target === this._elements.button ||
-      this._elements.button.contains(event.target) ||
-      bullsEye !== null ||
-      /* Detects virtual cursor or Narrator on Windows */
-      event.clientX <= 0 && event.clientY <= 0) {
-      this._onRemoveButtonClick(event);
-      bullsEye = null;
-    }
-  }
-  
-  /** @private */
-  _onMouseDown(event) {
-    // Determine the center point of the event target
-    const offsetCenter = getOffsetCenter(event.target);
-    // This Tag will be the event.target when mousedown originates from a screen reader.
-    if (event.target === this &&
-      Math.abs(event.pageX - offsetCenter.x) < 2 &&
-      Math.abs(event.pageY - offsetCenter.y) < 2) {
-      // If click is close enough to the center, store the coordinates.
-      bullsEye = {
-        x: event.pageX,
-        y: event.pageY
-      };
-    }
-    else {
-      bullsEye = null;
-    }
-    events.on('mouseup.Tag', this._onMouseUp);
-  }
-  
-  /** @private */
-  _onMouseUp(event) {
-    // If stored bullseye coordinates don't match mouse up event coordinates,
-    // don't store them any more.
-    if (bullsEye !== null && (event.pageX !== bullsEye.x || event.pageY !== bullsEye.y)) {
-      bullsEye = null;
-    }
-    events.off('mouseup.Tag', this._onMouseUp);
-  }
-  
   /**
    Updates the aria-label property from the button and label elements.
    
@@ -426,43 +377,28 @@ class Tag extends BaseComponent(HTMLElement) {
    */
   _updateAriaLabel() {
     const button = this._elements.button;
+    const buttonCell = this._elements.buttonCell;
     const label = this._elements.label;
   
     // In the edge case that this is a Tag without a TagList,
     // just treat the Tag as a container element without special labelling.
-    if (this.getAttribute('role') !== 'option') {
-      button.removeAttribute('aria-hidden');
-      label.removeAttribute('aria-hidden');
+    if (this.getAttribute('role') !== 'row') {
+      buttonCell.removeAttribute('role');
+      label.removeAttribute('role');
+      if (this.getAttribute('aria-labelledby') === label.id) {
+        this.removeAttribute('aria-labelledby');
+      }
       return;
     }
-  
-    const labelText = [];
-  
+
+    buttonCell.setAttribute('role', 'gridcell');
+    label.setAttribute('role', 'gridcell');
+
     const buttonAriaLabel = button.getAttribute('title');
     const labelTextContent = label.textContent;
   
-    if (button.parentElement) {
-      if (!label.parentElement || labelTextContent !== buttonAriaLabel) {
-        if (!button.hidden) {
-          labelText.push(buttonAriaLabel);
-        }
-        button.setAttribute('aria-hidden', 'true');
-      }
-    }
-  
-    if (label.parentElement) {
-      if (!button.parentElement || buttonAriaLabel !== labelTextContent) {
-        labelText.push(labelTextContent);
-        label.setAttribute('aria-hidden', 'true');
-      }
-    }
-  
-    if (labelText.length) {
-      this.setAttribute('aria-label', labelText.join(' '));
-    }
-    else {
-      this.removeAttribute('aria-label');
-    }
+    // button should be labelled, "Remove: labelTextContent".
+    button.setAttribute('aria-label', `${buttonAriaLabel}: ${labelTextContent}`);
   }
   
   get _contentZones() { return {'coral-tag-label': 'label'}; }
@@ -490,7 +426,8 @@ class Tag extends BaseComponent(HTMLElement) {
       'multiline',
       'size',
       'color',
-      'disabled'
+      'disabled',
+      'role'
     ]);
   }
   
@@ -498,7 +435,11 @@ class Tag extends BaseComponent(HTMLElement) {
   attributeChangedCallback(name, oldValue, value) {
     // This is required by TagList but we don't need to expose disabled publicly as API
     if (name === 'disabled') {
-      this._elements.button.disabled = true;
+      this._elements.button.disabled = value;
+    }
+    // This is required by TagList but we don't need to expose disabled publicly as API
+    else if (name === 'role') {
+      this._updateAriaLabel();
     }
     else {
       super.attributeChangedCallback(name, oldValue, value);
@@ -521,7 +462,7 @@ class Tag extends BaseComponent(HTMLElement) {
     if (!this._size) { this.size = size.MEDIUM; }
     if (!this._color) { this.color = color.DEFAULT; }
   
-    const templateHandleNames = ['input', 'button'];
+    const templateHandleNames = ['input', 'button', 'buttonCell'];
     
     const label = this._elements.label;
   

--- a/coral-component-taglist/src/scripts/TagList.js
+++ b/coral-component-taglist/src/scripts/TagList.js
@@ -284,7 +284,7 @@ class TagList extends BaseFormField(BaseComponent(HTMLElement)) {
     attachedItem.setAttribute('size', Tag.size.SMALL);
     
     // adds the role to support accessibility
-    attachedItem.setAttribute('role', 'listitem');
+    attachedItem.setAttribute('role', 'row');
     attachedItem.setAttribute('tabindex', '-1');
     attachedItem[this.readOnly ? 'removeAttribute' : 'setAttribute']('closable', '');
     
@@ -491,7 +491,7 @@ class TagList extends BaseFormField(BaseComponent(HTMLElement)) {
     this.classList.add(CLASSNAME);
     
     // adds the role to support accessibility
-    this.setAttribute('role', 'list');
+    this.setAttribute('role', 'grid');
   
     this.setAttribute('aria-live', 'off');
     this.setAttribute('aria-atomic', 'false');

--- a/coral-component-taglist/src/templates/base.html
+++ b/coral-component-taglist/src/templates/base.html
@@ -1,6 +1,8 @@
-<button tracking="off" handle="button" is="coral-button" type="button" variant="_custom" class="_coral-ClearButton _coral-ClearButton--small _coral-Tags-item-removeButton" title="{{data.i18n.get('Remove')}}" hidden tabindex="-1" coral-close>
-  <coral-button-label handle="buttonLabel"></coral-button-label>
-</button>
+<span handle="buttonCell" hidden>
+  <button tracking="off" handle="button" is="coral-button" type="button" variant="_custom" class="_coral-ClearButton _coral-ClearButton--small _coral-Tags-item-removeButton" title="{{data.i18n.get('Remove')}}" hidden tabindex="-1" coral-close>
+    <coral-button-label handle="buttonLabel"></coral-button-label>
+  </button>
+</span>
 <js>
   // Don't wait for button MO to pick up the label
   this.button._elements.label = this.buttonLabel;

--- a/coral-component-taglist/src/tests/test.TagList.js
+++ b/coral-component-taglist/src/tests/test.TagList.js
@@ -111,7 +111,7 @@ describe('TagList', function() {
         expect(tagList.items.length).to.equal(2);
         tagList.items.getAll().forEach(function(item) {
           expect(item.getAttribute('role')).to.equal('row');
-          expect(item.label.getAttribute('role')).to.equal('gridcell');
+          expect(item.label.getAttribute('role')).to.equal('rowheader');
           expect(item._elements.buttonCell.getAttribute('role')).to.equal('gridcell');
         });
       });
@@ -126,7 +126,7 @@ describe('TagList', function() {
         expect(eventSpy.callCount).to.equal(1, 'coral-collection:remove should be called once');
         expect(eventSpy.args[0][0].detail.item.tagName).to.equal('CORAL-TAG');
         expect(eventSpy.args[0][0].detail.item.getAttribute('role')).not.to.equal('row');
-        expect(eventSpy.args[0][0].detail.item.label.getAttribute('role')).not.to.equal('gridcell');
+        expect(eventSpy.args[0][0].detail.item.label.getAttribute('role')).not.to.equal('rowheader');
         expect(eventSpy.args[0][0].detail.item._elements.buttonCell.getAttribute('role')).not.to.equal('gridcell');
         expect(tagList.items.length).to.equal(0);
       });

--- a/coral-component-taglist/src/tests/test.TagList.js
+++ b/coral-component-taglist/src/tests/test.TagList.js
@@ -107,10 +107,12 @@ describe('TagList', function() {
         
         expect(eventSpy.callCount).to.equal(1, 'coral-collection:add should be called once');
         expect(eventSpy.args[0][0].detail.item.tagName).to.equal('CORAL-TAG');
-        expect(eventSpy.args[0][0].detail.item.getAttribute('role')).to.equal('listitem');
+        expect(eventSpy.args[0][0].detail.item.getAttribute('role')).to.equal('row');
         expect(tagList.items.length).to.equal(2);
         tagList.items.getAll().forEach(function(item) {
-          expect(item.getAttribute('role')).to.equal('listitem');
+          expect(item.getAttribute('role')).to.equal('row');
+          expect(item.label.getAttribute('role')).to.equal('gridcell');
+          expect(item._elements.buttonCell.getAttribute('role')).to.equal('gridcell');
         });
       });
       
@@ -123,7 +125,9 @@ describe('TagList', function() {
         
         expect(eventSpy.callCount).to.equal(1, 'coral-collection:remove should be called once');
         expect(eventSpy.args[0][0].detail.item.tagName).to.equal('CORAL-TAG');
-        expect(eventSpy.args[0][0].detail.item.getAttribute('role')).not.to.equal('listitem');
+        expect(eventSpy.args[0][0].detail.item.getAttribute('role')).not.to.equal('row');
+        expect(eventSpy.args[0][0].detail.item.label.getAttribute('role')).not.to.equal('gridcell');
+        expect(eventSpy.args[0][0].detail.item._elements.buttonCell.getAttribute('role')).not.to.equal('gridcell');
         expect(tagList.items.length).to.equal(0);
       });
       
@@ -423,7 +427,7 @@ describe('TagList', function() {
   describe('User Interaction', function() {
     it('should have a role', function() {
       var tagList = helpers.build(window.__html__['TagList.base.html']);
-      expect(tagList.getAttribute('role')).to.equal('list');
+      expect(tagList.getAttribute('role')).to.equal('grid');
     });
     
     it('should remove a focused tag on backspace', function() {
@@ -597,7 +601,7 @@ describe('TagList', function() {
     
     it('should call the tracker callback fn with expected parameters when the a tag is removed', function() {
       const el = helpers.build(window.__html__['TagList.tracking.full.html']);
-      el.querySelector('coral-tag:nth-child(1)').click();
+      el.querySelector('coral-tag:nth-child(1) [handle="button"]').click();
       expect(trackerFnSpy.callCount).to.equal(1, 'Tracker should have been called only once.');
       
       var spyCall = trackerFnSpy.getCall(0);


### PR DESCRIPTION
## Description
Rather than a listbox, or list, Coral.TagList should implement the WAI-ARIA layout grid design pattern, similar to the authoring practices guide example: [Example 2: Pill List For a List of Message Recipients](https://www.w3.org/TR/wai-aria-practices-1.2/examples/grid/LayoutGrids.html#ex2_label).

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4294267

## Motivation and Context
The original implementation in Coral used `role=listbox`, which made it difficult to express that a Tag, both exists and can be removed. For screen reader users, each element in the listbox, was an option with an aria-label to remove the item.

This was change to be presented as a static list, which wasn't a true representation of the behavior, because items can be navigated as a grid, using arrow keys and roving tabindex.

The layout grid design pattern allows the user to navigate between Tags as rows within a grid, and still navigate the label and button cell as grid cells within the grid, which is a better experience for screen reader users.

## How Has This Been Tested?
Tested with VoiceOver on macOS and iOS.

Tested with NVDA in Firefox on Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
