### PR TITLE
CUI-7422 ColumnView item should not be set active twice when using the mouse

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -88,6 +88,9 @@ class ColumnView extends BaseComponent(HTMLElement) {
       'key:esc': '_onKeyCtrlShiftA',
 
       'capture:focus coral-columnview-item': '_onItemFocus',
+
+      'mousedown coral-columnview-item': '_onItemMouseDown',
+      'mouseup coral-columnview-item': '_onItemMouseUp',
   
       // column events
       'coral-columnview-column:_loaditems': '_onColumnLoadItems',
@@ -576,7 +579,9 @@ class ColumnView extends BaseComponent(HTMLElement) {
     // we use click instead of selected to force the deselection of the other items
     if (item && item !== document.activeElement) {
       item.focus();
-      if (this.selectionMode === selectionMode.NONE || selectedItems.length === 0) {
+      if (this.selectionMode === selectionMode.NONE  ||
+        selectedItems.length === 0 ||
+        item.parentElement !== selectedItems[0].parentElement) {
         item.click();
       }
     }
@@ -620,7 +625,9 @@ class ColumnView extends BaseComponent(HTMLElement) {
     // we use click instead of selected to force the deselection of the other items
     if (item && item !== document.activeElement) {
       item.focus();
-      if (this.selectionMode === selectionMode.NONE || selectedItems.length === 0) {
+      if (this.selectionMode === selectionMode.NONE ||
+        selectedItems.length === 0 ||
+        item.parentElement !== selectedItems[0].parentElement) {
         item.click();
       }
     }
@@ -640,7 +647,19 @@ class ColumnView extends BaseComponent(HTMLElement) {
 
     event.preventDefault();
 
-    const nextColumn = (this.activeItem && this.activeItem.closest('coral-columnview-column').nextElementSibling);
+    // we can only navigate right when there is a column on the right side to navigate to
+    let nextColumn;
+    // using _oldSelection since it should be equivalent to this.items._getSelectedItems() but faster
+    let selectedItems = this._oldSelection;
+
+    // when there is an active item, we use the item containing the active item as reference
+    if (matchedTarget) {
+      nextColumn = matchedTarget.closest('coral-columnview-column').nextElementSibling;
+    }
+    // otherwise when there is selection, we use the item containing the selected items as reference
+    else if (selectedItems.length !== 0) {
+      nextColumn = selectedItems[0].closest('coral-columnview-column').nextElementSibling;
+    }
       
     if (nextColumn && nextColumn.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
       // we need to make sure the column is initialized
@@ -676,7 +695,10 @@ class ColumnView extends BaseComponent(HTMLElement) {
       const activeDescendant = previousColumn.activeItem || previousColumn.items._getFirstSelected() || previousColumn.items._getFirstSelectable();
       if (activeDescendant && activeDescendant !== document.activeElement) {
         activeDescendant.focus();
-        activeDescendant.click();
+        if (this.selectionMode === selectionMode.NONE ||
+          selectedItems.length === 0) {
+          activeDescendant.click();
+        }
       }
     }
   }
@@ -771,7 +793,7 @@ class ColumnView extends BaseComponent(HTMLElement) {
     }
 
     const matchedTarget = this._getRealMatchedTarget(event);
-    if (!matchedTarget.hasAttribute('active') && !this._oldSelection.length) {
+    if(!this.activeItem && !this._oldSelection.length && !matchedTarget._flagMouseDown) {
       matchedTarget.setAttribute('active', '');
     }
     this.items._getSelectableItems().forEach(item => {
@@ -781,6 +803,24 @@ class ColumnView extends BaseComponent(HTMLElement) {
     if (matchedTarget.contains(document.activeElement)) {
       matchedTarget.focus();
     }
+  }
+
+  /** @ignore */
+  _onItemMouseDown(event) {
+    if (isInteractiveTarget(event.target)) {
+      return;
+    }
+    var matchedTarget = this._getRealMatchedTarget(event);
+    matchedTarget._flagMouseDown = true;
+  }
+
+  /** @ignore */
+  _onItemMouseUp(event) {
+    if (isInteractiveTarget(event.target)) {
+      return;
+    }
+    var matchedTarget = this._getRealMatchedTarget(event);
+    delete matchedTarget._flagMouseDown;
   }
 
   /** @ignore */
@@ -1177,17 +1217,21 @@ class ColumnView extends BaseComponent(HTMLElement) {
 
   _focusAndActivateFirstSelectableItem(column) {
     let item;
+    let selectedItems = this.selectedItems;
 
     if (column.items) {
       item = column.items._getFirstSelectable();
     }
     else if (column.tagName === 'CORAL-COLUMNVIEW-PREVIEW') {
-      item = this.selectedItems[0] || this.activeItem;
+      item = selectedItems[0] || this.activeItem;
     }
 
     if (item && item !== document.activeElement) {
       item.focus();
-      if (this.selectionMode === selectionMode.NONE || this._oldSelection.length === 0) {
+      if (this.selectionMode === selectionMode.NONE ||
+        this._oldSelection.length === 0 || 
+        selectedItems.length === 0 ||
+        item.parentElement !== selectedItems[0].parentElement) {
         item.click();
       }
     }

--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -581,6 +581,9 @@ class ColumnView extends BaseComponent(HTMLElement) {
       item.focus();
       if (this.selectionMode === selectionMode.NONE  ||
         selectedItems.length === 0 ||
+        // For use case in cascading schema editor,
+        // where the focused item is not in the same column as the selected items,
+        // we should activate the item so that coral-columnview:activeitemchange gets called.
         item.parentElement !== selectedItems[0].parentElement) {
         item.click();
       }
@@ -627,6 +630,9 @@ class ColumnView extends BaseComponent(HTMLElement) {
       item.focus();
       if (this.selectionMode === selectionMode.NONE ||
         selectedItems.length === 0 ||
+        // For use case in cascading schema editor,
+        // where the focused item is not in the same column as the selected items,
+        // we should activate the item so that coral-columnview:activeitemchange gets called.
         item.parentElement !== selectedItems[0].parentElement) {
         item.click();
       }
@@ -1231,6 +1237,9 @@ class ColumnView extends BaseComponent(HTMLElement) {
       if (this.selectionMode === selectionMode.NONE ||
         this._oldSelection.length === 0 || 
         selectedItems.length === 0 ||
+        // For use case in cascading schema editor,
+        // where the focused item is not in the same column as the selected items,
+        // we should activate the item so that coral-columnview:activeitemchange gets called.
         item.parentElement !== selectedItems[0].parentElement) {
         item.click();
       }

--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -200,60 +200,64 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
   set selected(value) {
     this._selected = transform.booleanAttr(value);
     this._reflectAttribute('selected', this._selected);
-  
-    this.classList.toggle('is-selected', this._selected);
-    this.setAttribute('aria-selected', this._selected);
-
-    // @a11y Update aria-expanded. Active drilldowns should be expanded.
-    // Note: Omit aria-expanded on Chrome for macOS, because with VoiceOver tends 
-    // to announce drilldown items as "row 1 expanded" or "row 1 collapsed" when 
-    // navigating between items. 
-    if (this.variant === variant.DRILLDOWN) {
-      if (this._selected || (isChromeMacOS && this.getAttribute('aria-level') === '1')) {
-        this.removeAttribute('aria-expanded');
-      }
-      else {
-        this.setAttribute('aria-expanded', this.active);
-      }
-    }
-
-    let accessibilityState = this._elements.accessibilityState;
-    
-    if (this.selected) {
-
-      // @a11y Panels to right of selected item are removed, so remove aria-owns and aria-describedby attributes.
-      this.removeAttribute('aria-owns');
-      this.removeAttribute('aria-describedby');
-
-      // @a11y Update content to ensure that checked state is announced by assistive technology when the item receives focus
-      accessibilityState.innerHTML = i18n.get(', checked');
-
-      // @a11y append live region content element
-      if (!this.contains(accessibilityState)) {
-        this.appendChild(accessibilityState);
-      }
-    }
-    // @a11y If deselecting from checked state,
-    else {
-
-      // @a11y remove, but retain reference to accessibilityState state
-      this._elements.accessibilityState = accessibilityState.parentNode.removeChild(accessibilityState);
-
-      // @a11y Update content to remove checked state
-      this._elements.accessibilityState.innerHTML = '';
-    }
-
-    // @a11y Item should be labelled by thumbnail, content, and if appropriate accessibility state.
-    let ariaLabelledby = this._elements.thumbnail.id + ' ' + this._elements.content.id;
-    this.setAttribute('aria-labelledby', this.selected ? `${ariaLabelledby} ${accessibilityState.id}` : ariaLabelledby);
-
-    // Sync checkbox item selector
-    const itemSelector = this.querySelector('coral-checkbox[coral-columnview-itemselect]');
-    if (itemSelector) {
-      itemSelector[this._selected ? 'setAttribute' : 'removeAttribute']('checked', '');
-    }
-    
     this.trigger('coral-columnview-item:_selectedchanged');
+  
+    // wait a frame before updating attributes
+    commons.nextFrame(() => {
+      this.classList.toggle('is-selected', this._selected);
+      this.setAttribute('aria-selected', this._selected);
+
+      // @a11y Update aria-expanded. Active drilldowns should be expanded.
+      // Note: Omit aria-expanded on Chrome for macOS, because with VoiceOver tends 
+      // to announce drilldown items as "row 1 expanded" or "row 1 collapsed" when 
+      // navigating between items. 
+      if (this.variant === variant.DRILLDOWN) {
+        if (this._selected || (isChromeMacOS && this.getAttribute('aria-level') === '1')) {
+          this.removeAttribute('aria-expanded');
+        }
+        else {
+          this.setAttribute('aria-expanded', this.active);
+        }
+      }
+
+      let accessibilityState = this._elements.accessibilityState;
+      
+      if (this._selected) {
+
+        // @a11y Panels to right of selected item are removed, so remove aria-owns and aria-describedby attributes.
+        this.removeAttribute('aria-owns');
+        this.removeAttribute('aria-describedby');
+
+        // @a11y Update content to ensure that checked state is announced by assistive technology when the item receives focus
+        accessibilityState.innerHTML = i18n.get(', checked');
+
+        // @a11y append live region content element
+        if (!this.contains(accessibilityState)) {
+          this.appendChild(accessibilityState);
+        }
+      }
+      // @a11y If deselecting from checked state,
+      else {
+
+        // @a11y remove, but retain reference to accessibilityState state
+        if (accessibilityState.parentNode) {
+          this._elements.accessibilityState = accessibilityState.parentNode.removeChild(accessibilityState);
+        }
+
+        // @a11y Update content to remove checked state
+        this._elements.accessibilityState.innerHTML = '';
+      }
+
+      // @a11y Item should be labelled by thumbnail, content, and if appropriate accessibility state.
+      let ariaLabelledby = this._elements.thumbnail.id + ' ' + this._elements.content.id;
+      this.setAttribute('aria-labelledby', this.selected ? `${ariaLabelledby} ${accessibilityState.id}` : ariaLabelledby);
+
+      // Sync checkbox item selector
+      const itemSelector = this.querySelector('coral-checkbox[coral-columnview-itemselect]');
+      if (itemSelector) {
+        itemSelector[this._selected ? 'setAttribute' : 'removeAttribute']('checked', '');
+      }
+    });
   }
   
   /**

--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -319,6 +319,9 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
         if (!itemSelector) {
           itemSelector = new Checkbox();
           itemSelector.setAttribute('coral-columnview-itemselect', '');
+          if (this.classList.contains('is-selected')){
+            itemSelector.setAttribute('checked', '');
+          }
           itemSelector._elements.input.tabIndex = -1;
           itemSelector.setAttribute('labelledby', this._elements.content.id);
       

--- a/coral-component-columnview/src/tests/test.ColumnView.Item.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.Item.js
@@ -80,14 +80,19 @@ describe('ColumnView.Item', function() {
         expect(el.selected).to.be.false;
       });
 
-      it('should be settable', function() {
+      it('should be settable', function(done) {
         el.selected = true;
-        expect(el.selected).to.be.true;
-        expect(el.classList.contains('is-selected')).to.be.true;
+        helpers.next(() => {
+          expect(el.selected).to.be.true;
+          expect(el.classList.contains('is-selected')).to.be.true;
 
-        el.selected = false;
-        expect(el.selected).to.be.false;
-        expect(el.classList.contains('is-selected')).to.be.false;
+          el.selected = false;
+          helpers.next(() => {
+            expect(el.selected).to.be.false;
+            expect(el.classList.contains('is-selected')).to.be.false;
+            done();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## Description
Relating to https://jira.corp.adobe.com/browse/CQ-4301452, ColumnView items are being set to active twice. First with the focus event that comes on mouse down, and then again with the item click event on mouse up. This is causing choices to not be preserved in Granite's metadata schema editor, because when the item is already active, the item click event that follows does not trigger a `coral-columnview:activeitemchanged` event, which the schema editor uses to load the appropriate items and selection into the adjacent column: https://git.corp.adobe.com/Granite/com.adobe.granite.clientlibs.compiler/blob/master/src/test/resources/apps_libs5/libs/dam/gui/coral/components/admin/schemaforms/formbuilder/v2/clientlibs/js/cascadingschema/cascade.js#L176

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7422
and https://jira.corp.adobe.com/browse/CQ-4301452

## Motivation and Context
This PR corrects regressions in Granite's metadata schema editor cause by keyboard accessibility changes in the ColumnView.

## How Has This Been Tested?
Unit tests have been added and the fixes have been tested against ColumnView examples.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
