### PR TITLE
CUI-7391 Coral.Shell.MenuBar: NVDA workaround screen layout announcement of buttons

### DIFF
--- a/coral-component-shell/src/styles/menubar/index.styl
+++ b/coral-component-shell/src/styles/menubar/index.styl
@@ -20,11 +20,10 @@ coral-shell-menu {
 
 ._coral-Shell-menubar {
   // Live in harmony with buttons
-  display: inline-block;
+  display: flex;
 }
 
 ._coral-Shell-menubar-item {
-  display: inline-block;
   vertical-align: top;
   padding-left: 8px;
   padding-right: 8px;


### PR DESCRIPTION
## Description
In browse mode, NVDA reads elements with display: inline-block as a single block of text. For the Shell.MenuBar, where buttons are rendered with display: inline-block, all the buttons are announced as a line, rather than one button being announced with each ArrowDown. This is the expected behavior for NVDA, and the user can exit NVDA's screen layout mode using NVDA+V keyboard shortcut. However, it may create some confusion.

A workaround may be to use display: flex on ._coral-Shell-menubar, so that the items still appear inline, but do not use display: inline-block on ._coral-Shell-menubar-item.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7391
[NVDA issue #11187 closed as not a bug](https://github.com/nvaccess/nvda/issues/11187)

## Motivation and Context
Make navigation of MenuBar buttons in the Shell Header more intuitive in NVDA browse mode.

## How Has This Been Tested?
Tested with NVDA on Windows 10 using Chrome, Edge, and Firefox.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
