### PR TITLE
fix(CUI-7436) ColumnView.Preview should not be in tab order with selection in previous column

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewPreview.js
+++ b/coral-component-columnview/src/scripts/ColumnViewPreview.js
@@ -91,13 +91,21 @@ class ColumnViewPreview extends BaseComponent(HTMLElement) {
     let i;
     let element;
     let elementLabel;
+
+    // @a11y If the previous column has selected items,
+    // do not include item values in the tab order, 
+    // so that a keyboard user can quickly advance to a subsequent toolbar.
+    const tabIndex = (this.parentElement &&
+      this.parentElement.tagName === 'CORAL-COLUMNVIEW' &&
+      this.parentElement.selectedItems.length) ? -1 : 0;
+
     for (i = 0; i < length; i++) {
       element = elements[i];
       elementLabel = element.previousElementSibling;
       elementLabel.id = elementLabel.id || commons.getUID();
       element.setAttribute('aria-labelledby', elementLabel.id);
       element.setAttribute('role', 'textbox');
-      element.setAttribute('tabindex', '0');
+      element.setAttribute('tabindex', tabIndex);
       element.setAttribute('aria-readonly', 'true');
 
       // force ChromeVox to read value of textbox

--- a/coral-component-columnview/src/tests/test.ColumnView.js
+++ b/coral-component-columnview/src/tests/test.ColumnView.js
@@ -1517,5 +1517,57 @@ describe('ColumnView', function() {
         expect(item.getAttribute('tabindex')).to.equal(i === 0 ? '0' : '-1');
       });
     });
+
+    describe('ColumnView.Preview', function() {
+      function onChangeEvent(event) {
+        const columnView = event.target;
+        if (event.detail.selection.length) {
+          // on selection, it means we load the item content
+          let url = columnView.items._getLastSelected().dataset.src;
+  
+          // there is no information on additional items
+          if (typeof url === 'undefined') {
+            return;
+          }
+  
+          // we load the url from the snippets instead of using ajax
+          let data = window.__html__[`examples/${url}`];
+          if (typeof data !== 'undefined') {
+            let t = document.createElement('div');
+            t.innerHTML = data;
+            let el = t.firstElementChild;
+  
+            // if it is a preview column we add it directly
+            if (el.matches('coral-columnview-preview')) {
+              columnView.setNextColumn(el, columnView.columns.last(), false);
+            }
+          }
+        }
+      }
+
+      beforeEach(function() {
+        helpers.target.addEventListener('coral-columnview:change', onChangeEvent);
+      });
+  
+      afterEach(function() {
+        helpers.target.removeEventListener('coral-columnview:change', onChangeEvent);
+      });
+
+      it('should not be in tab order with selection in previous column', function() {
+        const el = helpers.build(window.__html__['ColumnView.full.html']);
+        const item = el.items.getAll()[3];
+        item.focus();
+        item.active = true;
+        let focusables = el.querySelectorAll('coral-columnview-preview coral-columnview-preview-value[tabindex="-1"]');
+        let tabbables = el.querySelectorAll('coral-columnview-preview coral-columnview-preview-value[tabindex="0"]');
+        expect(focusables.length).to.equal(0);
+        expect(tabbables.length).to.equal(7);
+        item.selected = true;
+        focusables = el.querySelectorAll('coral-columnview-preview coral-columnview-preview-value[tabindex="-1"]');
+        tabbables = el.querySelectorAll('coral-columnview-preview coral-columnview-preview-value[tabindex="0"]');
+        expect(focusables.length).to.equal(7);
+        expect(tabbables.length).to.equal(0);
+      })
+    });
   });
 });


### PR DESCRIPTION
## Description
Per CQ-4295167, if a previous column has selected items, do not include ColumnView Preview item values in the tab order, so that a keyboard user can quickly advance to a subsequent toolbar without having to tab through the Preview item content.

## Related Issue

- [CQ-4295167](https://jira.corp.adobe.com/browse/CQ-4295167)
- [CUI-7436](https://jira.corp.adobe.com/browse/CUI-7436)

## Motivation and Context
So that a keyboard user can quickly advance to a subsequent toolbar without having to tab through the Preview item content when one or more items are selected.


## How Has This Been Tested?
Unit tests have been added, and tested against documentation examples

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
