### PR TITLE
:memo: chore(documentation): update README to provide information on turning external SVG rendering off

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ If icons are not displayed, ensure the path to the styles and icons are set e.g.
 <script data-coral-icons="dist/icons/" src="dist/bundle.min.js"></script>
 ```
 
+If icons still do not display, you can try setting them to display as inline
+SVGs, instead of external resources. Coral Spectrum will default to external
+resources on browsers other than IE11. Using the previous example, this option
+can be set with:
+
+```html
+<link rel="stylesheet" href="dist/style.min.css">
+<script data-coral-icons="dist/icons/" data-coral-icons-external="off" src="dist/bundle.min.js"></script>
+```
+
 **Note:** Calendar, Clock and Datepicker components will leverage [moment.js](http://momentjs.com/) if available. 
 
 ## Contributing


### PR DESCRIPTION
## Description
Updated README file to include information on how to render SVG icons internally (direct reference to attached shadow-root DOM SVG element/path) through Coral Spectrum, as opposed to externally (DOM references external SVG document and symbol by id to get path).

## Related Issue
Several teams reporting issues rendering icons through Coral Spectrum.

## Motivation and Context
Documentation does not mention additional steps to help resolve this issue.

## How Has This Been Tested?
Ran `gulp`, opened browser, verified changes.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
