### PR TITLE
CUI-7393 Coral.ShellHelp: NVDA is not narrating ‘Searching help’ status message after searching any string in ‘Help Search’ field.

### DIFF
--- a/coral-component-shell/src/scripts/ShellHelp.js
+++ b/coral-component-shell/src/scripts/ShellHelp.js
@@ -128,6 +128,28 @@ class ShellHelp extends BaseComponent(HTMLElement) {
   }
 
   /** @private */
+  _clearTimeout(timeoutName) {
+    if (this[timeoutName]) {
+      window.clearTimeout(this[timeoutName]);
+      this[timeoutName] = undefined;
+    }
+  }
+
+  /** @private */
+  _showMessage(elementName, message) {
+    var el = this._elements[elementName];
+    var timeoutName = '_' + elementName + 'Timeout';
+
+    // Show message element
+    el.hidden = false;
+
+    // Add message text after 150ms delay to give screen readers enough
+    // time to recognize the live region and respond to the text update 
+    this._clearTimeout(timeoutName);
+    this[timeoutName] = window.setTimeout(() => el.appendChild(message), 150);
+  }
+
+  /** @private */
   _showLoading() {
     if (!this._elements.loading.hidden) {
       return;
@@ -136,14 +158,8 @@ class ShellHelp extends BaseComponent(HTMLElement) {
     if (this._elements.loading.contains(this._elements.loadingMessage)) {
       this._elements.loadingMessage = this._elements.loading.removeChild(this._elements.loadingMessage);
     }
-    this._elements.loading.hidden = false;
 
-    // use setTimeout to so that screen readers have enough time to detect and announce the status change
-    if (this._showLoadingTimeout) {
-      window.clearTimeout(this._showLoadingTimeout);
-      this._showLoadingTimeout = undefined;
-    } 
-    this._showLoadingTimeout = window.setTimeout(() => this._elements.loading.appendChild(this._elements.loadingMessage), 150);
+    this._showMessage('loading', this._elements.loadingMessage);
   }
 
   /** @private */
@@ -154,11 +170,8 @@ class ShellHelp extends BaseComponent(HTMLElement) {
 
     this._elements.loading.hidden = true;
 
-    // clear setTimeout
-    if (this._showLoadingTimeout) {
-      window.clearTimeout(this._showLoadingTimeout);
-      this._showLoadingTimeout = undefined;
-    }
+    // clear the timeout
+    this._clearTimeout('_loadingTimeout');
     if (this._elements.loading.contains(this._elements.loadingMessage)) {
       this._elements.loadingMessage = this._elements.loading.removeChild(this._elements.loadingMessage);
     }
@@ -173,14 +186,8 @@ class ShellHelp extends BaseComponent(HTMLElement) {
     
     this._elements.resultMessage.innerHTML = '';
 
-    // use setTimeout to so that screen readers have enough time to detect and announce the status change
-    if (this._showResultsTimeout) {
-      window.clearTimeout(this._showResultsTimeout);
-      this._showResultsTimeout = undefined;
-    }
-    this._showResultsTimeout = setTimeout(() => this._elements.resultMessage.appendChild(helpSearchError.call(this._elements, {i18n})), 150);
-    
-    this._elements.resultMessage.hidden = false;
+    // Show the error message
+    this._showMessage('resultMessage', helpSearchError.call(this._elements, {i18n}));
   }
   
   /**
@@ -206,10 +213,8 @@ class ShellHelp extends BaseComponent(HTMLElement) {
     if (!results || total === 0) {
       // Clear existing result message
       this._elements.resultMessage.innerHTML = '';
-      // Indicate to the user that no results were found using setTimeout to so that screen readers have enough time to detect and announce the status change
-      this._showResultsTimeout = setTimeout(() => this._elements.resultMessage.appendChild(noHelpResults.call(this._elements, {i18n})), 150);
-      // Show result message
-      this._elements.resultMessage.hidden = false;
+      // Indicate to the user that no results were found
+      this._showMessage('resultMessage', noHelpResults.call(this._elements, {i18n}));
     }
     else {
       // Clear existing results

--- a/coral-component-shell/src/scripts/ShellHelp.js
+++ b/coral-component-shell/src/scripts/ShellHelp.js
@@ -99,7 +99,7 @@ class ShellHelp extends BaseComponent(HTMLElement) {
     
     // Show loading
     this._elements.items.hidden = true;
-    this._elements.loading.hidden = false;
+    this._showLoading();
     this._elements.resultMessage.hidden = true;
     this._elements.results.hidden = true;
     
@@ -118,7 +118,7 @@ class ShellHelp extends BaseComponent(HTMLElement) {
     this._elements.results.hidden = true;
     
     // Hide loading
-    this._elements.loading.hidden = true;
+    this._hideLoading();
     
     // Hide no-results
     this._elements.resultMessage.hidden = true;
@@ -126,17 +126,59 @@ class ShellHelp extends BaseComponent(HTMLElement) {
     // Show items
     this._elements.items.hidden = false;
   }
+
+  /** @private */
+  _showLoading() {
+    if (!this._elements.loading.hidden) {
+      return;
+    }
+
+    if (this._elements.loading.contains(this._elements.loadingMessage)) {
+      this._elements.loadingMessage = this._elements.loading.removeChild(this._elements.loadingMessage);
+    }
+    this._elements.loading.hidden = false;
+
+    // use setTimeout to so that screen readers have enough time to detect and announce the status change
+    if (this._showLoadingTimeout) {
+      window.clearTimeout(this._showLoadingTimeout);
+      this._showLoadingTimeout = undefined;
+    } 
+    this._showLoadingTimeout = window.setTimeout(() => this._elements.loading.appendChild(this._elements.loadingMessage), 150);
+  }
+
+  /** @private */
+  _hideLoading() {
+    if (this._elements.loading.hidden) {
+      return;
+    }
+
+    this._elements.loading.hidden = true;
+
+    // clear setTimeout
+    if (this._showLoadingTimeout) {
+      window.clearTimeout(this._showLoadingTimeout);
+      this._showLoadingTimeout = undefined;
+    }
+    if (this._elements.loading.contains(this._elements.loadingMessage)) {
+      this._elements.loadingMessage = this._elements.loading.removeChild(this._elements.loadingMessage);
+    }
+  }
   
   /**
    Indicate to the user that an error has occurred
    */
   showError() {
     // Hide loading
-    this._elements.loading.hidden = true;
+    this._hideLoading();
     
     this._elements.resultMessage.innerHTML = '';
-    
-    this._elements.resultMessage.appendChild(helpSearchError.call(this._elements, {i18n}));
+
+    // use setTimeout to so that screen readers have enough time to detect and announce the status change
+    if (this._showResultsTimeout) {
+      window.clearTimeout(this._showResultsTimeout);
+      this._showResultsTimeout = undefined;
+    }
+    this._showResultsTimeout = setTimeout(() => this._elements.resultMessage.appendChild(helpSearchError.call(this._elements, {i18n})), 150);
     
     this._elements.resultMessage.hidden = false;
   }
@@ -153,13 +195,19 @@ class ShellHelp extends BaseComponent(HTMLElement) {
    */
   showResults(results, total, allResultsURL) {
     // Hide loading
-    this._elements.loading.hidden = true;
-    
+    this._hideLoading();
+
+    // clear setTimeout
+    if (this._showResultsTimeout) {
+      window.clearTimeout(this._showResultsTimeout);
+      this._showResultsTimeout = undefined;
+    }
+
     if (!results || total === 0) {
       // Clear existing result message
       this._elements.resultMessage.innerHTML = '';
-      // Indicate to the user that no results were found
-      this._elements.resultMessage.appendChild(noHelpResults.call(this._elements, {i18n}));
+      // Indicate to the user that no results were found using setTimeout to so that screen readers have enough time to detect and announce the status change
+      this._showResultsTimeout = setTimeout(() => this._elements.resultMessage.appendChild(noHelpResults.call(this._elements, {i18n})), 150);
       // Show result message
       this._elements.resultMessage.hidden = false;
     }

--- a/coral-component-shell/src/templates/help.html
+++ b/coral-component-shell/src/templates/help.html
@@ -6,9 +6,9 @@ var labelId = data.commons.getUID();
   <coral-search class="_coral-Shell-help-search" handle="search" placeholder="{{data.i18n.get('Search for Help')}}" labelledby="{{labelId}}"></coral-search>
   <div class="_coral-Shell-help-items" handle="items"></div>
   <coral-anchorlist class="_coral-Shell-help-results" handle="results" hidden></coral-anchorlist>
-  <div class="_coral-Shell-help-resultMessage" handle="resultMessage" hidden></div>
-  <div class="_coral-Shell-help-loading" handle="loading" hidden>
+  <div class="_coral-Shell-help-resultMessage" handle="resultMessage" role="status" hidden></div>
+  <div class="_coral-Shell-help-loading" handle="loading" role="status" hidden>
     <coral-wait size="M" class="_coral-Shell-help-loading-wait"></coral-wait>
-    <span class="coral-Heading--2 _coral-Shell-help-loading-info">{{data.i18n.get('Searching Help&hellip;')}}</span>
+    <span class="coral-Heading--2 _coral-Shell-help-loading-info" handle="loadingMessage">{{data.i18n.get('Searching Help&hellip;')}}</span>
   </div>
 </div>

--- a/coral-component-shell/src/tests/test.Shell.Help.js
+++ b/coral-component-shell/src/tests/test.Shell.Help.js
@@ -88,14 +88,17 @@ describe('Shell.Help', function() {
 
   describe('Markup', function() {
     describe('#showError()', function() {
-      it('should display an Error Message on "showError" function call', function() {
+      it('should display an Error Message on "showError" function call', function(done) {
         const el = helpers.build(htmlSnippet);
         var resultMessage = el._elements.resultMessage;
         var expectedResultMessage = 'Error fetching results';
 
         el.showError();
-        expect(el._elements.resultMessage.hidden).to.equal(false);
-        expect(resultMessage.querySelector('._coral-Shell-help-resultMessage-heading').textContent).to.equal(expectedResultMessage);
+        window.setTimeout(() => {
+          expect(el._elements.resultMessage.hidden).to.equal(false);
+          expect(resultMessage.querySelector('._coral-Shell-help-resultMessage-heading').textContent).to.equal(expectedResultMessage);
+          done();
+        }, 151);
       });
     });
 
@@ -130,14 +133,17 @@ describe('Shell.Help', function() {
         expect(el._elements.results.lastChild.target).to.equal('_blank');
       });
 
-      it('should display a "no results message" on "showResults" function call with an array and total = 0', function() {
+      it('should display a "no results message" on "showResults" function call with an array and total = 0', function(done) {
         const el = helpers.build(htmlSnippet);
         el.showResults([], 0);
         var resultMessage = el._elements.resultMessage;
         var expectedResultMessage = 'No results found';
 
-        expect(el._elements.resultMessage.hidden).to.equal(false);
-        expect(resultMessage.querySelector('._coral-Shell-help-resultMessage-heading').textContent).to.equal(expectedResultMessage);
+        window.setTimeout(() => {
+          expect(el._elements.resultMessage.hidden).to.equal(false);
+          expect(resultMessage.querySelector('._coral-Shell-help-resultMessage-heading').textContent).to.equal(expectedResultMessage);
+          done();
+        }, 151);
       });
     });
   });

--- a/coral-component-shell/src/tests/test.Shell.Help.js
+++ b/coral-component-shell/src/tests/test.Shell.Help.js
@@ -15,7 +15,7 @@ import {Shell} from '../../../coral-component-shell';
 import {Collection} from '../../../coral-collection';
 
 describe('Shell.Help', function() {
-  var htmlSnippet = '<coral-shell-help></coral-shell-help>';
+  let htmlSnippet = '<coral-shell-help></coral-shell-help>';
 
   describe('Namespace', function() {
     it('should be defined in the Shell namespace', function() {
@@ -31,7 +31,7 @@ describe('Shell.Help', function() {
     });
 
     it('should support creation from js', function() {
-      var help = new Shell.Help();
+      const help = new Shell.Help();
       expect(help instanceof Shell.Help).to.equal(true);
     });
 
@@ -62,7 +62,7 @@ describe('Shell.Help', function() {
 
       it('Setting Help Menu items should have no effect', function() {
         const el = helpers.build(htmlSnippet);
-        var items = el.items;
+        const items = el.items;
         
         try {
           el.items = new Collection();
@@ -90,21 +90,21 @@ describe('Shell.Help', function() {
     describe('#showError()', function() {
       it('should display an Error Message on "showError" function call', function(done) {
         const el = helpers.build(htmlSnippet);
-        var resultMessage = el._elements.resultMessage;
-        var expectedResultMessage = 'Error fetching results';
+        const resultMessage = el._elements.resultMessage;
+        const expectedResultMessage = 'Error fetching results';
 
         el.showError();
         window.setTimeout(() => {
           expect(el._elements.resultMessage.hidden).to.equal(false);
           expect(resultMessage.querySelector('._coral-Shell-help-resultMessage-heading').textContent).to.equal(expectedResultMessage);
           done();
-        }, 151);
+        }, 300);
       });
     });
 
     describe('#showResults()', function() {
       it('should show search results on "showResults" function call', function() {
-        var resultItems = [
+        const resultItems = [
           {
             'tags': [
               'Marketing Cloud',
@@ -123,8 +123,8 @@ describe('Shell.Help', function() {
           }
         ];
 
-        var total = 1111;
-        var allResultsURL = 'https://adobe.com';
+        const total = 1111;
+        const allResultsURL = 'https://adobe.com';
 
         const el = helpers.build(htmlSnippet);
         el.showResults(resultItems, total, allResultsURL);
@@ -136,14 +136,14 @@ describe('Shell.Help', function() {
       it('should display a "no results message" on "showResults" function call with an array and total = 0', function(done) {
         const el = helpers.build(htmlSnippet);
         el.showResults([], 0);
-        var resultMessage = el._elements.resultMessage;
-        var expectedResultMessage = 'No results found';
+        const resultMessage = el._elements.resultMessage;
+        const expectedResultMessage = 'No results found';
 
         window.setTimeout(() => {
           expect(el._elements.resultMessage.hidden).to.equal(false);
           expect(resultMessage.querySelector('._coral-Shell-help-resultMessage-heading').textContent).to.equal(expectedResultMessage);
           done();
-        }, 151);
+        }, 300);
       });
     });
   });
@@ -151,10 +151,10 @@ describe('Shell.Help', function() {
   describe('User Interaction', function() {
     describe('search', function() {
       it('should perform a search', function() {
-        var searchSpy = sinon.spy();
+        const searchSpy = sinon.spy();
 
         const el = helpers.build(window.__html__['Shell.Help.base.html']);
-        var search = el.querySelector('coral-search');
+        const search = el.querySelector('coral-search');
         el.on('coral-shell-help:search', searchSpy);
         search.value = 'customer';
         
@@ -168,7 +168,7 @@ describe('Shell.Help', function() {
 
       it('it should clear loading spinner on clear button click', function() {
         const el = helpers.build(window.__html__['Shell.Help.base.html']);
-        var search = el.querySelector('coral-search');
+        const search = el.querySelector('coral-search');
 
         search.value = 'customer';
         


### PR DESCRIPTION
## Description
Use setTimeout so that screen readers have enough time to detect and announce the status changes.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7393
https://jira.corp.adobe.com/browse/CQ-4293363

## Motivation and Context
Ensures that status update messages are communicated to screen reader user when filtering help topics.

## How Has This Been Tested?
Tested using VoiceOver with Chrome and Safari on macOS.
Tested using NVDA with Chrome, Firefox and Edge on Windows 10

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
