### PR TITLE
fix(CQ-4295097): Accessibility - Spectrum SelectList user is not able to select next group with keyboard

### DIFF
--- a/coral-base-list/src/scripts/BaseList.js
+++ b/coral-base-list/src/scripts/BaseList.js
@@ -196,9 +196,10 @@ const BaseList = (superClass) => class extends superClass {
   /** @ignore */
   focus() {
     if (!this.contains(document.activeElement)) {
-      const items = this._getSelectableItems();
+      const items = this._getSelectableItems().filter(item => !item.hasAttribute('hidden'));
       if (items.length > 0) {
-        items[0].focus();
+        const firstFocusable = items.find(item => item.tabIndex === 0);
+        (firstFocusable || items[0]).focus();
       }
     }
   }

--- a/coral-base-list/src/scripts/BaseList.js
+++ b/coral-base-list/src/scripts/BaseList.js
@@ -198,8 +198,7 @@ const BaseList = (superClass) => class extends superClass {
     if (!this.contains(document.activeElement)) {
       const items = this._getSelectableItems();
       if (items.length > 0) {
-        const firstFocusable = items.find(item => item.tabIndex === 0);
-        (firstFocusable || items[0]).focus();
+        items[0].focus();
       }
     }
   }

--- a/coral-base-list/src/scripts/BaseList.js
+++ b/coral-base-list/src/scripts/BaseList.js
@@ -196,7 +196,7 @@ const BaseList = (superClass) => class extends superClass {
   /** @ignore */
   focus() {
     if (!this.contains(document.activeElement)) {
-      const items = this._getSelectableItems().filter(item => !item.hasAttribute('hidden'));
+      const items = this._getSelectableItems();
       if (items.length > 0) {
         const firstFocusable = items.find(item => item.tabIndex === 0);
         (firstFocusable || items[0]).focus();

--- a/coral-collection/src/scripts/SelectableCollection.js
+++ b/coral-collection/src/scripts/SelectableCollection.js
@@ -131,7 +131,6 @@ class SelectableCollection extends Collection {
       }
     }
   
-    // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
     return sibling || item;
   }
   

--- a/coral-collection/src/scripts/SelectableCollection.js
+++ b/coral-collection/src/scripts/SelectableCollection.js
@@ -87,17 +87,14 @@ class SelectableCollection extends Collection {
    @protected
    */
   _getPreviousSelectable(item) {
-    let sibling = item.previousElementSibling;
-    while (sibling) {
-      if (sibling.matches(this._selectableItemSelector)) {
-        break;
-      }
-      else {
-        sibling = sibling.previousElementSibling;
-      }
+    var items = this._getSelectableItems();
+    var index = items.indexOf(item);
+  
+    // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
+    if (index === -1) {
+      return items[0] || null;
     }
-    
-    return sibling || item;
+    return index === 0 ? item : items[index - 1];
   }
   
   /**
@@ -112,17 +109,14 @@ class SelectableCollection extends Collection {
    @protected
    */
   _getNextSelectable(item) {
-    let sibling = item.nextElementSibling;
-    while (sibling) {
-      if (sibling.matches(this._selectableItemSelector)) {
-        break;
-      }
-      else {
-        sibling = sibling.nextElementSibling;
-      }
+    var items = this._getSelectableItems();
+    var index = items.indexOf(item);
+  
+    // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
+    if (index === -1) {
+      return items[0] || null;
     }
-    
-    return sibling || item;
+    return index === (items.length - 1) ? item : items[index + 1];
   }
   
   /**

--- a/coral-collection/src/scripts/SelectableCollection.js
+++ b/coral-collection/src/scripts/SelectableCollection.js
@@ -87,18 +87,26 @@ class SelectableCollection extends Collection {
    @protected
    */
   _getPreviousSelectable(item) {
-    var items = this._getSelectableItems();
-    var index = items.indexOf(item);
-  
-    // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
-    if (index === -1) {
-      return items[0] || null;
+    const items = this.getAll();
+    let index = items.indexOf(item);
+    let sibling = index > 0 ? items[index - 1] : null;
+
+    while (sibling) {
+      if (sibling.matches(this._selectableItemSelector)) {
+        break;
+      }
+      else {
+        index--;
+        sibling = index > 0 ? items[index - 1] : null;
+      }
     }
-    return index === 0 ? item : items[index - 1];
+
+    // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
+    return sibling || (item.matches(this._selectableItemSelector) ? item : this._getFirstSelectable());
   }
   
   /**
-   Returns the net selectable item.
+   Returns the next selectable item.
    
    @param {HTMLElement} item
    The reference item.
@@ -109,14 +117,22 @@ class SelectableCollection extends Collection {
    @protected
    */
   _getNextSelectable(item) {
-    var items = this._getSelectableItems();
-    var index = items.indexOf(item);
+    const items = this.getAll();
+    let index = items.indexOf(item);
+    let sibling = index < items.length - 1 ? items[index + 1] : null;
+
+    while (sibling) {
+      if (sibling.matches(this._selectableItemSelector)) {
+        break;
+      }
+      else {
+        index++;
+        sibling = index < items.length - 1 ? items[index + 1] : null;
+      }
+    }
   
     // in case the item is not specified, or it is not inside the collection, we need to return the first selectable
-    if (index === -1) {
-      return items[0] || null;
-    }
-    return index === (items.length - 1) ? item : items[index + 1];
+    return sibling || item;
   }
   
   /**

--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -411,32 +411,6 @@ class SelectList extends BaseComponent(HTMLElement) {
     }
     
     this._tabTarget = forceFirst ? items[0] : (items.find(item => item.tabIndex === 0) || items[0]);
-
-    if (this.groups && this._groups.getAll().length > 0) {
-      let firstFocusable;
-      this._groups.getAll().forEach((group) => {
-        const items = group.items._getSelectableItems().filter(item => !item.hasAttribute('hidden') && item.offsetParent);
-        if (items.length > 0) {
-          if (!firstFocusable) {
-            firstFocusable = items[0];
-            if (firstFocusable) {
-              firstFocusable.setAttribute('tabindex', 0);
-            }
-          }
-          items.forEach((item) => {
-            if (item === this._tabTarget) {
-              item.setAttribute('tabindex', 0);
-              if (firstFocusable && item !== firstFocusable) {
-                firstFocusable.setAttribute('tabindex', -1);
-              }
-            }
-            else if (item !== firstFocusable) {
-              item.setAttribute('tabindex', -1); 
-            }
-          });
-        }
-      });
-    }
   }
   
   /** @private */

--- a/coral-component-list/src/tests/test.SelectList.js
+++ b/coral-component-list/src/tests/test.SelectList.js
@@ -417,6 +417,71 @@ describe('SelectList', function() {
         done();
       });
     });
+
+    describe('groups', function() {
+      let el;
+      let groups;
+      let item1;
+      let item2;
+
+      beforeEach(function() {
+        el = helpers.build(window.__html__['SelectList.groups.html']);
+      });
+
+      afterEach(function() {
+        el.remove();
+        el = groups = item1 = item2 = null;
+      });
+
+      it('navigates between groups using ArrowUp/ArrowDown', function() {
+        groups = el.groups.getAll();
+
+        // last item in first group
+        item1 = groups[0].items.last();
+
+        // first item in last group
+        item2 = groups[1].items.first();
+
+        // focus last item in first group
+        item1.focus();
+
+        // ArrowDown focuses first item in next group
+        helpers.keypress('down', item1);
+
+        // verify focus on first item of second group
+        expect(item2).equals(document.activeElement);
+
+        // ArrowUp focuses last item in previous group
+        helpers.keypress('up', item2);
+
+        // verify focus on last item of first group
+        expect(item1).equals(document.activeElement);
+
+         // PageDown focuses first item in next group
+         helpers.keypress('pagedown', item1);
+
+         // verify focus on first item of second group
+         expect(item2).equals(document.activeElement);
+ 
+         // PageUp focuses last item in previous group
+         helpers.keypress('pageup', item2);
+ 
+         // verify focus on last item of first group
+         expect(item1).equals(document.activeElement);
+
+         // End focuses last item of last group
+         helpers.keypress('end', item1);
+ 
+         // verify focus on last item of last group
+         expect(groups[1].items.last()).equals(document.activeElement);
+
+         // Home focuses first item of first group
+         helpers.keypress('home', item1);
+ 
+         // verify focus on first item of first group
+         expect(groups[0].items.first()).equals(document.activeElement);
+      });
+    });
     // @todo: test focus of initial state
     // @todo: test focus of an empty list
     // @todo: test focus of a list with a selected item

--- a/coral-component-select/src/scripts/Select.js
+++ b/coral-component-select/src/scripts/Select.js
@@ -728,6 +728,9 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
     if (this.readOnly) {
       event.preventDefault();
     }
+
+    // focus first selected or tabbable item when the list expands
+    this._elements.list._resetTabTarget(true);
   }
 
   /** @private */


### PR DESCRIPTION
## Description

CQ-4295097 refactor _tabTarget setter and _resetTabTarget method

With SelectList groups only one item should receive focus at a time.

When resetting tabTarget, prioritized selected items over selectable items, but prioritize the last focused item over the first of the items in the array.

In Select component, we _resetTabTarget before the list opens, prioritizing the first selected item over the first selectable item.

## Related Issue
#124 and https://jira.corp.adobe.com/browse/CQ-4295097

## Motivation and Context
Correct behavior of a select list with option groups, by ensuring that only one item in the select list is tabbable at a time.

## How Has This Been Tested?
Behavior has been tested in example documents for SelectList and Select.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
