### PR TITLE
fix(CUI-7426): ColumnView fails to call _ensureTabbableItem with _setStateFromDOM

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -993,16 +993,15 @@ class ColumnView extends BaseComponent(HTMLElement) {
     // initial state of the columnview
     this._oldActiveItem = this.activeItem;
     this._oldSelection = this.selectedItems;
+      
+    this._ensureTabbableItem();
 
-    if (!this._oldActiveItem && !this._oldSelection.length) {
-      const selectableItems = this.items._getSelectableItems();
-      if (selectableItems.length) {
-        selectableItems[0].tabIndex = 0;
-      }
-    }
-
-    if (this.columns && this.columns.first()) {
-      this._updateAriaLevel(this.columns.first());
+    if (this.columns) {
+      var columns = this.columns.getAll();
+      var self = this;
+      columns.forEach(function(column) {
+        self._updateAriaLevel(column);
+      });
     }
   }
   

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -1358,5 +1358,14 @@ describe('ColumnView', function() {
       expect(activeItemSpy.callCount).to.equal(1, 'Deselecting the item causes the active item to change');
       expect(removeItemSpy.callCount).to.equal(1);
     });
+
+    it('should ensure tabbable item when ColumnView intializes', function() {
+      const el = helpers.build(window.__html__['Coral.ColumnView.base.html']);
+      const items = el.items.getAll();
+      
+      items.forEach(function(item, i) {
+	expect(item.getAttribute('tabindex')).to.equal(i === 0 ? '0' : '-1');
+      });
+    });
   });
 });

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -1364,7 +1364,7 @@ describe('ColumnView', function() {
       const items = el.items.getAll();
       
       items.forEach(function(item, i) {
-	expect(item.getAttribute('tabindex')).to.equal(i === 0 ? '0' : '-1');
+        expect(item.getAttribute('tabindex')).to.equal(i === 0 ? '0' : '-1');
       });
     });
   });

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -1360,7 +1360,7 @@ describe('ColumnView', function() {
     });
 
     it('should ensure tabbable item when ColumnView intializes', function() {
-      const el = helpers.build(window.__html__['Coral.ColumnView.base.html']);
+      const el = helpers.build(window.__html__['ColumnView.base.html']);
       const items = el.items.getAll();
       
       items.forEach(function(item, i) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/coral-spectrum",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/coral-spectrum",
   "description": "Coral Spectrum is a JavaScript library of Web Components following Spectrum design patterns.",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "homepage": "https://github.com/adobe/coral-spectrum#readme",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION



## Description
ColumnView sometimes fails to set a tabIndex="0" on first item when setting state from DOM. Fixes a race condition where ColumnView._ensureTabbableItem sets tabIndex before the ColumnViewItem renders, in which case, the first selectable item should already have a tabIndex attribute that should not be overwritten with -1 if the item is neither active nor selected.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7426
https://jira.corp.adobe.com/browse/CQ-4293579

## Motivation and Context
This PR ensures that the tabindex="0" is correctly set on first element while setting state from DOM. 

## How Has This Been Tested?
Unit tests have been added and the fixes have been tested against ColumnView examples.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
