### PR TITLE
CQ-4272964 fix VoiceOver announcing elements as "row 1 expanded" on focus

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -259,34 +259,38 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
 
     // @a11y Update aria-expanded. Active drilldowns should be expanded.
     if (this.variant === variant.DRILLDOWN) {
-      const isFocused = this === document.activeElement || this.contains(document.activeElement);
-      let activeElement;
-      if (isFocused && !this.selected) {
-        this.setAttribute('aria-expanded', this._active);
-        activeElement = document.activeElement;
-        activeElement.blur();
-      }
-      else {
-        this.setAttribute('aria-hidden', true);
-      }
       // @a11y workaround for VoiceOver announcing expanded state rather than the item name when the item receives focus.
-      const timeoutDelay = 60;
       if (this._ariaExpandedTimeout) {
+        window.cancelAnimationFrame(this._ariaExpandedTimeout);
         window.clearTimeout(this._ariaExpandedTimeout);
         this._ariaExpandedTimeout = undefined;
       }
-      // @a11y after a delay to give focused item time to announce,
-      this._ariaExpandedTimeout = window.setTimeout(() => {
-        if (isFocused && activeElement) {
-          activeElement.focus();
+      const timeoutDelay = 20;
+      this._ariaExpandedTimeout = commons.nextFrame(() => {
+        const isFocused = this === document.activeElement || this.contains(document.activeElement);
+        let activeElement;
+        if (isFocused && !this.selected) {
+          this.setAttribute('aria-expanded', this._active);
+          activeElement = document.activeElement;
+          activeElement.blur();
         }
         else {
-          window.setTimeout(() => {
-            this.setAttribute('aria-expanded', this._active);
-            this.removeAttribute('aria-hidden');
-          }, timeoutDelay * 2);
+          this.setAttribute('aria-hidden', true);
         }
-      }, timeoutDelay);
+      
+        // @a11y after a delay to give focused item time to announce,
+        commons.nextFrame(() => {
+          if (isFocused && activeElement) {
+            activeElement.focus();
+          }
+          else {
+            window.setTimeout(() => {
+              this.setAttribute('aria-expanded', this._active);
+              commons.nextFrame(() => this.removeAttribute('aria-hidden'));
+            }, timeoutDelay);
+          }
+        });
+      });
     }
 
     if (!this._active) {

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -845,7 +845,7 @@ describe('ColumnView', function() {
           expect(document.activeElement.id).to.equal(el.columns.getAll()[1].items.first().id);
           expect(document.activeElement.id).to.equal(el.activeItem.id);
           done();
-        }, 450);
+        }, 200);
       });
 
       it('ArrowDown should focus next item', function(done) {
@@ -857,7 +857,7 @@ describe('ColumnView', function() {
           expect(document.activeElement.id).to.equal(el.columns.getAll()[1].items.getAll()[2].id);
           expect(document.activeElement.id).to.equal(el.activeItem.id);
           done();
-        }, 450);
+        }, 200);
       });
 
       it('ArrowRight on item with variant=drilldown should focus first item in next column', function(done) {
@@ -870,7 +870,7 @@ describe('ColumnView', function() {
             expect(document.activeElement.id).to.equal(el.columns.getAll()[1].items.first().id);
             done();
           });
-        }, 400);
+        }, 200);
       });
 
       it('ArrowLeft on item with previous column should focus active item in previous column', function(done) {
@@ -878,11 +878,11 @@ describe('ColumnView', function() {
         const activeItem = el.activeItem;
         activeItem.trigger('click');
         helpers.keypress('left', activeItem);
-        helpers.next(function() {
+        window.setTimeout(function() {
           expect(document.activeElement.id).to.equal(el.columns.first().items.getAll()[1].id);
           expect(document.activeElement.id).to.equal(el.activeItem.id);
           done();
-        });
+        }, 200);
       });
 
       it('Space on item should toggle selection', function(done) {
@@ -1304,7 +1304,7 @@ describe('ColumnView', function() {
         window.setTimeout(function() {
           expect(el.activeItem.getAttribute('aria-expanded')).to.equal('true');
           done();
-        }, 450);
+        }, 200);
       });
 
       it('should express ownership of expanded column using aria-owns', function(done) {


### PR DESCRIPTION
## Description
Per: https://jira.corp.adobe.com/browse/CQ-4272964?focusedCommentId=21879694&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21879694

> "row1 expanded", "row1 collapsed" is announced while navigating using up/down key in first column.

## Related Issue
[CQ-4272964](https://jira.corp.adobe.com/browse/CQ-4272964)

## Motivation and Context
Ensure that when a ColumnView item receives keyboard focus, it announces the element name rather than its expanded/collapsed state.

## How Has This Been Tested?
Tested in Coral-Spectrum example pages.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
