### PR TITLE
CUI-7406 Coral.Popover should support role and aria-live attribute override

### DIFF
--- a/coral-component-popover/src/scripts/Popover.js
+++ b/coral-component-popover/src/scripts/Popover.js
@@ -509,7 +509,9 @@ class Popover extends Overlay {
     // ARIA
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'dialog');
+    }
     
+    if (!this.hasAttribute('aria-live')) {    
       // This helped announcements in certain screen readers
       this.setAttribute('aria-live', 'assertive');
     }

--- a/coral-component-popover/src/tests/snippets/Popover.a11yOverrides.html
+++ b/coral-component-popover/src/tests/snippets/Popover.a11yOverrides.html
@@ -1,0 +1,3 @@
+<coral-popover role="presentation" aria-live="off">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus imperdiet interdum convallis.
+</coral-popover>

--- a/coral-component-popover/src/tests/test.Popover.js
+++ b/coral-component-popover/src/tests/test.Popover.js
@@ -197,6 +197,20 @@ describe('Popover', function() {
         expect(el.content.classList.contains('_coral-CoachMarkPopover-content')).to.be.true;
       });
     });
+
+    describe('#role', function() {
+      it('should support override from markup', function() {
+        const el = helpers.build(window.__html__['Popover.a11yOverrides.html']);
+        expect(el.getAttribute('role')).to.equal('presentation');
+      });
+    });
+
+    describe('#aria-live', function() {
+      it('should support override from markup', function() {
+        const el = helpers.build(window.__html__['Popover.a11yOverrides.html']);
+        expect(el.getAttribute('aria-live')).to.equal('off');
+      });
+    });
   });
 
   describe('Events', function() {


### PR DESCRIPTION
## Description
For use cases where the Popover contains a listbox or menu, the Popover should support overriding the role attribute with role="presentation" and overriding the aria-live attribute with aria-live="off".

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7406
https://jira.corp.adobe.com/browse/CQ-4293363?focusedCommentId=22009932&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22009932

## Motivation and Context
For popovers Coral-Shell, we need to be able to set `aria-live="off"` so that opening popover doesn't announce too content.

## How Has This Been Tested?
Unit tests have been added and tested in Popover examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
