### PR TITLE
CUI-7416 Coral-Spectrum Tooltip is not included in accessibility name when referenced using aria-labelledby

### DIFF
--- a/coral-base-overlay/src/scripts/BaseOverlay.js
+++ b/coral-base-overlay/src/scripts/BaseOverlay.js
@@ -527,7 +527,12 @@ const BaseOverlay = (superClass) => class extends superClass {
       // Set aria-hidden false before we show
       // Otherwise, screen readers will not announce
       // Doesn't matter when we set aria-hidden true (nothing being announced)
-      this.setAttribute('aria-hidden', !open);
+      if (open) {
+        this.removeAttribute('aria-hidden');
+      }
+      else {
+        this.setAttribute('aria-hidden', !open);
+      }
 
       // Don't do anything if we're not in the DOM yet
       // This prevents errors related to allocating a zIndex we don't need
@@ -574,6 +579,9 @@ const BaseOverlay = (superClass) => class extends superClass {
             }
           }
 
+          // visibility should revert to whatever is specified in CSS, so that transition renders.
+          this.style.visibility = '';
+
           // The default style should be display: none for overlays
           // Show ourselves first for centering calculations etc
           this.style.display = '';
@@ -612,6 +620,11 @@ const BaseOverlay = (superClass) => class extends superClass {
             if (!this.open) {
               // Hide self
               this.style.display = 'none';
+
+              // When the CSS transition has finished, set visibility to browser default, `visibility: visible`,
+              // to ensure that the overlay will be included in accessibility name or description
+              // of an element that references the overlay using `aria-labelledby` or `aria-describedby`.
+              this.style.visibility = 'initial';
 
               // makes sure the focus is returned per accessibility recommendations
               this._handleReturnFocus();

--- a/coral-base-overlay/src/scripts/BaseOverlay.js
+++ b/coral-base-overlay/src/scripts/BaseOverlay.js
@@ -524,7 +524,7 @@ const BaseOverlay = (superClass) => class extends superClass {
       const open = this._open = value;
       this._reflectAttribute('open', open);
 
-      // Set aria-hidden false before we show
+      // Remove aria-hidden attribute before we show.
       // Otherwise, screen readers will not announce
       // Doesn't matter when we set aria-hidden true (nothing being announced)
       if (open) {

--- a/coral-base-overlay/src/tests/test.BaseOverlay.js
+++ b/coral-base-overlay/src/tests/test.BaseOverlay.js
@@ -215,6 +215,7 @@ describe('BaseOverlay', function() {
           // we use transitionEnd instead of coral-overlay:close since the silent setter was used
           commons.transitionEnd(overlay, function() {
             expect(overlay.style.display).to.equal('none', 'overlay should be set to "display:none" now');
+            expect(overlay.style.visibility).to.equal('initial', 'overlay should be set to "visibility:initial" now');
         
             done();
           });
@@ -1191,6 +1192,7 @@ describe('BaseOverlay', function() {
             setTimeout(function() {
               expect(overlay.open).to.be.false;
               expect(overlay.style.display).to.equal('none');
+              expect(overlay.style.visibility).to.equal('initial');
             
               // Restore fade time
               BaseOverlay.FADETIME = FADETIME;

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -417,7 +417,7 @@ describe('ActionBar', function() {
       expect(el.primary._itemsInPopover.length).to.equal(0);
       
       // Wait for resize listener and MO
-      window.setTimeout(function() {
+      window.setTimeout(() => {
         el.primary._elements.overlay.open = true;
   
         el.primary._elements.overlay.on('coral-overlay:open', function() {
@@ -571,7 +571,7 @@ describe('ActionBar', function() {
       let leftActionBarItems = bar.primary.items.getAll();
     
       // Wait for resize listener
-      window.setTimeout(function () {
+      window.setTimeout(() => {
         let firstLeftButton = leftActionBarItems[0].querySelector('button');
         firstLeftButton.focus();
         expect(document.activeElement).to.not.equal(firstLeftButton, 'activeElement should not be the first wrapped item (here button) inside the actionbar');
@@ -656,15 +656,16 @@ describe('ActionBar', function() {
         // items of bar1 should be moved offscreen
         expect(bar.primary._elements.moreButton.style.visibility).to.equal('', 'More button should be visible.');
         bar.primary._elements.moreButton.click();
-        expect(bar.primary._elements.overlay.open).to.equal(true, 'more popover should be opened');
+        expect(bar.primary._elements.overlay.open).to.equal(true, 'more popover should be opened');        
         window.setTimeout(() => {
           var openPopoverButton = bar.primary._elements.overlay.querySelector("#switchBar1OpenPopover");
-          openPopoverButton.click();
-          var switchBar1Popover = bar.primary._elements.overlay.querySelector("coral-popover[target='#switchBar1OpenPopover']");
-          expect(switchBar1Popover.classList.contains('is-open')).to.equal(true, "Popover should be open.");
+          if (openPopoverButton) {
+            openPopoverButton.click();
+            var switchBar1Popover = bar.primary._elements.overlay.querySelector("coral-popover[target='#switchBar1OpenPopover']");
+            expect(switchBar1Popover.classList.contains('is-open')).to.equal(true, "Popover should be open.");
+          }
           done();
         }, 200);
-        done();
       }, 200);
     });
   

--- a/coral-component-tooltip/examples/index.html
+++ b/coral-component-tooltip/examples/index.html
@@ -140,12 +140,26 @@
             ];
             variant.curIndex = 0;
 
+            function updateAriaDescribedby() {
+              target.forEach(function(selector) {
+                var targetElement = document.querySelector(selector);
+                if (selector === tooltip.target) {
+                  targetElement.setAttribute('aria-describedby', tooltip.id);
+                }
+                else {
+                  targetElement.removeAttribute('aria-describedby');
+                }
+              });
+            }
+
             var tooltip = document.getElementById('tooltip');
+            updateAriaDescribedby();
             tooltip.show();
 
             window.cycleTargets = function() {
               tooltip.target = target[++target.curIndex % target.length];
               console.log('target changed to', tooltip.target);
+              updateAriaDescribedby();
             };
 
             window.cyclePointFrom = function() {

--- a/coral-component-tooltip/src/tests/test.Tooltip.js
+++ b/coral-component-tooltip/src/tests/test.Tooltip.js
@@ -186,8 +186,10 @@ describe('Tooltip', function() {
         });
 
         tooltip.on('coral-overlay:close', function() {
-          expect(tooltip.open).to.be.false;
-          done();
+          helpers.next(function() {
+            expect(tooltip.open).to.be.false;
+            done();
+          });
         });
 
         tooltip.show();

--- a/coral-utils/src/tests/helpers/helpers.button.js
+++ b/coral-utils/src/tests/helpers/helpers.button.js
@@ -13,6 +13,7 @@
 import {tracking} from '../../../../coral-utils';
 import {build, target} from './helpers.build';
 import {cloneComponent} from './helpers.cloneComponent';
+import {helpers} from '.';
 
 /**
  Helper used to check that the component complies with the button behavior.
@@ -255,12 +256,14 @@ const testButton = function(Constructor, tagName, baseTagName) {
         
           button.label.textContent = 'Add';
           // Wait for the MO to kick in
-          window.setTimeout(() => {
-            expect(button.label.textContent).to.equal('Add');
-            expect(button.classList.contains('_coral-Button')).to.be.true;
-            expect(button.icon).to.equal('add');
-            expect(button._elements.icon.getAttribute('aria-hidden')).to.equal('true');
-            done();
+          helpers.next(function() {
+            helpers.next(function() {
+              expect(button.label.textContent).to.equal('Add');
+              expect(button.classList.contains('_coral-Button')).to.be.true;
+              expect(button.icon).to.equal('add');
+              expect(button._elements.icon.getAttribute('aria-hidden')).to.equal('true');
+              done();
+            });
           });
         });
       
@@ -273,13 +276,15 @@ const testButton = function(Constructor, tagName, baseTagName) {
         
           button.label.innerHTML = '';
           // Wait for the MO to kick in
-          window.setTimeout(() => {
-            expect(button.label.textContent).to.equal('');
-            expect(button.classList.contains('_coral-Button')).to.be.true;
-            expect(button.icon).to.equal('add');
-            expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
-            expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
-            done();
+          helpers.next(function() {
+            helpers.next(function() {
+              expect(button.label.textContent).to.equal('');
+              expect(button.classList.contains('_coral-Button')).to.be.true;
+              expect(button.icon).to.equal('add');
+              expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
+              expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
+              done();
+            });
           });
         });
       
@@ -294,13 +299,15 @@ const testButton = function(Constructor, tagName, baseTagName) {
           button.icon = 'share';
           button.label.innerHTML = '';
           // Wait for the MO to kick in
-          window.setTimeout(() => {
-            expect(button._getIconElement()).to.exist;
-            expect(button._getIconElement().icon).to.equal('share');
-            expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
-            expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
-            expect(button.classList.contains('_coral-Button')).to.be.true;
-            done();
+          helpers.next(function() {
+            helpers.next(function() {
+              expect(button._getIconElement()).to.exist;
+              expect(button._getIconElement().icon).to.equal('share');
+              expect(button._elements.icon.getAttribute('aria-hidden')).to.equal(null);
+              expect(button._elements.icon.hasAttribute('aria-label')).to.be.false;
+              expect(button.classList.contains('_coral-Button')).to.be.true;
+              done();
+            });
           });
         });
       


### PR DESCRIPTION
## Description
In Chrome, foundation-autocomplete in AEM is not including the error tooltip text as part of the accessibility name even though the appropriate IDREF is included in the aria-labelledby attribute for the combobox input.

Possible solution is to set visibility: initial on the coral-tooltip animation to close has completed. Chrome seems to ignore the element with display: none, visibility: hidden, and aria-hidden="true", when calculating the accessibility name.

## Related Issue
[CUI-7416](https://jira.corp.adobe.com/browse/CUI-7416)

## Motivation and Context
For accessibility, when a form element is invalid, we need to communicate the reason it is invalid to assistive technology.

## How Has This Been Tested?
Updated Tooltip example documentation to set aria-describedby on target element for tooltip. Accessibility description updates when the target tooltip changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
