### PR TITLE
fix(CUI-7435) ColumnView: first column should have role="presentation"

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -560,9 +560,10 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
     super.render();
     
     this.classList.add(CLASSNAME);
-  
     // @a11y
-    this.setAttribute('role', 'group');
+    if (!this.hasAttribute('role')) {
+      this.setAttribute('role', 'group');
+    }
 
     this.id = this.id || commons.getUID();
   

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -1316,6 +1316,14 @@ describe('ColumnView', function() {
       expect(el.getAttribute('role')).to.equal('tree');
     });
 
+    describe('First column', function() {
+      it('should have role equal to "presentation", while subsequent columns have role equal to "group"', function() {
+        const el = helpers.build(window.__html__['ColumnView.full.html']);
+        expect(el.columns.first().getAttribute('role')).to.equal('presentation');
+        expect(el.columns.getAll()[1].getAttribute('role')).to.equal('group');
+      });
+    });
+
     describe('when selectionMode equals "multiple"', function() {
       it('should have aria-multiselectable equal to "true"', function(done) {
         const el = helpers.build(window.__html__['ColumnView.selectionMode.multiple.html']);


### PR DESCRIPTION
## Description
Per CQ-4295167, the first Column of ColumnView should have role="presentation" so that items in the first column are at the root level of the tree.

Add unit test for the behavior in Coral-Spectrum.

## Related Issue

- [CQ-4295167](https://jira.corp.adobe.com/browse/CQ-4295167)
- [CUI-7435](https://jira.corp.adobe.com/browse/CUI-7435)

## Motivation and Context
Improve screen reader announcement with NVDA per [CQ-4295167](https://jira.corp.adobe.com/browse/CQ-4295167) :

> * Generally, role="group" should not be used as a container for the items in the root column of this tree, because the treeitem elements in the root column should be direct descendants of the tree. If the tree is properly labeled, this should simplify announcement of the items at the root level

## How Has This Been Tested?
Unit test has been added, and behavior has been verified in the rendered DOM using Web Inspector.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
