### PR TITLE
fix(CUI-7432) Calendar: is-focused style for today's date is insufficient to communicate the focused state

### DIFF
--- a/coral-component-calendar/src/styles/index.styl
+++ b/coral-component-calendar/src/styles/index.styl
@@ -57,3 +57,20 @@
 .coral--large ._coral-Calendar {
   max-height: 377px;
 }
+
+.coral--light ._coral-Calendar-body:focus ._coral-Calendar-date.is-today.is-focused:before {
+  border-color: var(--spectrum-light-calendar-day-border-color-key-focus);
+}
+
+.coral--lightest ._coral-Calendar-body:focus ._coral-Calendar-date.is-today.is-focused:before {
+  border-color: var(--spectrum-lightest-calendar-day-border-color-key-focus);
+}
+
+.coral--dark ._coral-Calendar-body:focus ._coral-Calendar-date.is-today.is-focused:before {
+  border-color: var(--spectrum-dark-calendar-day-border-color-key-focus);
+}
+
+.coral--darkest ._coral-Calendar-body:focus ._coral-Calendar-date.is-today.is-focused:before {
+  border-color: var(--spectrum-darkest-calendar-day-border-color-key-focus);
+}
+


### PR DESCRIPTION
## Description

See https://opensource.adobe.com/spectrum-css/calendar.html#focused

The grey background color for the .is-focused style on today's date is insufficient to communicate that the date has focus. We should use either the blue focus ring as we do for other focused styles, or to continue communicating that the date is today, some sort of double border.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7432
https://jira.corp.adobe.com/browse/DNA-1057
https://jira.corp.adobe.com/browse/CQ-4293602

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested against Coral-Spectrum example docs.

## Screenshots (if appropriate):

### Before, with black focus ring on Today, making it impossible to distinguish the focused style from the not focused style
<img width="408" alt="Calendar - Before with black focus ring on Today " src="https://user-images.githubusercontent.com/154077/96276476-1025dc00-0fa1-11eb-93e5-0e09b90484ff.png">

### After, with blue focus ring on Today
<img width="408" alt="Calendar - After with blue focus ring on Today " src="https://user-images.githubusercontent.com/154077/96276609-3b103000-0fa1-11eb-9a8a-7111ac91cb7c.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
