### PR TITLE
CUI-7390 Coral.Shell.MenuBar.Item button should have type="button"

### DIFF
--- a/coral-component-shell/examples/index.html
+++ b/coral-component-shell/examples/index.html
@@ -45,7 +45,7 @@
         <coral-shell>
           <coral-shell-header>
             <coral-shell-header-home>
-              <a is="coral-shell-homeanchor" icon="adobeExperienceManagerColor" href="#">Adobe Experience Manager</a>
+              <a is="coral-shell-homeanchor" icon="adobeExperienceManagerColor_Dark" href="#">Adobe Experience Manager</a>
             </coral-shell-header-home>
             <coral-shell-header-content>
               <coral-shell-workspaces role="tablist" aria-label="Workspaces">
@@ -59,10 +59,10 @@
               <!--<a is="coral-anchorbutton" variant="quiet" href="#">Beta Feedback</a>-->
               <coral-shell-menubar> 
                 <coral-shell-menubar-item menu="#menu_organizations">Microsoft</coral-shell-menubar-item>
-                <coral-shell-menubar-item menu="#menu_solutions" icon="apps" aria-label="Apps" title="Apps"></coral-shell-menubar-item>
+                <coral-shell-menubar-item menu="#menu_solutions" icon="apps" aria-label="Solutions" title="Solutions"></coral-shell-menubar-item>
                 <coral-shell-menubar-item menu="#menu_help" icon="helpOutline" aria-label="Help" title="Help"></coral-shell-menubar-item>
-                <coral-shell-menubar-item menu="#menu_pulse" icon="bell" badge="5" aria-label="5 Notifications" title="5 Notifications"></coral-shell-menubar-item>
-                <coral-shell-menubar-item menu="#menu_user" iconsize="M" iconvariant="circle" icon="userCircleColor" aria-label="User Profile" title="User Profile"></coral-shell-menubar-item>
+                <coral-shell-menubar-item menu="#menu_pulse" icon="bell" badge="5" aria-label="Inbox : 5 Notifications" title="Inbox : 5 Notifications"></coral-shell-menubar-item>
+                <coral-shell-menubar-item menu="#menu_user" iconsize="M" iconvariant="circle" icon="userCircleColor_Dark" aria-label="User Profile" title="User Profile"></coral-shell-menubar-item>
               </coral-shell-menubar>
             </coral-shell-header-actions>
           </coral-shell-header>
@@ -92,7 +92,7 @@
           <coral-shell-menu id="menu_solutions" placement="top" from="top" full top>
             <coral-shell-solutionswitcher>
               <coral-shell-solutions>
-                <a is="coral-shell-solution" icon="adobeExperienceCloudColor" linked href="#">Experience Cloud</a>
+                <a is="coral-shell-solution" icon="AdobeExperienceCloudColor" linked href="#">Experience Cloud</a>
               </coral-shell-solutions>
 
               <coral-shell-solutions>
@@ -100,7 +100,7 @@
                 <a is="coral-shell-solution" icon="adobeAnalytics" href="#">Analytics</a>
                 <a is="coral-shell-solution" icon="adobeAudienceManager" href="#">Audience Manager</a>
                 <a is="coral-shell-solution" icon="adobeCampaign" href="#">Campaign</a>
-                <a is="coral-shell-solution" icon="adobeExperienceManagerColor" linked href="#">Experience Manager</a>
+                <a is="coral-shell-solution" icon="AdobeExperienceManagerColor_Dark" linked href="#">Experience Manager</a>
                 <a is="coral-shell-solution" icon="magentoCommerce" href="#">Magento Commerce</a>
                 <a is="coral-shell-solution" icon="adobePrimetime" href="#">Primetime</a>
                 <a is="coral-shell-solution" icon="adobeSocial" href="#">Social</a>
@@ -108,7 +108,7 @@
               </coral-shell-solutions>
 
               <coral-shell-solutions secondary>
-                <a is="coral-shell-solution" icon="adobeExperiencePlatformColor" linked href="#">Experience Platform</a>
+                <a is="coral-shell-solution" icon="AdobeExperiencePlatformColor" linked href="#">Experience Platform</a>
                 <a is="coral-shell-solution" href="#">Exchange</a>
                 <a is="coral-shell-solution" href="#">Launch</a>
                 <a is="coral-shell-solution" href="#">People</a>

--- a/coral-component-shell/src/scripts/ShellMenuBar.js
+++ b/coral-component-shell/src/scripts/ShellMenuBar.js
@@ -26,6 +26,8 @@ class ShellMenuBar extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
+
+    this.setAttribute('role', 'list');
     
     this.items._startHandlingItems(true);
   }

--- a/coral-component-shell/src/scripts/ShellMenuBarItem.js
+++ b/coral-component-shell/src/scripts/ShellMenuBarItem.js
@@ -165,6 +165,7 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
       // Toggle the target menu
       if (menu.open !== this._open) {
         menu.open = this._open;
+        this._elements.shellMenuButton.setAttribute('aria-expanded', this._open);
       }
   
       this.trigger(`coral-shell-menubar-item:${this._open ? 'open' : 'close'}`);
@@ -216,6 +217,9 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
     if (menu) {
       this.id = this.id || commons.getUID();
       menu.setAttribute('target', `#${this.id}`);
+      const shellMenuButton = this._elements.shellMenuButton;
+      shellMenuButton.setAttribute('aria-haspopup', menu.getAttribute('role') || 'dialog');
+      shellMenuButton.setAttribute('aria-expanded', this.open);
     }
   }
   
@@ -224,7 +228,9 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
   
     if (target === this._getMenu()) {
       // Mark button as selected
-      this._elements.shellMenuButton.classList.toggle('is-selected', !target.open);
+      const shellMenuButton = this._elements.shellMenuButton;
+      shellMenuButton.classList.toggle('is-selected', !target.open);
+      shellMenuButton.setAttribute('aria-expanded', target.open);
     }
   }
   
@@ -235,6 +241,7 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
     // matches the open state of the target in case it was open separately
     if (target === this._getMenu() && this.open !== target.open) {
       this.open = target.open;
+      this._elements.shellMenuButton.setAttribute('aria-expanded', target.open);
     }
   }
   
@@ -313,7 +320,9 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
   /** @ignore */
   render() {
     super.render();
-    
+
+    this.setAttribute('role', 'listitem');
+
     this.classList.add(CLASSNAME);
     
     const button = this.querySelector('._coral-Shell-menu-button');

--- a/coral-component-shell/src/scripts/ShellUser.js
+++ b/coral-component-shell/src/scripts/ShellUser.js
@@ -24,7 +24,7 @@ const CLASSNAME = '_coral-Shell-user';
  Default avatar, show user icon from icon font.
  */
 const avatar = {
-  DEFAULT: 'userCircleColor'
+  DEFAULT: 'UserCircleColor_Light'
 };
 
 /**

--- a/coral-component-shell/src/templates/menuBarItem.html
+++ b/coral-component-shell/src/templates/menuBarItem.html
@@ -1,3 +1,3 @@
-<button is="coral-button" variant="quietaction" iconsize="S" class="_coral-Shell-menu-button" handle="shellMenuButton">
+<button is="coral-button" variant="quietaction" iconsize="S" class="_coral-Shell-menu-button" handle="shellMenuButton" type="button">
   <coral-button-label handle="shellMenuButtonLabel"></coral-button-label>
 </button>

--- a/coral-component-shell/src/tests/test.Shell.MenuBar.Item.js
+++ b/coral-component-shell/src/tests/test.Shell.MenuBar.Item.js
@@ -25,6 +25,10 @@ describe('Shell.MenuBar.Item', function() {
       const el = helpers.build('<coral-shell-menubar-item>');
       expect(el).to.be.an.instanceof(Shell.MenuBar.Item);
     });
+
+    it('should have role="listitem"', function() {
+      const el = helpers.build('<coral-shell-menubar-item>');
+    });
   
     helpers.cloneComponent(
       'should be possible to clone using markup',
@@ -115,12 +119,16 @@ describe('Shell.MenuBar.Item', function() {
     describe('#open', function() {
       it('should default to false', function() {
         expect(el.open).to.be.false;
+        expect(el._elements.shellMenuButton.getAttribute('aria-haspopup')).to.be.null;
+        expect(el._elements.shellMenuButton.getAttribute('aria-expanded')).to.be.null;
       });
 
       it('should ignore true if no valid menu is provided', function() {
         el.open = true;
 
         expect(el.open).to.be.false;
+        expect(el._elements.shellMenuButton.getAttribute('aria-haspopup')).to.be.null;
+        expect(el._elements.shellMenuButton.getAttribute('aria-expanded')).to.be.null;
       });
 
       it('should open the menu when open = true', function(done) {
@@ -130,6 +138,8 @@ describe('Shell.MenuBar.Item', function() {
         menu.on('coral-overlay:open', function() {
           expect(menu.open).to.be.true;
           expect(el.open).to.be.true;
+          expect(el._elements.shellMenuButton.getAttribute('aria-haspopup')).to.equal('dialog');
+          expect(el._elements.shellMenuButton.getAttribute('aria-expanded')).to.equal('true');
 
           done();
         });
@@ -147,12 +157,20 @@ describe('Shell.MenuBar.Item', function() {
         menu.on('coral-overlay:open', function() {
           helpers.next(function() {
             expect(el.open).to.be.true;
+            expect(el._elements.shellMenuButton.getAttribute('aria-haspopup')).to.equal('dialog');
+            expect(el._elements.shellMenuButton.getAttribute('aria-expanded')).to.equal('true');
+
             done();
           });
         });
 
-        // opening the menu separately, should update the item
-        menu.open = true;
+        helpers.next(function() {
+          expect(el._elements.shellMenuButton.getAttribute('aria-haspopup')).to.equal('dialog');
+          expect(el._elements.shellMenuButton.getAttribute('aria-expanded')).to.equal('false');
+
+          // opening the menu separately, should update the item
+          menu.open = true;
+        });
       });
     });
 
@@ -346,6 +364,18 @@ describe('Shell.MenuBar.Item', function() {
           el.label.textContent = 'This is the profile button';
           el.setAttribute('aria-label', 'Profile');
           expect(el._elements.shellMenuButton.getAttribute('aria-label')).to.equal(null);
+        });
+      });
+
+      it('should have role="listitem"', function() {
+        const el = helpers.build(new Shell.MenuBar.Item());
+        expect(el.getAttribute('role')).to.equal('listitem');
+      });
+
+      describe('shellMenuButton', function() {
+        it('should have type="button"', function() {
+          const el = helpers.build(new Shell.MenuBar.Item());
+          expect(el._elements.shellMenuButton.getAttribute('type')).to.equal('button');
         });
       });
     });

--- a/coral-component-shell/src/tests/test.Shell.MenuBar.js
+++ b/coral-component-shell/src/tests/test.Shell.MenuBar.js
@@ -50,4 +50,11 @@ describe('Shell.MenuBar', function() {
   describe('User Interaction', function() {});
 
   describe('Implementation Details', function() {});
+
+  describe('Accessibility', function() {
+    it('should support have role="list"', function() {
+      const el = helpers.build('<coral-shell-menubar>');
+      expect(el.getAttribute('role')).to.equal('list');
+    });
+  });
 });


### PR DESCRIPTION
## Description
In AEM, so that pressing Enter key with focus on a Search button within a Shell.MenuBar will open dialog and set focus to the Search box in forms mode, announcing the combobox with its accessibility name, the Shell.MenuBar.Item button button should have type="button".

We also need a way to set aria-haspopup and aria-expanded properties for buttons within Shell.MenuBar.Item.

## Related Issues
https://jira.corp.adobe.com/browse/CUI-7390
https://jira.corp.adobe.com/browse/CQ-4293363

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
