### PR TITLE
CQ-42822133 Keyboard focus is not moving to the close(x) button present in 'Version Preview' dialog, while navigating using Keyboard TAB key.

### DIFF
--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -309,32 +309,33 @@ class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
       this.setAttribute('aria-labelledby', this.header.id);
     }
 
-    const hasContent = this.content && this.content.textContent !== '';
+    // If the dialog has no content, or the content is empty, do nothing further.
+    if (!this.content || this.content.textContent === '') {
+      return;
+    }
 
     // If the dialog has a content,
-    if (hasContent) {
-      this.content.id = this.content.id || commons.getUID();
+    this.content.id = this.content.id || commons.getUID();
 
-      // In an alertdialog with a content region, if the alertdialog is not otherwise described.
-      if (this._variant !== variant.DEFAULT) {
+    // In an alertdialog with a content region, if the alertdialog is not otherwise described.
+    if (this._variant !== variant.DEFAULT) {
 
-        // with no header, 
-        if (!hasHeader) {
+      // with no header, 
+      if (!hasHeader) {
 
-          // label the alertdialog with a reference to the content
-          this.setAttribute('aria-labelledby', this.content.id);
-        }
-
-        // otherwise, if the alertdialog is not otherwise described,
-        else if (!this.hasAttribute('aria-describedby')) {
-
-          // ensure that the alertdialog is described by the content.
-          this.setAttribute('aria-describedby', this.content.id);
-        }
+        // label the alertdialog with a reference to the content
+        this.setAttribute('aria-labelledby', this.content.id);
       }
-      else if (this.getAttribute('aria-labelledby') === this.content.id) {
-        this.removeAttribute('aria-labelledby');
+
+      // otherwise, if the alertdialog is not otherwise described,
+      else if (!this.hasAttribute('aria-describedby')) {
+
+        // ensure that the alertdialog is described by the content.
+        this.setAttribute('aria-describedby', this.content.id);
       }
+    }
+    else if (this.getAttribute('aria-labelledby') === this.content.id) {
+      this.removeAttribute('aria-labelledby');
     }
   }
   
@@ -392,7 +393,13 @@ class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
       if (this.open) {
         commons.transitionEnd(this._elements.wrapper, () => {
           this._handleFocus();
+          this._elements.closeButton.tabIndex = 0;
+          this._elements.closeButton.removeAttribute('coral-tabcapture');
         });
+      }
+      else {
+        this._elements.closeButton.tabIndex = -1;
+        this._elements.closeButton.setAttribute('coral-tabcapture', '');
       }
     });
   }

--- a/coral-component-dialog/src/tests/test.Dialog.js
+++ b/coral-component-dialog/src/tests/test.Dialog.js
@@ -12,7 +12,7 @@
 
 import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {Dialog} from '../../../coral-component-dialog';
-import {tracking} from '../../../coral-utils';
+import {commons, tracking} from '../../../coral-utils';
 import {DragAction} from '../../../coral-dragaction';
 
 describe('Dialog', function() {
@@ -308,6 +308,16 @@ describe('Dialog', function() {
       
       el.on('coral-overlay:open', function() {
         expect(document.activeElement).to.not.equal(el._elements.closeButton);
+        commons.transitionEnd(el._elements.wrapper, () => {
+          expect(el._elements.closeButton.tabIndex).to.equal(0);
+          expect(el._elements.closeButton.hasAttribute('coral-tabcapture')).to.be.false;
+          el.hide();
+        });
+      });
+
+      el.on('coral-overlay:close', function() {
+        expect(el._elements.closeButton.tabIndex).to.equal(-1);
+        expect(el._elements.closeButton.hasAttribute('coral-tabcapture')).to.be.true;
         done();
       });
     });


### PR DESCRIPTION
## Description
After Dialog opens and focuses an element other than the close button, include the close button in the tab order.

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4282133
https://jira.corp.adobe.com/browse/CUI-7392

## Motivation and Context
For keyboard-only users, even though the Dialog can be closed using the Esc key, it is confusing for the Close button to not be included in the tab navigation order.

## How Has This Been Tested?
Tested using a keyboard in Coral-Spectrum example documentation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
