### PR TITLE
CUI-7405 Coral.Shell.MenuBar.Item fix aria-expanded when set in response to coral-overlay:open or coral-overlay:close event

### DIFF
--- a/coral-component-shell/src/scripts/ShellMenuBarItem.js
+++ b/coral-component-shell/src/scripts/ShellMenuBarItem.js
@@ -290,9 +290,7 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
   
     if (target === this._getMenu()) {
       // Mark button as selected
-      const shellMenuButton = this._elements.shellMenuButton;
-      shellMenuButton.classList.toggle('is-selected', !target.open);
-      shellMenuButton.setAttribute('aria-expanded', target.open);
+      this._elements.shellMenuButton.classList.toggle('is-selected', !target.open);
     }
   }
   
@@ -301,9 +299,14 @@ class ShellMenuBarItem extends BaseComponent(HTMLElement) {
     const target = event.target;
     
     // matches the open state of the target in case it was open separately
-    if (target === this._getMenu() && this.open !== target.open) {
-      this.open = target.open;
-      this._elements.shellMenuButton.setAttribute('aria-expanded', target.open);
+    if (target === this._getMenu()) {
+      const shellMenuButton = this._elements.shellMenuButton;
+      if (this.open !== target.open) {
+        this.open = target.open;
+      }
+      else if (shellMenuButton.getAttribute('aria-expanded') !== target.open) {
+        shellMenuButton.setAttribute('aria-expanded', target.open);
+      }
     }
   }
   


### PR DESCRIPTION
## Description

Per CQ-4293363#comment-21888821:

> 1. On pressing enter on any of the collapsed shell buttons like Solutions, Help, User, etc., NVDA briefly announces "expanded" but then it also announces "collapsed" again followed by "dialog" in some cases.

This seems to be caused in part by the rapid toggling of aria-expanded between coral-spectrum:beforeopen, coral-spectrum:open, and the setting of the open property, which was introduced with CUI-7390 and PR #88. We probably don't need to set aria-expanded on coral-spectrum:beforeopen, and should be careful to only update the attribute if its value is different from the current state of the overlay.

## Related Issues:
- [CUI-7405](https://jira.corp.adobe.com/browse/CUI-7405)
- [CQ-4293363#comment-21888821](https://jira.corp.adobe.com/browse/CQ-4293363?focusedCommentId=21888821&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21888821)

Regression introduced by [CUI-7390](https://jira.corp.adobe.com/browse/CUI-7390)

## Motivation and Context
NVDA sometimes announces expanded state rather than the dialog receiving focus occasionally, because the state is toggling rapidly on and off with coral-spectrum:beforeopen and coral-spectrum:open

## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
