### PR TITLE
CUI-7417 [A11y] Coral.StepList should support labelledBy and describedBy on Step items

### DIFF
--- a/coral-base-formfield/src/scripts/BaseFormField.js
+++ b/coral-base-formfield/src/scripts/BaseFormField.js
@@ -150,7 +150,23 @@ const BaseFormField = (superClass) => class extends superClass {
     this.setAttribute('aria-invalid', this._invalid);
     this.classList.toggle('is-invalid', this._invalid);
   }
+
+  /**
+   Reflects the <code>aria-describedby</code> attribute to the labellable element e.g. inner input.
+   
+   @type {String}
+   @default null
+   @htmlattribute describedby
+   */
+  get describedBy() {
+    return this._getLabellableElement().getAttribute('aria-describedby');
+  }
+  set describedBy(value) {
+    value = transform.string(value);
   
+    this._getLabellableElement()[value ? 'setAttribute' : 'removeAttribute']('aria-describedby', value);
+  }
+
   /**
    Reflects the <code>aria-label</code> attribute to the labellable element e.g. inner input.
    
@@ -368,6 +384,7 @@ const BaseFormField = (superClass) => class extends superClass {
   
   static get _attributePropertyMap() {
     return commons.extend(super._attributePropertyMap, {
+      describedby: 'describedBy',
       labelledby: 'labelledBy',
       readonly: 'readOnly',
     });
@@ -376,6 +393,7 @@ const BaseFormField = (superClass) => class extends superClass {
   // We don't want to watch existing attributes for components that extend native HTML elements
   static get _nativeObservedAttributes() {
     return super.observedAttributes.concat([
+      'describedby',
       'labelled',
       'labelledby',
       'invalid'
@@ -385,6 +403,7 @@ const BaseFormField = (superClass) => class extends superClass {
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat([
+      'describedby',
       'labelled',
       'labelledby',
       'invalid',

--- a/coral-base-formfield/src/tests/test.BaseFormField.js
+++ b/coral-base-formfield/src/tests/test.BaseFormField.js
@@ -87,16 +87,16 @@ describe('BaseFormField', function() {
       el = null;
     });
     
-    ['name', 'value', 'disabled', 'required', 'readOnly', 'invalid', 'labelled', 'labelledBy'].forEach((prop) => {
+    ['name', 'value', 'disabled', 'required', 'readOnly', 'invalid', 'labelled', 'labelledBy', 'describedBy'].forEach((prop) => {
   
-      const value = ['name', 'value', 'labelledBy', 'labelled'].indexOf(prop) !== -1 ? 'test' : true;
+      const value = ['name', 'value', 'labelledBy', 'labelled', 'describedBy'].indexOf(prop) !== -1 ? 'test' : true;
       
       describe(`#${prop}`, function() {
         it('should set by property', function() {
           el[prop] = value;
           expect(el[prop]).to.equal(value);
           
-          if (prop !== 'invalid' && prop !== 'labelledBy' && prop !== 'labelled') {
+          if (prop !== 'invalid' && prop !== 'labelledBy' && prop !== 'labelled' && prop !== 'describedBy') {
             expect(el._elements.input[prop]).to.equal(value);
           }
         });
@@ -105,12 +105,12 @@ describe('BaseFormField', function() {
           el.setAttribute(prop, value);
           expect(el[prop]).to.equal(value);
   
-          if (prop !== 'invalid' && prop !== 'labelledBy' && prop !== 'labelled') {
+          if (prop !== 'invalid' && prop !== 'labelledBy' && prop !== 'labelled' && prop !== 'describedBy') {
             expect(el._elements.input[prop]).to.equal(value);
           }
         });
     
-        if (prop !== 'value' && prop !== 'labelledBy' && prop !== 'labelled') {
+        if (prop !== 'value' && prop !== 'labelledBy' && prop !== 'labelled' && prop !== 'describedBy') {
           it('should be reflected', function() {
             el[prop] = value;
             
@@ -155,6 +155,27 @@ describe('BaseFormField', function() {
     
         expect(label.getAttribute('for')).to.equal(example._elements.input.id);
         expect(example._elements.input.getAttribute('aria-labelledby')).to.equal(label.id);
+      });
+    });
+
+    describe('#describedBy', function() {
+      it('should remove old for assignments', function() {
+        const label = document.createElement('label');
+        const example = document.createElement('coral-formfield-element');
+    
+        label.id = commons.getUID();
+        label.textContent = 'label';
+    
+        helpers.target.appendChild(label);
+        helpers.target.appendChild(example);
+        
+        example.describedBy = label.id;
+    
+        expect(example._elements.input.getAttribute('aria-describedby')).to.equal(label.id);
+
+        example.describedBy = null;
+
+        expect(example._elements.input.getAttribute('aria-describedby')).to.be.null;
       });
     });
     

--- a/coral-component-steplist/examples/index.html
+++ b/coral-component-steplist/examples/index.html
@@ -142,7 +142,6 @@
             var stepList = document.getElementById('labelled-steps-example');
             var spans = stepList.nextElementSibling.querySelectorAll('span');
             function onStepListChange(event) {
-              console.log('onStepListChange', event.detail);
               var stepLabel = event.detail.selection.getAttribute('labelled');
               for (var i = 0; i < spans.length; i++) {
                 spans[i].textContent = stepLabel;

--- a/coral-component-steplist/examples/index.html
+++ b/coral-component-steplist/examples/index.html
@@ -123,6 +123,39 @@
           <coral-step disabled>Step 5</coral-step>
         </coral-steplist>
       </div>
+
+      <h2 class="coral-Heading--S">labelled, labelledBy and describedBy</h2>
+      <div class="markup">
+        <coral-steplist size="S" interaction="on" id="labelled-steps-example">
+          <coral-step labelled="Step 1"></coral-step>
+          <coral-step labelled="Step 2" labelledby="labelled-steps-example-label" describedby="labelled-steps-example-desc" selected></coral-step>
+          <coral-step labelled="Step 3"></coral-step>
+          <coral-step labelled="Step 4"></coral-step>
+          <coral-step labelled="Step 5"></coral-step>
+        </coral-steplist>
+        <div class="coral-Well">
+          <h3><span id="labelled-steps-example-label">Step 2</span> heading</h3>
+          <p id="labelled-steps-example-desc"><span>Step 2</span> content</p>
+        </div>
+        <script>
+          document.addEventListener('DOMContentLoaded', function() {
+            var stepList = document.getElementById('labelled-steps-example');
+            var spans = stepList.nextElementSibling.querySelectorAll('span');
+            function onStepListChange(event) {
+              console.log('onStepListChange', event.detail);
+              var stepLabel = event.detail.selection.getAttribute('labelled');
+              for (var i = 0; i < spans.length; i++) {
+                spans[i].textContent = stepLabel;
+              }
+              event.detail.oldSelection.removeAttribute('labelledby');
+              event.detail.selection.setAttribute('labelledby', stepList.id + '-label');
+              event.detail.oldSelection.removeAttribute('describedby');
+              event.detail.selection.setAttribute('describedby', stepList.id + '-desc');
+            }
+            stepList.addEventListener('coral-steplist:change', onStepListChange);
+          });
+        </script>
+      </div>
     </main>
   </body>
 </html>

--- a/coral-component-steplist/src/scripts/Step.js
+++ b/coral-component-steplist/src/scripts/Step.js
@@ -140,25 +140,65 @@ class Step extends BaseComponent(HTMLElement) {
   /**
     Reflects the <code>aria-label</code> attribute to the marker dot for cases where no visible label is provided for the Step.
     @type {?String}
-    @default ''
+    @default null
     @htmlattribute labelled
-    @htmlattributereflected
     @memberof Coral.Step#
   */
   get labelled() {
-    return this._labelled || this.getAttribute('labelled') || this._elements.stepMarkerContainer.getAttribute('aria-label') || '';
+    return this._elements.stepMarkerContainer.getAttribute('aria-label');
   }
   set labelled(value) {
-    this._labelled = transform.string(value);
-    this._reflectAttribute('labelled', this._labelled);
+    value = transform.string(value);
     if (value) {
-      this._elements.stepMarkerContainer.setAttribute('aria-label', this.labelled);
+      this._elements.stepMarkerContainer.setAttribute('aria-label', value);
       this._elements.stepMarkerContainer.removeAttribute('aria-hidden');
     }
     else {
       this._elements.stepMarkerContainer.removeAttribute('aria-label');
-      this._elements.stepMarkerContainer.setAttribute('aria-hidden', 'true');
+      if (!this.labelledBy) {
+        this._elements.stepMarkerContainer.setAttribute('aria-hidden', 'true');
+      }
     }
+  }
+
+  /**
+    Reflects the <code>aria-labelledby</code> attribute to the marker dot for cases where no visible label is provided for the Step, 
+    and the Step is labelled by an external element.
+    @type {?String}
+    @default null
+    @htmlattribute labelledby
+    @memberof Coral.Step#
+  */
+  get labelledBy() {
+    return this._elements.stepMarkerContainer.getAttribute('aria-labelledby');
+  }
+  set labelledBy(value) {
+    value = transform.string(value);
+    if (value) {
+      this._elements.stepMarkerContainer.setAttribute('aria-labelledby', value);
+      this._elements.stepMarkerContainer.removeAttribute('aria-hidden');
+    }
+    else {
+      this._elements.stepMarkerContainer.removeAttribute('aria-labelledby');
+      if (!this.labelled) {
+        this._elements.stepMarkerContainer.setAttribute('aria-hidden', 'true');
+      }
+    }
+  }
+
+    /**
+    Reflects the <code>aria-describedby</code> attribute to the link element.
+    @type {?String}
+    @default null
+    @htmlattribute describedby
+    @memberof Coral.Step#
+  */
+  get describedBy() {
+    return this._elements.link.getAttribute('aria-describedby');
+  }
+  set describedBy(value) {
+    value = transform.string(value);
+    this._elements.link[value ? 'setAttribute' : 'removeAttribute']('aria-describedby', value);
   }
   
   /**
@@ -256,9 +296,17 @@ class Step extends BaseComponent(HTMLElement) {
   }
   
   get _contentZones() { return {'coral-step-label': 'label'}; }
+
+  /** @ignore */
+  static get _attributePropertyMap() {
+    return commons.extend(super._attributePropertyMap, {
+      labelledby: 'labelledBy',
+      describedby: 'describedBy',
+    });
+  }
   
   /** @ignore */
-  static get observedAttributes() { return super.observedAttributes.concat(['selected', 'target', 'disabled', 'labelled']); }
+  static get observedAttributes() { return super.observedAttributes.concat(['selected', 'target', 'disabled', 'labelled', 'labelledby', 'describedby']); }
   
   /** @ignore */
   connectedCallback() {

--- a/coral-component-steplist/src/scripts/Step.js
+++ b/coral-component-steplist/src/scripts/Step.js
@@ -140,17 +140,19 @@ class Step extends BaseComponent(HTMLElement) {
   /**
     Reflects the <code>aria-label</code> attribute to the marker dot for cases where no visible label is provided for the Step.
     @type {?String}
-    @default null
+    @default ''
     @htmlattribute labelled
+    @htmlattributereflected
     @memberof Coral.Step#
   */
   get labelled() {
-    return this._elements.stepMarkerContainer.getAttribute('aria-label');
+    return this._labelled || this.getAttribute('labelled') || this._elements.stepMarkerContainer.getAttribute('aria-label') || '';
   }
   set labelled(value) {
-    value = transform.string(value);
-    if (value) {
-      this._elements.stepMarkerContainer.setAttribute('aria-label', value);
+    this._labelled = transform.string(value);
+    this._reflectAttribute('labelled', value || false);
+    if (this._labelled !== '') {
+      this._elements.stepMarkerContainer.setAttribute('aria-label', this._labelled);
       this._elements.stepMarkerContainer.removeAttribute('aria-hidden');
     }
     else {
@@ -165,17 +167,19 @@ class Step extends BaseComponent(HTMLElement) {
     Reflects the <code>aria-labelledby</code> attribute to the marker dot for cases where no visible label is provided for the Step, 
     and the Step is labelled by an external element.
     @type {?String}
-    @default null
+    @default ''
     @htmlattribute labelledby
+    @htmlattributereflected
     @memberof Coral.Step#
   */
   get labelledBy() {
-    return this._elements.stepMarkerContainer.getAttribute('aria-labelledby');
+    return this._labelledBy || this.getAttribute('labelledby') || this._elements.stepMarkerContainer.getAttribute('aria-labelledby') || '';
   }
   set labelledBy(value) {
-    value = transform.string(value);
-    if (value) {
-      this._elements.stepMarkerContainer.setAttribute('aria-labelledby', value);
+    this._labelledBy = transform.string(value);
+    this._reflectAttribute('labelledby', value || false);
+    if (this._labelledBy !== '') {
+      this._elements.stepMarkerContainer.setAttribute('aria-labelledby', this._labelledBy);
       this._elements.stepMarkerContainer.removeAttribute('aria-hidden');
     }
     else {
@@ -189,16 +193,23 @@ class Step extends BaseComponent(HTMLElement) {
     /**
     Reflects the <code>aria-describedby</code> attribute to the link element.
     @type {?String}
-    @default null
+    @default ''
     @htmlattribute describedby
+    @htmlattributereflected
     @memberof Coral.Step#
   */
   get describedBy() {
-    return this._elements.link.getAttribute('aria-describedby');
+    return this._describedBy || this.getAttribute('describedby') || this._elements.link.getAttribute('aria-describedby') || '';
   }
   set describedBy(value) {
-    value = transform.string(value);
-    this._elements.link[value ? 'setAttribute' : 'removeAttribute']('aria-describedby', value);
+    this._describedBy = transform.string(value);
+    this._reflectAttribute('describedby', value || false);
+    if (this._describedBy !== '') {
+      this._elements.link.setAttribute('aria-describedby', this._describedBy);
+    }
+    else {
+      this._elements.link.removeAttribute('aria-describedby');
+    }
   }
   
   /**

--- a/coral-component-steplist/src/tests/test.Step.js
+++ b/coral-component-steplist/src/tests/test.Step.js
@@ -96,16 +96,34 @@ describe('Step', function() {
 
     describe('#labelled', function() {
       it('should default to empty string', function() {
-        expect(item.labelled).to.be.null;
+        expect(item.labelled).to.equal('');
       });
 
       it('should be settable', function(done) {
         item.labelled = 'Item 1';
         helpers.next(function() {
+          expect(item.getAttribute('labelled')).to.equal(item.labelled);
           expect(item._elements.stepMarkerContainer.getAttribute('aria-label')).to.equal(item.labelled);
           expect(item._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
           item.labelled = null;
           helpers.next(function() {
+            expect(item.hasAttribute('labelled')).to.be.false;
+            expect(item._elements.stepMarkerContainer.hasAttribute('aria-label')).to.be.false;
+            expect(item._elements.stepMarkerContainer.getAttribute('aria-hidden')).to.equal('true');
+            done();
+          });
+        });
+      });
+
+      it('should reflect attribute', function(done) {
+        item.setAttribute('labelled', 'Item 1');
+        helpers.next(function() {
+          expect(item.labelled).to.equal('Item 1');
+          expect(item._elements.stepMarkerContainer.getAttribute('aria-label')).to.equal(item.labelled);
+          expect(item._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
+          item.removeAttribute('labelled');
+          helpers.next(function() {
+            expect(item.labelled).to.equal('');
             expect(item._elements.stepMarkerContainer.hasAttribute('aria-label')).to.be.false;
             expect(item._elements.stepMarkerContainer.getAttribute('aria-hidden')).to.equal('true');
             done();
@@ -116,16 +134,34 @@ describe('Step', function() {
 
     describe('#labelledBy', function() {
       it('should default to empty string', function() {
-        expect(item.labelledBy).to.be.null;
+        expect(item.labelledBy).to.equal('');
       });
 
       it('should be settable', function(done) {
         item.labelledBy = 'foo';
         helpers.next(function() {
+          expect(item.getAttribute('labelledby')).to.equal(item.labelledBy);
           expect(item._elements.stepMarkerContainer.getAttribute('aria-labelledby')).to.equal(item.labelledBy);
           expect(item._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
           item.labelledBy = null;
           helpers.next(function() {
+            expect(item.hasAttribute('labelledby')).to.be.false;
+            expect(item._elements.stepMarkerContainer.hasAttribute('aria-labelledby')).to.be.false;
+            expect(item._elements.stepMarkerContainer.getAttribute('aria-hidden')).to.equal('true');
+            done();
+          });
+        });
+      });
+
+      it('should reflect attribute', function(done) {
+        item.setAttribute('labelledby', 'foo');
+        helpers.next(function() {
+          expect(item.labelledBy).to.equal('foo');
+          expect(item._elements.stepMarkerContainer.getAttribute('aria-labelledby')).to.equal(item.labelledBy);
+          expect(item._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
+          item.removeAttribute('labelledby');
+          helpers.next(function() {
+            expect(item.labelledBy).to.equal('');
             expect(item._elements.stepMarkerContainer.hasAttribute('aria-labelledby')).to.be.false;
             expect(item._elements.stepMarkerContainer.getAttribute('aria-hidden')).to.equal('true');
             done();
@@ -136,15 +172,31 @@ describe('Step', function() {
 
     describe('#describedBy', function() {
       it('should default to empty string', function() {
-        expect(item.describedBy).to.be.null;
+        expect(item.describedBy).to.equal('');
       });
 
       it('should be settable', function(done) {
         item.describedBy = 'bar';
         helpers.next(function() {
+          expect(item.getAttribute('describedby')).to.equal(item.describedBy);
           expect(item._elements.link.getAttribute('aria-describedby')).to.equal(item.describedBy);
           item.describedBy = null;
           helpers.next(function() {
+            expect(item.hasAttribute('describedby')).to.be.false;
+            expect(item._elements.link.hasAttribute('aria-describedby')).to.be.false;
+            done();
+          });
+        });
+      });
+
+      it('should reflect attribute', function(done) {
+        item.setAttribute('describedby', 'foo');
+        helpers.next(function() {
+          expect(item.describedBy).to.equal('foo');
+          expect(item._elements.link.getAttribute('aria-describedby')).to.equal(item.describedBy);
+          item.removeAttribute('describedby');
+          helpers.next(function() {
+            expect(item.describedBy).to.equal('');
             expect(item._elements.link.hasAttribute('aria-describedby')).to.be.false;
             done();
           });

--- a/coral-component-steplist/src/tests/test.Step.js
+++ b/coral-component-steplist/src/tests/test.Step.js
@@ -96,7 +96,7 @@ describe('Step', function() {
 
     describe('#labelled', function() {
       it('should default to empty string', function() {
-        expect(item.labelled).to.equal('');
+        expect(item.labelled).to.be.null;
       });
 
       it('should be settable', function(done) {
@@ -108,6 +108,44 @@ describe('Step', function() {
           helpers.next(function() {
             expect(item._elements.stepMarkerContainer.hasAttribute('aria-label')).to.be.false;
             expect(item._elements.stepMarkerContainer.getAttribute('aria-hidden')).to.equal('true');
+            done();
+          });
+        });
+      });
+    });
+
+    describe('#labelledBy', function() {
+      it('should default to empty string', function() {
+        expect(item.labelledBy).to.be.null;
+      });
+
+      it('should be settable', function(done) {
+        item.labelledBy = 'foo';
+        helpers.next(function() {
+          expect(item._elements.stepMarkerContainer.getAttribute('aria-labelledby')).to.equal(item.labelledBy);
+          expect(item._elements.stepMarkerContainer.hasAttribute('aria-hidden')).to.be.false;
+          item.labelledBy = null;
+          helpers.next(function() {
+            expect(item._elements.stepMarkerContainer.hasAttribute('aria-labelledby')).to.be.false;
+            expect(item._elements.stepMarkerContainer.getAttribute('aria-hidden')).to.equal('true');
+            done();
+          });
+        });
+      });
+    });
+
+    describe('#describedBy', function() {
+      it('should default to empty string', function() {
+        expect(item.describedBy).to.be.null;
+      });
+
+      it('should be settable', function(done) {
+        item.describedBy = 'bar';
+        helpers.next(function() {
+          expect(item._elements.link.getAttribute('aria-describedby')).to.equal(item.describedBy);
+          item.describedBy = null;
+          helpers.next(function() {
+            expect(item._elements.link.hasAttribute('aria-describedby')).to.be.false;
             done();
           });
         });


### PR DESCRIPTION
## Description

Step item should support describedBy attribute that maps to aria-describedby on the item link, and labelledBy attribute that maps to aria-labelledby on the step list marker image.

## Related Issue

[CUI-7417](https://jira.corp.adobe.com/browse/CUI-7417)

## Motivation and Context
For https://jira.corp.adobe.com/browse/CQ-4298385. Step item should support aria-describedby

## How Has This Been Tested?
Unit tests and example added to documentation

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
