### PR TITLE
actions in more popover are not opening popover

### DIFF
--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -37,9 +37,6 @@ const copyAttributes = (from, to) => {
       }
     }
   }
-
-  // ensure that click event on menu item gets triggered on actionbar item
-  to.addEventListener('click', () => from.click());
 };
 
 /**

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -670,7 +670,6 @@ describe('ActionBar', function() {
       // Wait for resize listener
       window.setTimeout(() => {
         // items of bar1 should be moved offscreen
-        expect(bar.primary.items._getAllOffScreen().length).to.equal(6, 'all items of bar should be offscreen');
         expect(bar.primary._elements.moreButton.style.visibility).to.equal('', 'More button should be visible.');
         bar.primary._elements.moreButton.click();
         expect(bar.primary._elements.overlay.open).to.equal(true, 'more popover should be opened');        

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -670,6 +670,7 @@ describe('ActionBar', function() {
       // Wait for resize listener
       window.setTimeout(() => {
         // items of bar1 should be moved offscreen
+        expect(bar.primary.items._getAllOffScreen().length).to.equal(6, 'all items of bar should be offscreen');
         expect(bar.primary._elements.moreButton.style.visibility).to.equal('', 'More button should be visible.');
         bar.primary._elements.moreButton.click();
         expect(bar.primary._elements.overlay.open).to.equal(true, 'more popover should be opened');        


### PR DESCRIPTION
on clicking on action item inside a popover, another popover is displayed. "to.addEventListener('click', () => from.click());" hinders the click inside the popover to display another popover. 
@indra2gurjar Please review

@majornista  I am reverting the change in this file at line https://github.com/adobe/coral-spectrum/pull/132/files#diff-f6889f41ee5b8bc9ad89668528a7bc2aL42 made in this commit https://github.com/adobe/coral-spectrum/commit/be3d943b3c019e9709353acf588a98c710401574#diff-f6889f41ee5b8bc9ad89668528a7bc2a . as this is causing a regression that on clicking the relate button (when its inside the ... more popover), doesn't open the relation popover.

Also i have checked that after my change the https://jira.corp.adobe.com/browse/CQ-4293594 is working.  (arrow navigation to Add rendition behaviour is same with or without my changes). 



## Description
Whenever there is button inside a popover. clicking on that button opens another popover. Hence before this change nothing happens when the button is clicked and the outer popover is closed. 

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4301695

## Motivation and Context
This will allow proper functionality of nested popovers. 

## How Has This Been Tested?
Verified on cloud ready QS. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
