### PR TITLE
CUI-7398 Coral.Table: Add support for custom role attribute in table cell

### DIFF
--- a/coral-component-table/src/scripts/TableRow.js
+++ b/coral-component-table/src/scripts/TableRow.js
@@ -354,6 +354,11 @@ class TableRow extends BaseComponent(HTMLTableRowElement) {
       );
     });
 
+    const rowHeaders = cells.filter(cell => {
+      return (cell.getAttribute('role') === 'rowheader' ||
+        (cell.tagName === 'TH' && cell.getAttribute('scope') === 'row'));
+    });
+
     let cellForAccessibilityState;
     const ids = cells.map(cell => {
       const handle = cell.querySelector('[coral-table-rowselect]');
@@ -372,8 +377,11 @@ class TableRow extends BaseComponent(HTMLTableRowElement) {
         }
       }
 
-      // @a11y include all other cells in the row in the accessibility name
-      return cell.id;
+      // @a11y include row headers, or if no row header is defined,
+      // all other cells in the row, in the accessibility name
+      if (rowHeaders.length === 0 || rowHeaders.indexOf(cell) !== -1) {
+        return cell.id;
+      }
     });
 
     // @a11y If an _accessibilityState has not been defined within one of the cells, add to the last 

--- a/coral-component-table/src/tests/snippets/Table.selectable.html
+++ b/coral-component-table/src/tests/snippets/Table.selectable.html
@@ -1,15 +1,15 @@
 <table is="coral-table" selectable>
   <tbody is="coral-table-body">
     <tr is="coral-table-row" selected>
-      <td is="coral-table-cell">td1</td>
+      <td is="coral-table-cell" role="rowheader">td1</td>
       <td is="coral-table-cell">td2</td>
     </tr>
     <tr is="coral-table-row" selected>
-      <td is="coral-table-cell">td1</td>
+      <td is="coral-table-cell" role="rowheader">td1</td>
       <td is="coral-table-cell">td2</td>
     </tr>
     <tr is="coral-table-row">
-      <td is="coral-table-cell">td1</td>
+      <td is="coral-table-cell" role="rowheader">td1</td>
       <td is="coral-table-cell">td2</td>
     </tr>
   </tbody>

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -2200,7 +2200,11 @@ describe('Table', function() {
             const accessibilityState = row._elements.accessibilityState;
             expect(accessibilityState).to.not.be.null;
             expect(accessibilityState.getAttribute('aria-hidden')).to.equal('true');
-            const cellIds = row.items.getAll().map(cell => cell.id);
+            const cellIds = row.items.getAll().map(cell => {
+              if (cell.getAttribute('role') === 'rowheader') {
+                return cell.id;
+              }
+            });
             cellIds.push(accessibilityState.id);
             expect(row.getAttribute('aria-labelledby')).to.equal(cellIds.join(' '));
             expect(row.getAttribute('aria-selected')).to.equal(row.selected ? 'true' : 'false');


### PR DESCRIPTION
##  Description
There is a need to add support for custom role attribute in table cell which could serve as rowheader.

## Related Issue
Per: https://jira.corp.adobe.com/browse/CUI-7398 and
https://jira.corp.adobe.com/browse/CQ-4271825

## Motivation and Context
Support `role="rowheader"` on table cells, and take row header in into account when calculating `aria-labelledby` which should help reduce the verbosity when focus is set to a table row.

## How Has This Been Tested?
Tested with VoiceOver in Google Chrome on macOS against examples page.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
