### PR TITLE
CUI-7408 [Accessibility] Coral-Spectrum Accordion should support level attribute

### DIFF
--- a/coral-component-accordion/examples/index.html
+++ b/coral-component-accordion/examples/index.html
@@ -157,7 +157,7 @@
 
     <h2 class="coral--Heading--S">Nested</h2>
     <div class="markup">
-      <coral-accordion>
+      <coral-accordion multiple>
         <coral-accordion-item selected>
           <coral-accordion-item-label>First <span class="u-coral-screenReaderOnly">(Nested)</span></coral-accordion-item-label>
           <coral-accordion-item-content>This is the first bit o'content</coral-accordion-item-content>
@@ -169,7 +169,7 @@
         <coral-accordion-item selected>
           <coral-accordion-item-label>Third <span class="u-coral-screenReaderOnly">(Nested)</span></coral-accordion-item-label>
           <coral-accordion-item-content>
-            <coral-accordion>
+            <coral-accordion level="4">
               <coral-accordion-item>
                 <coral-accordion-item-label>First <span class="u-coral-screenReaderOnly">(Nested - Level 2)</span></coral-accordion-item-label>
                 <span tabindex="0">This is the first bit o'content</span>

--- a/coral-component-accordion/src/scripts/Accordion.js
+++ b/coral-component-accordion/src/scripts/Accordion.js
@@ -153,6 +153,27 @@ class Accordion extends BaseComponent(HTMLElement) {
   get selectedItem() {
     return this.items._getFirstSelected();
   }
+
+  /**
+    The heading level for Accordion items within the Accordion
+
+    @type {Number}
+    @default 3
+    @htmlattribute level
+    @htmlattributereflected
+  */
+  get level() {
+    return this._level || 3;
+  }
+
+  set level(value) {
+    value = transform.number(value);
+    if (validate.valueMustChange(value, this._level) && value > 0 && value < 7) {
+      this._level = value;
+      this._reflectAttribute('level', this._level);
+      this.items.getAll().forEach(item => item.level = this._level);
+    }
+  }
   
   /** @private **/
   get _tabTarget() {
@@ -397,7 +418,7 @@ class Accordion extends BaseComponent(HTMLElement) {
 
   /** @ignore */
   static get observedAttributes() {
-    return super.observedAttributes.concat(['variant', 'multiple']);
+    return super.observedAttributes.concat(['variant', 'multiple', 'level']);
   }
   
   /** @ignore */

--- a/coral-component-accordion/src/scripts/Accordion.js
+++ b/coral-component-accordion/src/scripts/Accordion.js
@@ -171,7 +171,7 @@ class Accordion extends BaseComponent(HTMLElement) {
     if (validate.valueMustChange(value, this._level) && value > 0 && value < 7) {
       this._level = value;
       this._reflectAttribute('level', this._level);
-      this.items.getAll().forEach(item => item.level = this._level);
+      this.items.getAll().forEach(item => item.setAttribute('level', this._level));
     }
   }
   
@@ -329,6 +329,11 @@ class Accordion extends BaseComponent(HTMLElement) {
       }
     }
     
+    // set items level appropriately
+    if (item && item.level !== this.level) {
+      item.setAttribute('level', this.level);
+    }
+
     this._resetTabTarget();
     
     this._triggerChangeEvent();

--- a/coral-component-accordion/src/scripts/Accordion.js
+++ b/coral-component-accordion/src/scripts/Accordion.js
@@ -330,7 +330,7 @@ class Accordion extends BaseComponent(HTMLElement) {
     }
     
     // set items level appropriately
-    if (item && item.level !== this.level) {
+    if (item && item.getAttribute('level') !== this.level) {
       item.setAttribute('level', this.level);
     }
 

--- a/coral-component-accordion/src/scripts/AccordionItem.js
+++ b/coral-component-accordion/src/scripts/AccordionItem.js
@@ -181,7 +181,7 @@ set level(value) {
   }
 
   // If the value is the default or invalid, remove the aria-level override from the h3 element. 
-  this._elements.heading.removeAttribute('aria-level', this._level);
+  this._elements.heading.removeAttribute('aria-level');
 }
   
   /** @private **/

--- a/coral-component-accordion/src/scripts/AccordionItem.js
+++ b/coral-component-accordion/src/scripts/AccordionItem.js
@@ -11,8 +11,8 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
-import {transform, commons} from '../../../coral-utils';
 import base from '../templates/base';
+import {commons, transform, validate} from '../../../coral-utils';
 import {Icon} from '../../../coral-component-icon';
 
 const CLASSNAME = '_coral-Accordion-item';
@@ -146,6 +146,43 @@ class AccordionItem extends BaseComponent(HTMLElement) {
   
     this.selected = this.selected;
   }
+
+
+  /**
+    The heading level for the Accordion item 
+
+    @type {Number}
+    @default 3
+    @htmlattribute level
+    @htmlattributereflected
+  */
+ get level() {
+  return this._level || 3;
+}
+
+set level(value) {
+  value = transform.number(value);
+  // If the value has changed,
+  if (!validate.valueMustChange(value, this._level)) {
+    return;
+  }
+  // and the value is greater than 0
+  if (value > 0) {
+    // set the value and reflect the attribute.
+    this._level = value;
+    this._reflectAttribute('level', this._level);
+    
+    // If the new value is not equal to the default,
+    if (value !== 3) {
+      // override the aria-level on the h3 element. 
+      this._elements.heading.setAttribute('aria-level', this._level);
+      return;
+    }
+  }
+
+  // If the value is the default or invalid, remove the aria-level override from the h3 element. 
+  this._elements.heading.removeAttribute('aria-level', this._level);
+}
   
   /** @private **/
   get _isTabTarget() {
@@ -183,7 +220,7 @@ class AccordionItem extends BaseComponent(HTMLElement) {
   
   /** @ignore */
   static get observedAttributes() {
-    return super.observedAttributes.concat(['selected', 'disabled']);
+    return super.observedAttributes.concat(['selected', 'disabled', 'level']);
   }
   
   /** @ignore */

--- a/coral-component-accordion/src/tests/test.Accordion.js
+++ b/coral-component-accordion/src/tests/test.Accordion.js
@@ -132,6 +132,19 @@ describe('Accordion', function() {
         expect(item.label).not.to.be.null;
       });
     });
+
+    describe('#level', function() {
+      it('should set heading level for Accordion item headings', function(done) {
+        const el = helpers.build(window.__html__['Accordion.base.html']);
+        el.level = 4;
+        helpers.next(function() {
+          helpers.next(function() {
+            expect(el.querySelectorAll('h3[aria-level="4"]').length).equal(3);
+            done();
+          });
+        });
+      });
+    });
   });
   
   describe('Markup', function() {

--- a/coral-component-accordion/src/tests/test.Accordion.js
+++ b/coral-component-accordion/src/tests/test.Accordion.js
@@ -134,15 +134,10 @@ describe('Accordion', function() {
     });
 
     describe('#level', function() {
-      it('should set heading level for Accordion item headings', function(done) {
+      it('should set heading level for Accordion item headings', function() {
         const el = helpers.build(window.__html__['Accordion.base.html']);
         el.level = 4;
-        helpers.next(function() {
-          helpers.next(function() {
-            expect(el.querySelectorAll('h3[aria-level="4"]').length).equal(3);
-            done();
-          });
-        });
+        expect(el.querySelectorAll('h3[aria-level="4"]').length).equal(3);
       });
     });
   });


### PR DESCRIPTION
## Description

So that nested Accordions can properly represent their heading level hierarchy, Coral-Spectrum should support the level prop to set the aria-level for each descendant h3 element.

## Related Issue
[CUI-7408](https://jira.corp.adobe.com/browse/CUI-7408)
[CQ-4273103](https://jira.corp.adobe.com/browse/CQ-4273103?focusedCommentId=21990738&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21990738)

## Motivation and Context
Accordions can be nested, so the heading levels for Accordion items should reflect the hierarchy.

## How Has This Been Tested?
Unit tests and Nested example has been updated to use `level="4"`, rather than the default `level="3"` on nested Accordion.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
