### PR TITLE
CUI-7404 Coral.Popover should set aria-expanded on target with aria-haspopup attribute

### DIFF
--- a/coral-component-popover/examples/index.html
+++ b/coral-component-popover/examples/index.html
@@ -84,7 +84,7 @@
 
         <table class="grid">
           <tr>
-            <td><button class="box" id="target_1">Target 1</button></td>
+            <td><button class="box" id="target_1" aria-haspopup="dialog">Target 1</button></td>
             <td></td>
             <td><button class="box" id="target_2">Target 2</button></td>
           </tr>
@@ -153,7 +153,13 @@
             popover.show();
 
             window.cycleTargets = function() {
-              popover.target = target[++target.curIndex % target.length];
+              var curTarget = document.querySelector(target[target.curIndex % target.length]);
+              curTarget.removeAttribute('aria-haspopup');
+              curTarget.removeAttribute('aria-expanded');
+
+              var newTarget = target[++target.curIndex % target.length];
+              document.querySelector(newTarget).setAttribute('aria-haspopup', 'dialog');
+              popover.target = newTarget;
               console.log('target changed to', popover.target);
             };
 

--- a/coral-component-popover/src/scripts/Popover.js
+++ b/coral-component-popover/src/scripts/Popover.js
@@ -295,7 +295,7 @@ class Popover extends Overlay {
       this.setAttribute('variant', variant._COACHMARK);
     }
 
-    this.open = this.open;
+    this._setAriaExpandedOnTarget();
   }
   
   /**
@@ -314,11 +314,7 @@ class Popover extends Overlay {
         target.classList.toggle('is-selected', this.open);
       }
 
-      const hasPopupAttribute = target.hasAttribute('aria-haspopup');
-      if (hasPopupAttribute || target.querySelector('[aria-haspopup]') !== null) {
-        const targetElements = hasPopupAttribute ? [target] : target.querySelectorAll('[aria-haspopup]');
-        targetElements.forEach((targetElement) => targetElement.setAttribute('aria-expanded', this.open));
-      }
+      this._setAriaExpandedOnTarget();
     }
   }
   
@@ -332,6 +328,17 @@ class Popover extends Overlay {
   }
   set icon(value) {
     this._icon = transform.string(value);
+  }
+  
+  _setAriaExpandedOnTarget() {
+    const target = this._getTarget();
+    if (target) {
+      const hasPopupAttribute = target.hasAttribute('aria-haspopup');
+      if (hasPopupAttribute || target.querySelector('[aria-haspopup]') !== null) {
+        const targetElements = hasPopupAttribute ? [target] : target.querySelectorAll('[aria-haspopup]');
+        targetElements.forEach((targetElement) => targetElement.setAttribute('aria-expanded', this.open));
+      }
+    }
   }
   
   _onPositioned(event) {

--- a/coral-component-popover/src/scripts/Popover.js
+++ b/coral-component-popover/src/scripts/Popover.js
@@ -294,6 +294,8 @@ class Popover extends Overlay {
     if (target && target.tagName === 'CORAL-COACHMARK') {
       this.setAttribute('variant', variant._COACHMARK);
     }
+
+    this.open = this.open;
   }
   
   /**
@@ -310,6 +312,12 @@ class Popover extends Overlay {
       const is = target.getAttribute('is');
       if (is === 'coral-button' || is === 'coral-anchorbutton') {
         target.classList.toggle('is-selected', this.open);
+      }
+
+      const hasPopupAttribute = target.hasAttribute('aria-haspopup');
+      if (hasPopupAttribute || target.querySelector('[aria-haspopup]') !== null) {
+        const targetElements = hasPopupAttribute ? [target] : target.querySelectorAll('[aria-haspopup]');
+        targetElements.forEach((targetElement) => targetElement.setAttribute('aria-expanded', this.open));
       }
     }
   }

--- a/coral-component-popover/src/tests/test.Popover.js
+++ b/coral-component-popover/src/tests/test.Popover.js
@@ -382,6 +382,33 @@ describe('Popover', function() {
 
       expect(el.open).to.equal(false, 'popover still closed after clicking target');
     });
+
+    it('should set aria-expanded on target with aria-haspopup when opened/closed', function(done) {
+      var target = helpers.overlay.createStaticTarget();
+      target.setAttribute('aria-haspopup', 'dialog');
+
+      el.set({
+        content: 'A popover',
+        target: target
+      });
+
+      helpers.next(() => {
+        expect(target.getAttribute('aria-expanded')).to.equal('false');
+
+        el.open = true;
+
+        helpers.next(() => {
+          expect(target.getAttribute('aria-expanded')).to.equal('true');
+
+          el.open = false;
+
+          helpers.next(() => {
+            expect(target.getAttribute('aria-expanded')).to.equal('false');
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('Implementation details', function() {


### PR DESCRIPTION
## Description
Per CQ-4273029, when a Coral.Popover is associated with a target and that target has and aria-haspopup attribute, the aria-expanded prop should also be assigned to the target to communicate the open/closed state of the Popover.

## Related Issue

- [CUI-7404](https://jira.corp.adobe.com/browse/CUI-7404)
- [CQ-4273029](https://jira.corp.adobe.com/browse/CQ-4273029)

## Motivation and Context
Give users of assistive technology context for elements that open a popup.

## How Has This Been Tested?
Updated documentation example

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
