### PR TITLE
[ColumnView] - Rendering issue with content zone

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -227,7 +227,7 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
     }
 
     // @a11y Item should be labelled by thumbnail, content, and if appropriate accessibility state.
-    let ariaLabelledby = this.thumbnail.id + ' ' + this.content.id;
+    let ariaLabelledby = this._elements.thumbnail.id + ' ' + this._elements.content.id;
     this.setAttribute('aria-labelledby', this.selected ? `${ariaLabelledby} ${accessibilityState.id}` : ariaLabelledby);
 
     // Sync checkbox item selector
@@ -322,7 +322,7 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
           itemSelector = new Checkbox();
           itemSelector.setAttribute('coral-columnview-itemselect', '');
           itemSelector._elements.input.tabIndex = -1;
-          itemSelector.setAttribute('labelledby', this.content.id);
+          itemSelector.setAttribute('labelledby', this._elements.content.id);
       
           // Add the item selector as first child
           this.insertBefore(itemSelector, this.firstChild);


### PR DESCRIPTION
Initially while updating the column view item the content zone can be out of DOM during initial upgrading phase. Aa a result this.content can be null, and attributeChangedCallback during upgradeElement in customElementInternal can result in NullPointer exception.

@review @icaraps @CezCz @majornista 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
https://jira.corp.adobe.com/browse/CUI-7401

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
