### PR TITLE
fix(Masonry): Changing Masonry parent leads to removal of its items

### DIFF
--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -816,7 +816,7 @@ class Masonry extends BaseComponent(HTMLElement) {
     if (!item.hasAttribute('_removing')) {
       // Attach again for remove transition
       item.setAttribute('_removing', '');
-      /* Avoid calling of connected and disconnected callbacks */
+      // Avoid calling of connected and disconnected callbacks.
       item._ignoreConnectedCallback = true;
       this.appendChild(item);
       item._ignoreConnectedCallback = false;
@@ -824,7 +824,7 @@ class Masonry extends BaseComponent(HTMLElement) {
         var parent = item.parentElement;
         var connected = !item._disconnected || false;
         item.remove();
-        /* If items gets reattached either by user or reattaching, again append the items */
+        // If items gets reattached either by user or reattaching, again append the items.
         connected && parent.appendChild(item);
       });
     }

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -816,16 +816,9 @@ class Masonry extends BaseComponent(HTMLElement) {
     if (!item.hasAttribute('_removing')) {
       // Attach again for remove transition
       item.setAttribute('_removing', '');
-      // Avoid calling of connected and disconnected callbacks.
-      item._ignoreConnectedCallback = true;
       this.appendChild(item);
-      item._ignoreConnectedCallback = false;
       commons.transitionEnd(item, () => {
-        var parent = item.parentElement;
-        var connected = !item._disconnected || false;
         item.remove();
-        // If items gets reattached either by user or reattaching, again append the items.
-        connected && parent.appendChild(item);
       });
     }
     // remove transition completed

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -816,9 +816,16 @@ class Masonry extends BaseComponent(HTMLElement) {
     if (!item.hasAttribute('_removing')) {
       // Attach again for remove transition
       item.setAttribute('_removing', '');
+      /* Avoid calling of connected and disconnected callbacks */
+      item._ignoreConnectedCallback = true;
       this.appendChild(item);
+      item._ignoreConnectedCallback = false;
       commons.transitionEnd(item, () => {
+        var parent = item.parentElement;
+        var connected = !item._disconnected || false;
         item.remove();
+        /* If items gets reattached either by user or reattaching, again append the items */
+        connected && parent.appendChild(item);
       });
     }
     // remove transition completed

--- a/coral-component-masonry/src/scripts/MasonryItem.js
+++ b/coral-component-masonry/src/scripts/MasonryItem.js
@@ -150,8 +150,11 @@ class MasonryItem extends BaseComponent(HTMLElement) {
   
   /** @ignore */
   connectedCallback() {
+    if (this._ignoreConnectedCallback) {
+      return;
+    }
+
     super.connectedCallback();
-    
     // Inform masonry immediately
     this.trigger('coral-masonry-item:_connected');
   }
@@ -177,8 +180,11 @@ class MasonryItem extends BaseComponent(HTMLElement) {
   
   /** @ignore */
   disconnectedCallback() {
+    if (this._ignoreConnectedCallback) {
+      return;
+    }
     super.disconnectedCallback();
-  
+
     // Handle it in masonry immediately
     const masonry = this._masonry;
     if (masonry) {

--- a/coral-component-masonry/src/scripts/MasonryItem.js
+++ b/coral-component-masonry/src/scripts/MasonryItem.js
@@ -150,7 +150,7 @@ class MasonryItem extends BaseComponent(HTMLElement) {
   
   /** @ignore */
   connectedCallback() {
-    if (this._ignoreConnectedCallback) {
+    if (!this.isConnected) {
       return;
     }
 
@@ -180,9 +180,10 @@ class MasonryItem extends BaseComponent(HTMLElement) {
   
   /** @ignore */
   disconnectedCallback() {
-    if (this._ignoreConnectedCallback) {
+    if (this.isConnected) {
       return;
     }
+
     super.disconnectedCallback();
 
     // Handle it in masonry immediately

--- a/coral-component-masonry/src/tests/snippets/Masonry.with.div.wrapper.html
+++ b/coral-component-masonry/src/tests/snippets/Masonry.with.div.wrapper.html
@@ -1,0 +1,6 @@
+<div>
+  <coral-masonry layout="fixed-centered" columnwidth="250">
+    <coral-masonry-item>item1</coral-masonry-item>
+    <coral-masonry-item>item2</coral-masonry-item>
+  </coral-masonry>
+</div>

--- a/coral-component-masonry/src/tests/test.Masonry.Item.js
+++ b/coral-component-masonry/src/tests/test.Masonry.Item.js
@@ -12,6 +12,7 @@
 
 import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {Masonry} from '../../../coral-component-masonry';
+import {commons} from '../../../coral-utils';
 
 describe('Masonry.Item', function() {
   describe('Namespace', function() {
@@ -186,7 +187,75 @@ describe('Masonry.Item', function() {
       });
     });
   });
-  
+
+  describe('Attach/Detach', function() {
+    describe('replacing masonry item', function() {
+      it('with another masonry item using replaceChild', function(done) {
+        const el = helpers.build(window.__html__['Masonry.with.div.wrapper.html']);
+        const masonry = el.querySelector("coral-masonry");
+        const oldItem = masonry.querySelector("coral-masonry-item");
+
+        const newItem = new Masonry.Item();
+        newItem.content.innerHTML = "Hi";
+
+        masonry.replaceChild(newItem, oldItem);
+
+        // Here we cannot test oldItem _disconnected and isConnected
+        // because we again attach item with removing attribute to show transition.
+        expect(oldItem.hasAttribute("_removing")).to.be.true;
+
+        expect(newItem.isConnected).to.be.true;
+        expect(newItem.parentElement).to.equal(masonry);
+        expect(masonry.items.getAll().length).to.equal(2);
+
+        const item = masonry.querySelector("coral-masonry-item");
+        //wait for transition to end
+        commons.transitionEnd(oldItem, () => {
+          helpers.next(function() {
+            expect(masonry.items.getAll().length).to.equal(2);
+            // After transition, we test for oldItem _disconnected and isConnected
+            expect(oldItem._disconnected).to.be.true;
+            expect(oldItem.isConnected).to.be.false;
+            expect(oldItem.parentElement).to.equal(null);
+            done();
+          });
+        });
+      });
+
+      it('with another masonry item using replaceWith', function(done) {
+        const el = helpers.build(window.__html__['Masonry.with.div.wrapper.html']);
+        const masonry = el.querySelector("coral-masonry");
+        const oldItem = masonry.querySelector("coral-masonry-item");
+
+        const newItem = new Masonry.Item();
+        newItem.content.innerHTML = "Hi";
+
+        oldItem.replaceWith(newItem);
+
+        // Here we cannot test oldItem _disconnected and isConnected
+        // because we again attach item with removing attribute to show transition.
+        expect(oldItem.hasAttribute("_removing")).to.be.true;
+
+        expect(newItem.isConnected).to.be.true;
+        expect(newItem.parentElement).to.equal(masonry);
+        expect(masonry.items.getAll().length).to.equal(2);
+
+        const item = masonry.querySelector("coral-masonry-item");
+        //wait for transition to end
+        commons.transitionEnd(oldItem, () => {
+          helpers.next(function() {
+            expect(masonry.items.getAll().length).to.equal(2);
+            // after actual removal _disconnected is false and isConnected is true
+            expect(oldItem._disconnected).to.be.true;
+            expect(oldItem.isConnected).to.be.false;
+            expect(oldItem.parentElement).to.equal(null);
+            done();
+          });
+        });
+      });
+    });
+  });
+
   describe('Accessibility', function() {
     it('should have an aria attribute for selection', function() {
       const el = new Masonry.Item();

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -580,7 +580,7 @@ describe('Masonry', function() {
 
       expect(masonry.items.getAll().length).to.equal(2);
 
-      masonry.replaceChild(item);
+      masonry.removeChild(item);
       // Here we cannot test item _disconnected and isConnected
       // because we again attach item with removing attribute to show transition.
       expect(item.hasAttribute("_removing")).to.be.true;

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -12,6 +12,7 @@
 
 import {helpers} from '../../../coral-utils/src/tests/helpers';
 import {Masonry} from '../../../coral-component-masonry';
+import {commons} from '../../../coral-utils';
 
 describe('Masonry.Layout', function() {
   
@@ -532,6 +533,70 @@ describe('Masonry.Layout', function() {
       expect(el.parentElement.getAttribute('aria-label')).to.equal('Masonry Label', 'Masonry parent element should receive same aria-label as Masonry');
       expect(el.parentElement.getAttribute('aria-labelledby')).to.equal('Masonry Labelledby', 'Masonry parent element should receive same aria-labelledby as Masonry');
     });
+  });
 
+  describe('#attaching/detching', function() {
+    it('reattaching changing masonry should keep child intact', function(done) {
+      const el = helpers.build(window.__html__['Masonry.with.div.wrapper.html']);
+      const masonry = el.querySelector("coral-masonry");
+
+      expect(masonry.items.getAll().length).to.equal(2);
+
+      el.appendChild(masonry);
+      //wait for transition to end
+      commons.transitionEnd(masonry, () => {
+        helpers.next(function() {
+          expect(masonry.items.getAll().length).to.equal(2);
+          done();
+        });
+      });
+    });
+
+    it('removing item and then attaching should keep the item', function(done) {
+      const el = helpers.build(window.__html__['Masonry.with.div.wrapper.html']);
+      const masonry = el.querySelector("coral-masonry");
+      const item =  masonry.querySelector("coral-masonry-item");
+
+      expect(masonry.items.getAll().length).to.equal(2);
+
+      item.remove();
+      expect(item._disconnected).to.be.true;
+      expect(item.hasAttribute("_removing")).to.be.true;
+
+      masonry.appendChild(item);
+      expect(item._disconnected).to.be.false;
+
+      //wait for transition to end
+      commons.transitionEnd(masonry, () => {
+        helpers.next(function() {
+          expect(masonry.items.getAll().length).to.equal(2);
+          done();
+        });
+      });
+    });
+
+    it('removing item should not again attach the item', function(done) {
+      const el = helpers.build(window.__html__['Masonry.with.div.wrapper.html']);
+      const masonry = el.querySelector("coral-masonry");
+      const item =  masonry.querySelector("coral-masonry-item");
+
+      expect(masonry.items.getAll().length).to.equal(2);
+
+      item.remove();
+      expect(item._disconnected).to.be.true;
+      expect(item.hasAttribute("_removing")).to.be.true;
+
+      //wait for transition to end
+      commons.transitionEnd(masonry, () => {
+        helpers.next(function() {
+          expect(masonry.items.getAll().length).to.equal(1);
+          // even after some time it should not gets reattach
+          setTimeout(function() {
+            expect(masonry.items.getAll().length).to.equal(1);
+            done();
+          }, 200);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
**Experienced Behaviour:** Whenever we tries to change the masonry parent element or reattach to same parent leads to the removal of its child items. 
**Expected Behaviour:** Changing the masonry parent should keep its child items intact.
**Changes:** If the item is connected to the DOM, don't run the disconnected callbacks. Test cases included.

## Related Issue
Issue:  https://jira.corp.adobe.com/browse/CUI-7424
Steps to reproduce: Check [here](https://opensource.adobe.com/coral-spectrum/playground/#?livereload=true&screen=vertical&code=MTY1LDE0Niw0OSw3OSwxOTUsNDgsMTYsMTMzLDIzMSwyNDQsODcsMjQsNzksMjM3LDIwOCwxMjAsNywzOSwxOCw0Miw3Miw0OCwzMiwxNDQsOTYsOTcsMTE2LDIzNywxMDcsMjI3LDIxNCwxNzcsMTMxLDIzOSw4Miw0MSw2NiwyNTIsMTE5LDE0NiwxODQsMSwxODEsNjYsOTMsMTUyLDE4LDYxLDE5MSwyNTEsMjUyLDk0LDQ2LDI0MiwyMzQsMjM4LDEyMSwyNDUsMjQ2LDI1NCwxMTQsMjA3LDQyLDE3MCw5Myw1NywxNDcsMjExLDMsMTQ4LDQxLDEwMywxNDAsNzMsMTAzLDI1MywxNTgsNjksMTEyLDUsNzEsMjM0LDI4LDk2LDUsNjQsMTU2LDg1LDE3LDU0LDUsMTc1LDEzNiwyNiwxODgsMjIsMzQsNTIsMjI0LDQ5LDE4MCw4MSw2NywxNzQsNzYsODgsNjcsMTc0LDY3LDQ1LDExNiwxMzYsMjAyLDQ1LDE3NywxLDc3LDE3NywxNzMsNjksMjI3LDg0LDE4MywxNDEsMTYxLDI0NSw3MCwyNCwxMzksMzYsNTIsOTgsMTc4LDIyOCwyNTMsMjcsMjMsMjI3LDkzLDE2OCwxNjMsMTA5LDEzNiw5NywyMTIsMjU1LDk5LDIzOSwzOCwyNDQsMTQsMTIxLDQxLDY5LDE5NCwyNDYsMTY1LDY4LDEwNiwzNywyMTUsMTkzLDExNiw3Niw1OSwxMzMsODgsMjQwLDEzMiw5MCw1OCwxODcsMTczLDgsMTQ0LDI0OCwyNCwxOTYsMjE2LDY3LDU3LDIwMyw1MCwxNTMsMTQsMTA3LDEzMywxOTMsMTk5LDExMCw4MCwyMDYsMTY0LDE2NSwzNywxNjgsMjAzLDEzNSw3MSw0MSwyNTQsMTQ0LDE3OSwxMjksMzIsMjA2LDE3LDgyLDM2LDE4NCw5MiwxODMsNjgsMTkzLDUxLDI1MSwxNDcsMzMsOSwxNTYsNSwxOTEsMTE0LDg2LDIzOSwxMSwyMTMsMjQ0LDIxMywyMDUsMjM3LDg2LDg5LDYzLDk1LDE0OCwxNjMsMTk4LDE1OCw2NCwxMzgsMjI4LDI3LDE2LDgzLDE3Nyw0NCwyMTksMTgwLDk0LDE0NywyMzcsMTEzLDM5LDY3LDIzNiwxMTUsMTM2LDEyNCw4MCwxNDUsMjksMjM5LDEwMyw1LDUxLDY1LDE4Myw1MywxMjAsMjAyLDYzLDkwLDEzNiwyMjEsNDMsMTg0LDI1NCwyNywxMzQsNTYsMjMxLDM5LDU3LDI0OSwyMjYsMTAyLDE1NCwxMDgsODQsMjM2LDIyMSwyMyw2LDI1MSw1OCw3MSwxMjMsMTc4LDIzMCw0MSwxOTQsMTcwLDE3OCwyMDYsMjA0LDE0MywxODgsMjQxLDI1MiwxMDcsNDAsMjU1LDE4NywxMzksOTcsOSwyMjcsNzgsMTk4LDMxLDIzOCwyNw==&)

## Motivation and Context
**Experienced Behaviour:** Whenever we tries to change the masonry parent element or reattach to same parent leads to the removal of its child items. 
**Expected Behaviour:** Changing the masonry parent should keep its child items intact.

## How Has This Been Tested?
Test Cases has been included in the changes

## Review
please review @icaraps @indra2gurjar @CezCz 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
