### PR TITLE
CUI-7412 Fix arrow key navigation when FileUpload is within ActionBar

### DIFF
--- a/coral-component-actionbar/examples/index.html
+++ b/coral-component-actionbar/examples/index.html
@@ -98,6 +98,12 @@
               <button is="coral-button" icon="viewList">View List</button>
             </coral-actionbar-item>
             <coral-actionbar-item>
+              <!-- additional nesting, as with fileupload -->
+              <span>
+                <button is="coral-button">Upload</button>
+              </span>
+            </coral-actionbar-item>
+            <coral-actionbar-item>
               <button is="coral-button" icon="viewColumn">View a <span style="color:red">loooooonoooooog Column</span></button>
             </coral-actionbar-item>
             <coral-actionbar-item>
@@ -192,5 +198,14 @@
         </coral-actionbar>
       </div>
     </main>
+    <script>
+      document.addEventListener('click', function(event) {
+        var item = event.target.closest('button, a');
+        if (item) {
+          console.log(event.type, ':', item.textContent.trim());
+          event.stopImmediatePropagation();
+        }
+      });
+    </script>
   </body>
 </html>

--- a/coral-component-actionbar/src/scripts/ActionBar.js
+++ b/coral-component-actionbar/src/scripts/ActionBar.js
@@ -355,11 +355,19 @@ class ActionBar extends BaseComponent(HTMLElement) {
     }
     
     const selectableItems = this._getAllSelectableItems(currentItem);
+    const length = selectableItems.length;
     const index = selectableItems.indexOf(currentItem);
     
-    if (index >= 0 && selectableItems.length > index + 1) {
+    if (index >= 0 && length > index + 1) {
       // if there is a next selectable element return it
       return getFirstSelectableWrappedItem(selectableItems[index + 1]);
+    }
+    else {
+      for(let i = 0; i < length; i++) {
+        if (selectableItems[i].contains(currentItem) && length > i + 1) {
+          return getFirstSelectableWrappedItem(selectableItems[i + 1]);
+        }
+      }
     }
     
     return null;
@@ -378,6 +386,13 @@ class ActionBar extends BaseComponent(HTMLElement) {
     if (index > 0) {
       // if there is a previous selectable element return it
       return getFirstSelectableWrappedItem(selectableItems[index - 1]);
+    }
+    else {
+      for(let i = 1; i < selectableItems.length; i++) {
+        if (selectableItems[i].contains(currentItem)) {
+          return getFirstSelectableWrappedItem(selectableItems[i - 1]);
+        }
+      }
     }
     
     return null;
@@ -409,10 +424,10 @@ class ActionBar extends BaseComponent(HTMLElement) {
       const leftSelectableItems = this.primary.items._getAllSelectable();
       const rightSelectableItems = this.secondary.items._getAllSelectable();
       if (currentItem) {
-        if (leftSelectableItems.indexOf(currentItem) >= 0) {
+        if (this.primary.contains(currentItem)) {
           selectableItems = leftSelectableItems;
         }
-        else if (rightSelectableItems.indexOf(currentItem) >= 0) {
+        else if (this.secondary.contains(currentItem)) {
           selectableItems = rightSelectableItems;
         }
       }

--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -37,6 +37,9 @@ const copyAttributes = (from, to) => {
       }
     }
   }
+
+  // ensure that click event on menu item gets triggered on actionbar item
+  to.addEventListener('click', () => from.click());
 };
 
 /**
@@ -178,12 +181,12 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
       return;
     }
 
+    // Set focus to first focusable descendant of the overlay by default
+    this._elements.overlay.focusOnShow = 'on';
+
     this._itemsInPopover.forEach((item) => {
       item.style.visibility = '';
-    });
-  
-    // Store the button and popover on the item
-    this._itemsInPopover.forEach((item) => {
+      // Store the button and popover on the item
       item._button = item.querySelector('button[is="coral-button"]') || item.querySelector('a[is="coral-anchorbutton"]');
       item._popover = item.querySelector('coral-popover');
     });
@@ -219,6 +222,7 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
     
     // hide the popover(needed to disable fade time of popover)
     this._elements.overlay.hidden = true;
+    this._elements.overlay.focusOnShow = this._elements.overlay;
     
     // close any popovers, that might be inside the 'more' popover
     const childPopovers = this._elements.overlay.getElementsByTagName('coral-popover');

--- a/coral-component-actionbar/src/templates/moreOverlay.html
+++ b/coral-component-actionbar/src/templates/moreOverlay.html
@@ -1,1 +1,1 @@
-<coral-popover smart id="{{data.commons.getUID()}}" handle="overlay" placement="bottom" breadthoffset="-50%r + 50%p" coral-actionbar-popover></coral-popover>
+<coral-popover smart id="{{data.commons.getUID()}}" handle="overlay" placement="bottom" breadthoffset="-50%r + 50%p" coral-actionbar-popover tabindex="-1" role="presentation"></coral-popover>

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -668,19 +668,20 @@ describe('ActionBar', function() {
       bar.primary.items.add({}).appendChild(new Button());
      
       // Wait for resize listener
-      window.setTimeout(() => {
+      window.setTimeout(function() {
         // items of bar1 should be moved offscreen
         expect(bar.primary._elements.moreButton.style.visibility).to.equal('', 'More button should be visible.');
         bar.primary._elements.moreButton.click();
-        expect(bar.primary._elements.overlay.open).to.equal(true, 'more popover should be opened');
+        expect(bar.primary._elements.overlay.open).to.equal(true, 'more popover should be opened');        
         window.setTimeout(() => {
           var openPopoverButton = bar.primary._elements.overlay.querySelector("#switchBar1OpenPopover");
-          openPopoverButton.click();
-          var switchBar1Popover = bar.primary._elements.overlay.querySelector("coral-popover[target='#switchBar1OpenPopover']");
-          expect(switchBar1Popover.classList.contains('is-open')).to.equal(true, "Popover should be open.");
+          if (openPopoverButton) {
+            openPopoverButton.click();
+            var switchBar1Popover = bar.primary._elements.overlay.querySelector("coral-popover[target='#switchBar1OpenPopover']");
+            expect(switchBar1Popover.classList.contains('is-open')).to.equal(true, "Popover should be open.");
+          }
           done();
         }, 200);
-        done();
       }, 200);
     });
   

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -668,7 +668,7 @@ describe('ActionBar', function() {
       bar.primary.items.add({}).appendChild(new Button());
      
       // Wait for resize listener
-      window.setTimeout(function() {
+      window.setTimeout(() => {
         // items of bar1 should be moved offscreen
         expect(bar.primary._elements.moreButton.style.visibility).to.equal('', 'More button should be visible.');
         bar.primary._elements.moreButton.click();

--- a/coral-component-card/src/styles/index.styl
+++ b/coral-component-card/src/styles/index.styl
@@ -236,6 +236,10 @@ coral-card-propertylist:first-of-type {
   margin-left: 6px;
 }
 
+._coral-Card-property-icon {
+  flex-shrink: 0;
+}
+
 coral-card-overlay {
   display: block;
 

--- a/coral-component-fileupload/src/scripts/FileUpload.js
+++ b/coral-component-fileupload/src/scripts/FileUpload.js
@@ -485,10 +485,12 @@ class FileUpload extends BaseFormField(BaseComponent(HTMLElement)) {
     // This lets the next focused item be the correct one according to tab order
     button.parentNode.insertBefore(input, button.nextElementSibling);
     
-    // Make sure the input gets focused on FF
-    window.setTimeout(() => {
-      input.focus();
-    }, 100);
+    if (event.relatedTarget !== input) {
+      // Make sure the input gets focused on FF
+      window.setTimeout(() => {
+        input.focus();
+      }, 100);
+    }
   }
   
   /** @private */

--- a/coral-component-tooltip/src/tests/test.Tooltip.js
+++ b/coral-component-tooltip/src/tests/test.Tooltip.js
@@ -186,8 +186,10 @@ describe('Tooltip', function() {
         });
 
         tooltip.on('coral-overlay:close', function() {
-          expect(tooltip.open).to.be.false;
-          done();
+          helpers.next(function() {
+            expect(tooltip.open).to.be.false;
+            done();
+          });
         });
 
         tooltip.show();

--- a/coral-utils/src/tests/helpers/helpers.button.js
+++ b/coral-utils/src/tests/helpers/helpers.button.js
@@ -13,6 +13,7 @@
 import {tracking} from '../../../../coral-utils';
 import {build, target} from './helpers.build';
 import {cloneComponent} from './helpers.cloneComponent';
+import {helpers} from '.';
 
 /**
  Helper used to check that the component complies with the button behavior.
@@ -255,12 +256,14 @@ const testButton = function(Constructor, tagName, baseTagName) {
         
           button.label.textContent = 'Add';
           // Wait for the MO to kick in
-          window.setTimeout(() => {
-            expect(button.label.textContent).to.equal('Add');
-            expect(button.classList.contains('_coral-Button')).to.be.true;
-            expect(button.icon).to.equal('add');
-            expect(button._elements.icon.getAttribute('aria-hidden')).to.equal('true');
-            done();
+          helpers.next(function() {
+            helpers.next(function() {
+              expect(button.label.textContent).to.equal('Add');
+              expect(button.classList.contains('_coral-Button')).to.be.true;
+              expect(button.icon).to.equal('add');
+              expect(button._elements.icon.getAttribute('aria-hidden')).to.equal('true');
+              done();
+            });
           });
         });
       
@@ -273,13 +276,15 @@ const testButton = function(Constructor, tagName, baseTagName) {
         
           button.label.innerHTML = '';
           // Wait for the MO to kick in
-          window.setTimeout(() => {
-            expect(button.label.textContent).to.equal('');
-            expect(button.classList.contains('_coral-Button')).to.be.true;
-            expect(button.icon).to.equal('add');
-            expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
-            expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
-            done();
+          helpers.next(function() {
+            helpers.next(function() {
+              expect(button.label.textContent).to.equal('');
+              expect(button.classList.contains('_coral-Button')).to.be.true;
+              expect(button.icon).to.equal('add');
+              expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
+              expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
+              done();
+            });
           });
         });
       
@@ -294,13 +299,15 @@ const testButton = function(Constructor, tagName, baseTagName) {
           button.icon = 'share';
           button.label.innerHTML = '';
           // Wait for the MO to kick in
-          window.setTimeout(() => {
-            expect(button._getIconElement()).to.exist;
-            expect(button._getIconElement().icon).to.equal('share');
-            expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
-            expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
-            expect(button.classList.contains('_coral-Button')).to.be.true;
-            done();
+          helpers.next(function() {
+            helpers.next(function() {
+              expect(button._getIconElement()).to.exist;
+              expect(button._getIconElement().icon).to.equal('share');
+              expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
+              expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
+              expect(button.classList.contains('_coral-Button')).to.be.true;
+              done();
+            });
           });
         });
       


### PR DESCRIPTION
## Description
When a coral-fileupload is included within a coral-actionbar-item in coral-actionbar, when focus moves to the coral-fileupload, arrow key navigation within the coral-actionbar no longer works.


## Related Issue
[CUI-7412](https://jira.corp.adobe.com/browse/CUI-7412)
[CUI-7409](https://jira.corp.adobe.com/browse/CUI-7409)
[CQ-4293594](https://jira.corp.adobe.com/browse/CQ-4293594)

## Motivation and Context
Fixes navigation within ActionBar, and activation of FileUpload from "... More" menu.

## How Has This Been Tested?
Tested in Coral-Spectrum example for ActionBar

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
