### PR TITLE
fix(CUI-7430): Coral.mixin.overlay should not hide overlay before calling _handleReturnFocus

### DIFF
--- a/coral-base-overlay/src/scripts/BaseOverlay.js
+++ b/coral-base-overlay/src/scripts/BaseOverlay.js
@@ -633,8 +633,6 @@ const BaseOverlay = (superClass) => class extends superClass {
 
           const closeComplete = () => {
             if (!this.open) {
-              // Hide self
-              this.style.display = 'none';
 
               // When the CSS transition has finished, set visibility to browser default, `visibility: visible`,
               // to ensure that the overlay will be included in accessibility name or description
@@ -643,6 +641,9 @@ const BaseOverlay = (superClass) => class extends superClass {
 
               // makes sure the focus is returned per accessibility recommendations
               this._handleReturnFocus();
+
+              // Hide self
+              this.style.display = 'none';
 
               this._debounce(() => {
                 // Inform child overlays that we're closing

--- a/coral-base-overlay/src/tests/test.BaseOverlay.js
+++ b/coral-base-overlay/src/tests/test.BaseOverlay.js
@@ -408,9 +408,14 @@ describe('BaseOverlay', function() {
           overlay.hide();
         });
 
+        overlay.on('coral-overlay:beforeclose', function() {
+          expect(overlay).to.equal(document.activeElement, 'Overlay should be in focus');
+        });
+
         overlay.on('coral-overlay:close', function() {
           // See if our spy was called
           expect(focusSpy.callCount).to.equal(1, 'Focus should have been called once');
+          expect(button).to.equal(document.activeElement, 'Focus should be restored to the button');
 
           done();
         });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Focus should be returned to right element before adding `display = none` otherwise focus will be lost to the `document.body`

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7430
https://jira.corp.adobe.com/browse/CQ-4293600

## Motivation and Context
The PR ensures that focus should be returned to right element before adding `display = none` otherwise focus will be lost to the `document.body`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
