### PR TITLE
CQ-4272964 ColumnView fix VoiceOver announcing elements as "row 1 expanded" on focus

### DIFF
--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -841,11 +841,11 @@ describe('ColumnView', function() {
         const activeItem = el.activeItem;
         activeItem.trigger('click');
         helpers.keypress('up', activeItem);
-        window.setTimeout(function() {
+        helpers.next(function() {
           expect(document.activeElement.id).to.equal(el.columns.getAll()[1].items.first().id);
           expect(document.activeElement.id).to.equal(el.activeItem.id);
           done();
-        }, 200);
+        });
       });
 
       it('ArrowDown should focus next item', function(done) {
@@ -853,11 +853,11 @@ describe('ColumnView', function() {
         const activeItem = el.activeItem;
         activeItem.trigger('click');
         helpers.keypress('down', activeItem);
-        window.setTimeout(function() {
+        helpers.next(function() {
           expect(document.activeElement.id).to.equal(el.columns.getAll()[1].items.getAll()[2].id);
           expect(document.activeElement.id).to.equal(el.activeItem.id);
           done();
-        }, 200);
+        });
       });
 
       it('ArrowRight on item with variant=drilldown should focus first item in next column', function(done) {
@@ -1301,10 +1301,10 @@ describe('ColumnView', function() {
     describe('when item is expanded', function() {
       it('should have aria-expanded equal to "true"', function(done) {
         const el = helpers.build(window.__html__['ColumnView.full.html']);
-        window.setTimeout(function() {
+        helpers.next(function() {
           expect(el.activeItem.getAttribute('aria-expanded')).to.equal('true');
           done();
-        }, 200);
+        });
       });
 
       it('should express ownership of expanded column using aria-owns', function(done) {


### PR DESCRIPTION
## Description
Since problem only seems to occur in first column of items within Chrome on MacOS, we omit aria-expanded on those items.

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4272964

Earlier attempts to correct the issue: 
https://github.com/adobe/coral-spectrum/pull/116
https://github.com/adobe/coral-spectrum/pull/91
https://github.com/adobe/coral-spectrum/pull/11

## Motivation and Context
Earlier attempts failed to address the issue.

## How Has This Been Tested?
Tested against coral-spectrum examples and in context against a local CloudReady AEM instance.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
