### PR TITLE
CUI-7402 ColumnView should support coral-interactive on item descendants

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -13,6 +13,7 @@
 import accessibilityState from '../templates/accessibilityState';
 import {BaseComponent} from '../../../coral-base-component';
 import ColumnViewCollection from './ColumnViewCollection';
+import isInteractiveTarget from './isInteractiveTarget';
 import selectionMode from './selectionMode';
 import {transform, validate, commons, i18n} from '../../../coral-utils';
 
@@ -353,7 +354,7 @@ class ColumnView extends BaseComponent(HTMLElement) {
   /** @private */
   _onGlobalKeyUp(event) {
     // removes the class to stop selection
-    if (event.keyCode === 16) {
+    if (event.keyCode === 16 && !isInteractiveTarget(event.target)) {
       this.classList.remove('is-unselectable');
     }
   }
@@ -361,20 +362,21 @@ class ColumnView extends BaseComponent(HTMLElement) {
   /** @private */
   _onGlobalKeyDown(event) {
     // adds a class that prevents the text selection, otherwise shift + click would select the text
-    if (event.keyCode === 16) {
+    if (event.keyCode === 16 || !isInteractiveTarget(event.target)) {
       this.classList.add('is-unselectable');
     }
   }
 
   /** @private */
   _onKeyShiftAndUp(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     // don't select items when focus is within the preview
-    if (matchedTarget.closest('coral-columnview-preview')) {
+    if (matchedTarget.closest('coral-columnview-preview') || isInteractiveTarget(event.target)) {
       return;
     }
+
+    event.preventDefault();
 
     if (this.selectionMode === selectionMode.NONE) {
       this._onKeyUp(event);
@@ -453,13 +455,14 @@ class ColumnView extends BaseComponent(HTMLElement) {
   
   /** @private */
   _onKeyShiftAndDown(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     // don't select items when focus is within the preview
-    if (matchedTarget.closest('coral-columnview-preview')) {
+    if (matchedTarget.closest('coral-columnview-preview') || isInteractiveTarget(event.target)) {
       return;
     }
+
+    event.preventDefault();
 
     if (this.selectionMode === selectionMode.NONE) {
       this._onKeyDown(event);
@@ -539,13 +542,14 @@ class ColumnView extends BaseComponent(HTMLElement) {
   
   /** @private */
   _onKeyUp(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     // don't navigate items when focus is within the preview
-    if (matchedTarget.closest('coral-columnview-preview')) {
+    if (matchedTarget.closest('coral-columnview-preview') || isInteractiveTarget(event.target)) {
       return;
     }
+
+    event.preventDefault();
     
     // selection will win over active buttons, because they are the right most item. using _oldSelection since it
     // should be equivalent to this.items._getSelectedItems() but faster
@@ -580,13 +584,14 @@ class ColumnView extends BaseComponent(HTMLElement) {
   
   /** @private */
   _onKeyDown(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     // don't navigate items when focus is within the preview
-    if (matchedTarget.closest('coral-columnview-preview')) {
+    if (matchedTarget.closest('coral-columnview-preview') || isInteractiveTarget(event.target)) {
       return;
     }
+
+    event.preventDefault();
     
     // selection will win over active buttons, because they are the right most item. using _oldSelection since it
     // should be equivalent to this.items._getSelectedItems() but faster
@@ -623,12 +628,17 @@ class ColumnView extends BaseComponent(HTMLElement) {
   
   /** @private */
   _onKeyRight(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     if (matchedTarget.variant !== ColumnView.Item.variant.DRILLDOWN) {
       return false;
     }
+
+    if (isInteractiveTarget(event.target)) {
+      return;
+    }
+
+    event.preventDefault();
 
     const nextColumn = (this.activeItem && this.activeItem.closest('coral-columnview-column').nextElementSibling);
       
@@ -640,6 +650,10 @@ class ColumnView extends BaseComponent(HTMLElement) {
   
   /** @private */
   _onKeyLeft(event) {
+    if (isInteractiveTarget(event.target)) {
+      return;
+    }
+
     event.preventDefault();
     
     // we can only navigate left when there is a column on the left side to navigate to
@@ -669,13 +683,14 @@ class ColumnView extends BaseComponent(HTMLElement) {
   
   /** @private */
   _onKeySpace(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     // don't select item when focus is within the preview
-    if (matchedTarget.closest('coral-columnview-preview')) {
+    if (matchedTarget.closest('coral-columnview-preview') || isInteractiveTarget(event.target)) {
       return;
     }
+
+    event.preventDefault();
     
     // using _oldSelection since it should be equivalent to this.items._getSelectedItems() but faster
     const selectedItems = this._oldSelection;
@@ -709,13 +724,14 @@ class ColumnView extends BaseComponent(HTMLElement) {
 
   /** @private */
   _onKeyCtrlA(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     // don't select item when focus is within the preview
-    if (matchedTarget.closest('coral-columnview-preview')) {
+    if (matchedTarget.closest('coral-columnview-preview') || isInteractiveTarget(event.target)) {
       return;
     }
+
+    event.preventDefault();
 
     if (this.selectionMode === selectionMode.MULTIPLE) {
       const currentColumn = matchedTarget.closest('coral-columnview-column');
@@ -730,13 +746,14 @@ class ColumnView extends BaseComponent(HTMLElement) {
 
   /** @private */
   _onKeyCtrlShiftA(event) {
-    event.preventDefault();
     const matchedTarget = this._getRealMatchedTarget(event);
 
     // don't select item when focus is within the preview
-    if (matchedTarget.closest('coral-columnview-preview')) {
+    if (matchedTarget.closest('coral-columnview-preview') || isInteractiveTarget(event.target)) {
       return;
     }
+
+    event.preventDefault();
 
     if (this.selectionMode !== selectionMode.NONE) {
       const currentColumn = matchedTarget.closest('coral-columnview-column');
@@ -749,6 +766,10 @@ class ColumnView extends BaseComponent(HTMLElement) {
 
   /** @private */
   _onItemFocus(event) {
+    if (isInteractiveTarget(event.target)) {
+      return;
+    }
+
     const matchedTarget = this._getRealMatchedTarget(event);
     if (!matchedTarget.hasAttribute('active') && !this._oldSelection.length) {
       matchedTarget.setAttribute('active', '');
@@ -1101,7 +1122,7 @@ class ColumnView extends BaseComponent(HTMLElement) {
     this._addTimeout = window.setTimeout(() => {
       const activeElement = document.activeElement.closest('coral-columnview-item') || document.activeElement;
 
-      if (!this.contains(activeElement)) {
+      if (!this.contains(activeElement) || activeElement.tagName !== 'CORAL-COLUMNVIEW-ITEM') {
         return;
       }
 

--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import ColumnViewCollection from './ColumnViewCollection';
+import isInteractiveTarget from './isInteractiveTarget';
 import selectionMode from './selectionMode';
 import {commons, transform, validate} from '../../../coral-utils';
 
@@ -192,6 +193,10 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
   
   /** @private */
   _onItemClick(event) {
+    if (isInteractiveTarget(event.target)) {
+      return;
+    }
+
     // since transform will kill the modification, we trigger the event manually
     if (event.matchedTarget.hasAttribute('active')) {
       // directly calls the event since setting the attribute will not trigger an event
@@ -367,7 +372,7 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
    */
   _onColumnContentClick(event) {
     // we make sure the content was clicked directly and not an item
-    if (event.target !== event.matchedTarget) {
+    if (event.target !== event.matchedTarget || isInteractiveTarget(event.target)) {
       return;
     }
     

--- a/coral-component-columnview/src/scripts/isInteractiveTarget.js
+++ b/coral-component-columnview/src/scripts/isInteractiveTarget.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+
+/**
+ * Helper function to test whether event.target is explicitly marked as interactive.
+ * 
+ * Interactive elements included in an Item should respond to keyboard events without the event being handled by the Item as well.
+ *
+ * @private
+ */
+const isInteractiveTarget = (target) => {
+  return target.hasAttribute('coral-interactive') || target.closest('[coral-interactive]') !== null;
+};
+
+export default isInteractiveTarget;

--- a/coral-component-columnview/src/styles/index.styl
+++ b/coral-component-columnview/src/styles/index.styl
@@ -41,6 +41,11 @@
   margin-right: 0;
 }
 
+._coral-AssetList-item [coral-interactive] {
+  position: relative;
+  z-index: 1;
+}
+
 ._coral-AssetList-itemThumbnail {
 // Align icons
   text-align: center;

--- a/coral-component-columnview/src/tests/snippets/ColumnView.coral-interactive.html
+++ b/coral-component-columnview/src/tests/snippets/ColumnView.coral-interactive.html
@@ -1,0 +1,24 @@
+<coral-columnview selectionmode="single">
+  <coral-columnview-column>
+    <coral-columnview-column-content>
+      <coral-columnview-item variant="drilldown" data-src="content.en.html">
+        <coral-columnview-item-thumbnail>
+          <coral-icon icon="folder" title="Folder" size="M"></coral-icon>
+        </coral-columnview-item-thumbnail>
+        <coral-columnview-item-content>
+          <span id="radio-0-label">English</span>
+          <input type="checkbox" name="default" value="English" aria-label="Default: " aria-labelledby="radio-0 radio-0-label" coral-interactive tabindex="-1" />
+        </coral-columnview-item-content>
+      </coral-columnview-item>
+      <coral-columnview-item data-src="file1.html" icon="file">
+        <coral-columnview-item-thumbnail>
+          <coral-icon icon="file" title="file" size="M"></coral-icon>
+        </coral-columnview-item-thumbnail>
+        <coral-columnview-item-content>
+          <span id="radio-1-label">Document</span>
+          <input type="checkbox" name="default" value="Document" aria-label="Default: " aria-labelledby="radio-1 radio-1-label" coral-interactive tabindex="-1" />
+        </coral-columnview-item-content>
+      </coral-columnview-item>
+    </coral-columnview-column-content>
+  </coral-columnview-column>
+</coral-columnview>

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -1239,7 +1239,42 @@ describe('ColumnView', function() {
         }, 400);
       });
     });
-
+    describe('#coral-interactive', function() {
+      it('Clicking on checkbox within an item should not toggle selection of the item', function(done) {
+        const el = helpers.build(window.__html__['ColumnView.coral-interactive.html']);
+        const activeItem = el.items.getAll()[0];
+        const coralInteractiveElement = activeItem.querySelector('[coral-interactive]');
+        coralInteractiveElement.focus();
+        coralInteractiveElement.click();
+        helpers.next(function() {
+          expect(activeItem.selected).to.be.false;
+          expect(activeItem.hasAttribute('selected')).to.be.false;
+          expect(el.activeItem).to.be.null;
+          expect(el.selectedItem).to.be.null;
+          expect(coralInteractiveElement.checked).to.be.true;
+          coralInteractiveElement.click();
+          helpers.next(function() {
+            expect(activeItem.selected).to.be.false;
+            expect(activeItem.hasAttribute('selected')).to.be.false;
+            expect(el.activeItem).to.be.null;
+            expect(el.selectedItem).to.be.null;
+            expect(coralInteractiveElement.checked).to.be.false;
+            done();
+          });
+        });
+      });
+      it('Using arrow key with focus on checkbox within an item should not navigate', function(done) {
+        const el = helpers.build(window.__html__['ColumnView.coral-interactive.html']);
+        const activeItem = el.items.getAll()[0];
+        const coralInteractiveElement = activeItem.querySelector('[coral-interactive]');
+        coralInteractiveElement.focus();
+        helpers.keypress('down', document.activeElement);
+        helpers.next(function() {
+          expect(document.activeElement).to.equal(coralInteractiveElement);
+          done();
+        });
+      });
+    });
     describe('when selectionMode equals "single"', function() {
       it('should have aria-multiselectable equal to "false"', function(done) {
         const el = helpers.build(window.__html__['ColumnView.selectionMode.single.html']);


### PR DESCRIPTION
## Description
Like Accordion, some use cases of ColumnView require items to allow interactive descendants, like for example a checkbox.

To prevent keyboard and click events on the interactive descendants from bubbling up to be handled by the Item or ColumnView itself, we should support coral-interactive attribute to identify descendants that should be ignored.

## Related Issue
Per https://jira.corp.adobe.com/browse/CUI-7402 and https://jira.corp.adobe.com/browse/CQ-4297530

## How Has This Been Tested?
Tested against Coral-Spectrum example by adding a checkbox with `[coral-interactive]` to several of the items.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
