### PR TITLE
CUI-7399 StepList: fix labelled prop and size prop to better support NVDA browse mode

### DIFF
--- a/coral-component-steplist/src/scripts/Step.js
+++ b/coral-component-steplist/src/scripts/Step.js
@@ -146,7 +146,7 @@ class Step extends BaseComponent(HTMLElement) {
     @memberof Coral.Step#
   */
   get labelled() {
-    return this._labelled || this.getAttribute('labelled') || this._elements.stepMarkerContainer.getAttribute('aria-label');
+    return this._labelled || this.getAttribute('labelled') || this._elements.stepMarkerContainer.getAttribute('aria-label') || '';
   }
   set labelled(value) {
     this._labelled = transform.string(value);

--- a/coral-component-steplist/src/scripts/StepList.js
+++ b/coral-component-steplist/src/scripts/StepList.js
@@ -215,18 +215,16 @@ class StepList extends BaseComponent(HTMLElement) {
 
     // update aria-label for all children
     const _syncItemLabelled = () => {
+      const isSmall = this.size === size.SMALL;
       const steps = this.items.getAll();
       const stepsCount = steps.length;
 
       for (let i = 0; i < stepsCount; i++) {
         const step = steps[i];
-        if (step._elements.label.textContent.trim() !== '') {
-          if (this.size === size.SMALL) {
-            step.setAttribute('labelled', step._elements.label.textContent);
-          }
-          else {
-            step.removeAttribute('labelled');
-          }
+        const label = step._elements.label;
+        if (!step.labelled && label.textContent.length) {
+          label.classList.toggle('u-coral-screenReaderOnly', isSmall);
+          label.style.display = isSmall ? 'block' : '';
         }
       }
     };

--- a/coral-component-steplist/src/tests/test.Step.js
+++ b/coral-component-steplist/src/tests/test.Step.js
@@ -93,6 +93,26 @@ describe('Step', function() {
         expect(item1._elements.link.getAttribute('aria-current')).to.equal('step');
       });
     });
+
+    describe('#labelled', function() {
+      it('should default to empty string', function() {
+        expect(item.labelled).to.equal('');
+      });
+
+      it('should be settable', function(done) {
+        item.labelled = 'Item 1';
+        helpers.next(function() {
+          expect(item._elements.stepMarkerContainer.getAttribute('aria-label')).to.equal(item.labelled);
+          expect(item._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
+          item.labelled = null;
+          helpers.next(function() {
+            expect(item._elements.stepMarkerContainer.hasAttribute('aria-label')).to.be.false;
+            expect(item._elements.stepMarkerContainer.getAttribute('aria-hidden')).to.equal('true');
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('Implementation Details', function() {

--- a/coral-component-steplist/src/tests/test.StepList.js
+++ b/coral-component-steplist/src/tests/test.StepList.js
@@ -91,7 +91,41 @@ describe('StepList', function() {
     });
     
     describe('#interaction', function() {});
-    describe('#size', function() {});
+    describe('#size', function() {
+      it('should support Coral.StepList.size.SMALL', function(done) {
+        el.appendChild(item1);
+        el.appendChild(item2);
+        el.appendChild(item3);
+        el.size = StepList.size.SMALL;
+        var steps = el.items.getAll();
+        helpers.next(function() {
+          for (var i = 0; i < steps.length; i++) {
+            expect(steps[i].label.classList.contains('u-coral-screenReaderOnly')).to.be.true;
+            expect(steps[i].label.style.display).to.equal('block');
+          }
+          el.size = StepList.size.LARGE;
+          helpers.next(function() {
+            for (var i = 0; i < steps.length; i++) {
+              expect(steps[i].label.classList.contains('u-coral-screenReaderOnly')).to.be.false;
+              expect(steps[i].label.style.display).to.equal('');
+            }
+            item1.labelled = item1.label.textContent;
+            el.size = StepList.size.SMALL;
+            helpers.next(function() {
+              expect(item1.label.classList.contains('u-coral-screenReaderOnly')).to.be.false;
+              expect(item1.label.style.display).to.equal('');
+              expect(item1._elements.stepMarkerContainer.getAttribute('aria-label')).to.equal(item1.label.textContent);
+              expect(item1._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
+              for (var i = 1; i < steps.length; i++) {
+                expect(steps[i].label.classList.contains('u-coral-screenReaderOnly')).to.be.true;
+                expect(steps[i].label.style.display).to.equal('block');
+              }
+              done();
+            });
+          });
+        });
+      });
+    });
     describe('#target', function() {});
     describe('#selectedItem', function() {
 
@@ -191,7 +225,41 @@ describe('StepList', function() {
 
   describe('Markup', function() {
     describe('#interaction', function() {});
-    describe('#size', function() {});
+    describe('#size', function() {
+      it('should support Coral.StepList.size.SMALL', function(done) {
+
+        const el = helpers.build(window.__html__['StepList.base.html']);
+        el.size = StepList.size.SMALL;
+        const steps = el.items.getAll();
+        const item1 = steps[0];
+        helpers.next(function() {
+          for (var i = 0; i < steps.length; i++) {
+            expect(steps[i].label.classList.contains('u-coral-screenReaderOnly')).to.be.true;
+            expect(steps[i].label.style.display).to.equal('block');
+          }
+          el.size = StepList.size.LARGE;
+          helpers.next(function() {
+            for (var i = 0; i < steps.length; i++) {
+              expect(steps[i].label.classList.contains('u-coral-screenReaderOnly')).to.be.false;
+              expect(steps[i].label.style.display).to.equal('');
+            }
+            item1.labelled = item1.label.textContent;
+            el.size = StepList.size.SMALL;
+            helpers.next(function() {
+              expect(item1.label.classList.contains('u-coral-screenReaderOnly')).to.be.false;
+              expect(item1.label.style.display).to.equal('');
+              expect(item1._elements.stepMarkerContainer.getAttribute('aria-label')).to.equal(item1.label.textContent);
+              expect(item1._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
+              for (var i = 1; i < steps.length; i++) {
+                expect(steps[i].label.classList.contains('u-coral-screenReaderOnly')).to.be.true;
+                expect(steps[i].label.style.display).to.equal('block');
+              }
+              done();
+            });
+          });
+        });
+      });
+    });
     describe('#target', function() {});
     describe('#selectedItem', function() {
       it('should default to the first item', function() {


### PR DESCRIPTION
## Description
In NVDA's browse mode, the label for each Step in the StepList must be accessible to screen readers when the StepList.size prop is "s" for small, or when the StepListItem.labelled prop is used to add an aria-label to the link.

1. Make sure that aria-label prop is rendered to the stepMarkerContainer when labelled prop has been assigned.
2. When StepList.size="s", ensure that the label element is visible to assistive technology by adding .u-coral-screenReaderOnly and display: block to the label element when the StepListItem does not use labelled.

## Related Issue
[CUI-7399](https://jira.corp.adobe.com/browse/CUI-7399)

## Motivation and Context
When StepList.size="s", the label is hidden using CSS with display: none, which makes the link inaccessible to screen reader users.

## How Has This Been Tested?
Updated unit tests.
Tested against example docs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
