### PR TITLE
Fixed the issue where the icon shrinks on inserting long content in coral-card-property

### DIFF
--- a/coral-component-card/src/styles/index.styl
+++ b/coral-component-card/src/styles/index.styl
@@ -236,6 +236,10 @@ coral-card-propertylist:first-of-type {
   margin-left: 6px;
 }
 
+._coral-Card-property-icon {
+  flex-shrink: 0;
+}
+
 coral-card-overlay {
   display: block;
 


### PR DESCRIPTION
## Description
An issue was observed where the icon corresponding with coral-card-property shrinks in size as the associated content was increased. This was the case because of the CSS - `flex-shrink` wasn't set to 0.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7411
https://jira.corp.adobe.com/browse/CQ-4300425

## Motivation and Context
Solves the problem with the shrinking of an icon on long content in card-property.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
