### PR TITLE
CUI-7416 Coral-Spectrum Tooltip adjust visibility in connectedCallback

### DIFF
--- a/coral-base-overlay/src/scripts/BaseOverlay.js
+++ b/coral-base-overlay/src/scripts/BaseOverlay.js
@@ -623,8 +623,8 @@ const BaseOverlay = (superClass) => class extends superClass {
 
               // When the CSS transition has finished, set visibility to browser default, `visibility: visible`,
               // to ensure that the overlay will be included in accessibility name or description
-              // of an element that references the overlay using `aria-labelledby` or `aria-describedby`.
-              this.style.visibility = 'initial';
+              // of an element that references it using `aria-labelledby` or `aria-describedby`.
+              this.style.visibility = 'visible';
 
               // makes sure the focus is returned per accessibility recommendations
               this._handleReturnFocus();
@@ -1009,6 +1009,13 @@ const BaseOverlay = (superClass) => class extends superClass {
         // Show the backdrop again
         this._showBackdrop();
       }
+    }
+    else {
+      // If overlay is closed, make sure that it is hidden with `display: none`,
+      // but set `visibility: visible` to ensure that the overlay will be included in accessibility name or description
+      // of an element that references it using `aria-labelledby` or `aria-describedby`.
+      this.style.display = 'none';
+      this.style.visibility = 'visible';
     }
   }
 

--- a/coral-base-overlay/src/tests/test.BaseOverlay.js
+++ b/coral-base-overlay/src/tests/test.BaseOverlay.js
@@ -215,7 +215,7 @@ describe('BaseOverlay', function() {
           // we use transitionEnd instead of coral-overlay:close since the silent setter was used
           commons.transitionEnd(overlay, function() {
             expect(overlay.style.display).to.equal('none', 'overlay should be set to "display:none" now');
-            expect(overlay.style.visibility).to.equal('initial', 'overlay should be set to "visibility:initial" now');
+            expect(overlay.style.visibility).to.equal('visible', 'overlay should be set to "visibility:initial" now');
         
             done();
           });
@@ -733,33 +733,39 @@ describe('BaseOverlay', function() {
     });
     
     describe('tabcapture', function() {
-      it('should focus on the last focusable element when top tab capture focused', function() {
+      it('should focus on the last focusable element when top tab capture focused', function(done) {
         overlay.insertAdjacentHTML('afterbegin', window.__html__['BaseOverlay.someButtons.html']);
     
         var button2 = overlay.querySelector('#button2');
     
         overlay.open = true;
+
+        helpers.next(function() {
+          overlay.querySelector('[coral-tabcapture]').focus();
   
-        overlay.querySelector('[coral-tabcapture]').focus();
-  
-        helpers.event('focus', overlay.querySelector('[coral-tabcapture]'));
-        expect(document.activeElement).to.equal(button2);
+          helpers.event('focus', overlay.querySelector('[coral-tabcapture]'));
+          expect(document.activeElement).to.equal(button2);
+          done();
+        });
       });
   
-      it('should focus on the first focusable element when intermediate tab capture focused', function() {
+      it('should focus on the first focusable element when intermediate tab capture focused', function(done) {
         overlay.insertAdjacentHTML('afterbegin', window.__html__['BaseOverlay.someButtons.html']);
     
         var button1 = overlay.querySelector('#button1');
     
         overlay.open = true;
-    
-        overlay.querySelectorAll('[coral-tabcapture]')[1].focus();
-        // for FF
-        helpers.event('focus', overlay.querySelectorAll('[coral-tabcapture]')[1]);
-        expect(document.activeElement).to.equal(button1);
+
+        helpers.next(function() {
+          overlay.querySelectorAll('[coral-tabcapture]')[1].focus();
+          // for FF
+          helpers.event('focus', overlay.querySelectorAll('[coral-tabcapture]')[1]);
+          expect(document.activeElement).to.equal(button1);
+          done();
+        });
       });
   
-      it('should focus on the last focusable element when last tab capture focused', function() {
+      it('should focus on the last focusable element when last tab capture focused', function(done) {
         overlay = new OverlayDummy2();
         helpers.target.appendChild(overlay);
   
@@ -769,10 +775,13 @@ describe('BaseOverlay', function() {
     
         overlay.open = true;
     
-        overlay.querySelectorAll('[coral-tabcapture]')[2].focus();
-        // for FF
-        helpers.event('focus', overlay.querySelectorAll('[coral-tabcapture]')[2]);
-        expect(document.activeElement).to.equal(button2);
+        helpers.next(function() {
+          overlay.querySelectorAll('[coral-tabcapture]')[2].focus();
+          // for FF
+          helpers.event('focus', overlay.querySelectorAll('[coral-tabcapture]')[2]);
+          expect(document.activeElement).to.equal(button2);
+          done();
+        });
       });
   
       it('should position tabcapture elements correctly on show', function(done) {
@@ -1192,7 +1201,7 @@ describe('BaseOverlay', function() {
             setTimeout(function() {
               expect(overlay.open).to.be.false;
               expect(overlay.style.display).to.equal('none');
-              expect(overlay.style.visibility).to.equal('initial');
+              expect(overlay.style.visibility).to.equal('visible');
             
               // Restore fade time
               BaseOverlay.FADETIME = FADETIME;

--- a/coral-base-overlay/src/tests/test.BaseOverlay.js
+++ b/coral-base-overlay/src/tests/test.BaseOverlay.js
@@ -215,7 +215,7 @@ describe('BaseOverlay', function() {
           // we use transitionEnd instead of coral-overlay:close since the silent setter was used
           commons.transitionEnd(overlay, function() {
             expect(overlay.style.display).to.equal('none', 'overlay should be set to "display:none" now');
-            expect(overlay.style.visibility).to.equal('visible', 'overlay should be set to "visibility:initial" now');
+            expect(overlay.style.visibility).to.equal('visible', 'overlay should be set to "visibility:visible" now');
         
             done();
           });


### PR DESCRIPTION
## Description

In `connectedCallback`, if the overlay is closed, make sure that it is hidden with `display: none`, but set `visibility: visible` to ensure that the overlay will be included in accessibility name or description of an element that references it using `aria-labelledby` or `aria-describedby`.

## Related Issue
[CUI-7416](https://jira.corp.adobe.com/browse/CUI-7416)
[CQ-4293363](https://jira.corp.adobe.com/browse/CQ-4293363)

## Motivation and Context
Fix announcement of error instructions for invalid field when a closed tooltip is referenced with `aria-labelledby` or `aria-describedby`.

## How Has This Been Tested?
Tested with aria-describedby using Coral-Spectrun tooltip example.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
