### PR TITLE
CUI-7409 Coral.Fileupload should support .focus-ring style when visually hidden file input has focus

### DIFF
--- a/coral-component-fileupload/src/scripts/FileUpload.js
+++ b/coral-component-fileupload/src/scripts/FileUpload.js
@@ -493,6 +493,9 @@ class FileUpload extends BaseFormField(BaseComponent(HTMLElement)) {
   
   /** @private */
   _onInputFocusIn() {
+    // Get the input
+    const input = event.matchedTarget;
+
     const button = this.querySelector('[coral-fileupload-select]');
     if (button) {
       // Remove from the tab order so shift+tab works
@@ -503,6 +506,12 @@ class FileUpload extends BaseFormField(BaseComponent(HTMLElement)) {
       
       // Mark the button as focused
       button.classList.add('is-focused');
+
+      window.requestAnimationFrame(() => {
+        if (input.classList.contains('focus-ring')) {
+          button.classList.add('focus-ring');
+        }
+      });
     }
   }
   
@@ -511,6 +520,7 @@ class FileUpload extends BaseFormField(BaseComponent(HTMLElement)) {
     // Unmark all the focused buttons
     const button = this.querySelector('[coral-fileupload-select].is-focused');
     button.classList.remove('is-focused');
+    button.classList.remove('focus-ring');
     
     // Wait a frame so that shifting focus backwards with screen reader doesn't create a focus trap
     window.requestAnimationFrame(() => {

--- a/coral-component-fileupload/src/tests/test.FileUpload.js
+++ b/coral-component-fileupload/src/tests/test.FileUpload.js
@@ -824,5 +824,30 @@ describe('FileUpload', function() {
         done();
       });
     });
+
+    describe('focus-ring', function() {
+      it('should render focus-ring on select button when the input receives keyboard focus', function(done) {
+        var fileUpload = helpers.build(window.__html__['FileUpload.specialAttributes.html']);
+        // Wait for MO
+        helpers.next(() => {
+          var button = fileUpload.querySelector('[coral-fileupload-select]');
+          var input = fileUpload._elements.input;
+          // spoof keyboard focus
+          input.classList.add('focus-ring');
+          input.focus();
+          helpers.next(() => {
+            expect(button.classList.contains('is-focused')).to.be.true;
+            expect(button.classList.contains('focus-ring')).to.be.true;
+            input.blur();
+            helpers.next(() => {
+              expect(button.classList.contains('is-focused')).to.be.false;
+              expect(button.classList.contains('focus-ring')).to.be.false;
+              done();
+            });
+          });
+        });
+
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description
When the Coral.Fileupload button receives focus it moves focus immediately to a visually hidden file input element, yet when this input element receives focus, the .focus-ring style is lost on button.

## Related Issue
[CUI-7409](https://jira.corp.adobe.com/browse/CUI-7409)
[CQ-4293594](https://jira.corp.adobe.com/browse/CQ-4293594)

## Motivation and Context
Keyboard focus should be rendered when user closes Fileupload selection dialog using Esc key.

## How Has This Been Tested?
Tested using Example documentation

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
