### PR TITLE
CUI-7396 Coral.Shell.MenuBar.Item Add hasPopup prop

### DIFF
--- a/coral-component-shell/src/scripts/ShellMenuBarItem.js
+++ b/coral-component-shell/src/scripts/ShellMenuBarItem.js
@@ -56,7 +56,6 @@ const hasPopupRole = {
   TREE: 'tree',
   GRID: 'grid',
   DIALOG: 'dialog',
-  TRUE: 'true',
   DEFAULT: null
 };
 
@@ -252,7 +251,7 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
       this.id = this.id || commons.getUID();
       menu.setAttribute('target', `#${this.id}`);
       if (this.hasPopup === hasPopupRole.DEFAULT) {
-        this.hasPopup = menu.getAttribute('role') || 'dialog';
+        this.hasPopup = menu.getAttribute('role') || hasPopupRole.DIALOG;
       }
     }
     else if (this._menu && this.hasPopup !== hasPopupRole.DEFAULT) {
@@ -275,11 +274,6 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
 
     const shellMenuButton = this._elements.shellMenuButton;
     let ariaHaspopup = this._hasPopup;
-
-    // When hasPopup equals "true", the default aria-haspopup role for a shellMenuButton should be "dialog".
-    if (ariaHaspopup === hasPopupRole.TRUE) {
-      ariaHaspopup = hasPopupRole.DIALOG;
-    }
 
     if (ariaHaspopup) {
       shellMenuButton.setAttribute('aria-haspopup', ariaHaspopup);


### PR DESCRIPTION
## Description
Shell.MenuBar.Item needs to support a hasPopup property so that if a menu has not been defined, aria-haspopup and aria-expanded can still be added to the shellMenuButton element, and aria-expanded can be controlled using the open prop.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7396
https://jira.corp.adobe.com/browse/CQ-4293363

## Motivation and Context
Addresses issue identified in Accessibility audit:
MSFT 4995958 - [Screen Readers-Adobe AEM- Home Page]:In Browse mode, NVDA is not narrating the state as ‘Expand/Collapse’ for ‘App’, ’Help’, ’Inbox’ and ‘User account’ buttons in header section.

## How Has This Been Tested?
Unit tests still pass.
Tested with http://localhost:9001/examples/#shell

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
