### PR TITLE
CQ-4295097 : Accessibility - Spectrum SelectList user is not able to …

### DIFF
--- a/coral-collection/src/scripts/SelectableCollection.js
+++ b/coral-collection/src/scripts/SelectableCollection.js
@@ -87,17 +87,14 @@ class SelectableCollection extends Collection {
    @protected
    */
   _getPreviousSelectable(item) {
-    let sibling = item.previousElementSibling;
-    while (sibling) {
-      if (sibling.matches(this._selectableItemSelector)) {
-        break;
-      }
-      else {
-        sibling = sibling.previousElementSibling;
-      }
+    var items = this._getSelectableItems();
+    var index = items.indexOf(item);
+  
+    // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
+    if (index === -1) {
+      return items[0] || null;
     }
-    
-    return sibling || item;
+    return index === 0 ? item : items[index - 1];
   }
   
   /**
@@ -112,17 +109,14 @@ class SelectableCollection extends Collection {
    @protected
    */
   _getNextSelectable(item) {
-    let sibling = item.nextElementSibling;
-    while (sibling) {
-      if (sibling.matches(this._selectableItemSelector)) {
-        break;
-      }
-      else {
-        sibling = sibling.nextElementSibling;
-      }
+    var items = this._getSelectableItems();
+    var index = items.indexOf(item);
+  
+    // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
+    if (index === -1) {
+      return items[0] || null;
     }
-    
-    return sibling || item;
+    return index === (items.length - 1) ? item : items[index + 1];
   }
   
   /**

--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -299,14 +299,14 @@ class SelectList extends BaseComponent(HTMLElement) {
   /** @private */
   _focusPreviousItem(event) {
     event.preventDefault();
-    
+    event.stopPropagation();
     this._focusItem(this.items._getPreviousSelectable(event.target));
   }
   
   /** @private */
   _focusNextItem(event) {
     event.preventDefault();
-    
+    event.stopPropagation();
     this._focusItem(this.items._getNextSelectable(event.target));
   }
   

--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -218,13 +218,35 @@ class SelectList extends BaseComponent(HTMLElement) {
   get _tabTarget() {
     return this.__tabTarget || null;
   }
+  
   set _tabTarget(value) {
     this.__tabTarget = value;
-  
-    // Set all but the current set _tabTarget to not be a tab target:
-    this.items.getAll().forEach((item) => {
-      item.setAttribute('tabindex', item === value ? 0 : -1);
-    });
+    if (this.groups && this._groups.getAll().length > 0) {
+      // set first item or selected item to be tab target in each group
+      var groups = this._groups;
+      groups.getAll().forEach((group) => {
+        if (group.items.getAll().length > 0) {
+          var firstChild = group.firstElementChild;
+          firstChild.setAttribute('tabindex', 0);
+          var items = group.items.getAll();
+          for (let i = 1; i < items.length; i++) {
+            if (items[i] === value) {
+              items[i].setAttribute('tabindex', 0);
+              firstChild.setAttribute('tabindex', -1);
+            }
+            else {
+              items[i].setAttribute('tabindex', -1); 
+            }
+          }
+        }
+      });
+    }
+    else {
+      // Set all but the current set _tabTarget to not be a tab target:
+      this.items.getAll().forEach((item) => {
+        item.setAttribute('tabindex', item === value ? 0 : -1);
+      });
+    }
   }
   
   /** @private */


### PR DESCRIPTION
…select next group with keyboard

<!--- Provide a general summary of your changes in the Title above -->

## Description
In SelectList Groups, set first item or selected item to be tab target in each group

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4295097

Earlier attempts to correct the issue:
#62 
## Motivation and Context
User is able to tab to every first item of group, then use the arrow down keys to navigate within a group.

## How Has This Been Tested?

Tested against coral-spectrum examples 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
