### PR TITLE
CUI-7420 ActionBar: closing submenu using Escape should restore focus to the More... button

### DIFF
--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -222,6 +222,15 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
     }
     
     const focusedItem = document.activeElement.parentNode;
+
+    // we need to check if item has 'hasAttribute' because it is not present on the document
+    const isFocusedItemInsideActionBar = this.parentNode.contains(focusedItem);
+    const isFocusedItemOffscreen = focusedItem.hasAttribute && focusedItem.hasAttribute('coral-actionbar-offscreen');
+    if (isFocusedItemInsideActionBar && isFocusedItemOffscreen) {
+      // if currently an element is focused, that should not be visible (or is no actionbar-item) => select 'more'
+      // button
+      this._elements.moreButton.focus();
+    }
     
     // hide the popover(needed to disable fade time of popover)
     this._elements.overlay.hidden = true;
@@ -241,15 +250,6 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
 
     // clear overlay
     this._elements.overlay.content.innerHTML = '';
-
-    // we need to check if item has 'hasAttribute' because it is not present on the document
-    const isFocusedItemInsideActionBar = this.parentNode.contains(focusedItem);
-    const isFocusedItemOffscreen = focusedItem.hasAttribute && focusedItem.hasAttribute('coral-actionbar-offscreen');
-    if (isFocusedItemInsideActionBar && isFocusedItemOffscreen) {
-      // if currently an element is focused, that should not be visible (or is no actionbar-item) => select 'more'
-      // button
-      this._elements.moreButton.focus();
-    }
   }
   
   _onOverlayKeyDown(event) {


### PR DESCRIPTION
## Description
Per https://jira.corp.adobe.com/browse/CQ-4293592, closing the ActionBar submenu, that displays items that don't fit within the ActionBar, using the Escape key should restore focus to the More... button, ideally the event should not bubble to be handled by AEM's foundation-command.

## Related Issue
[CUI-7420](https://jira.corp.adobe.com/browse/CUI-7420) and [CQ-4293592](https://jira.corp.adobe.com/browse/CQ-4293592)

## Motivation and Context
Fix keyboard focus management in ActionBar for Collection views in AEM.

## How Has This Been Tested?
Tested in Coral-Spectrum examples and within CloudReady AEM instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
