### PR TITLE
fix(GRANITE-32187) : Massive performance drop in complex dialog openings with coral spectrum

### DIFF
--- a/coral-base-component/src/scripts/BaseComponent.js
+++ b/coral-base-component/src/scripts/BaseComponent.js
@@ -786,8 +786,6 @@ const BaseComponent = (superClass) => class extends superClass {
     if (this._disconnected) {
       delegateGlobalEvents.call(this);
     }
-    // set _disconnected to false instead of undefined
-    // would ensure that connectedCallback has executed for the component
     this._disconnected = false;
 
     if (!this._rendered) {

--- a/coral-base-component/src/scripts/BaseComponent.js
+++ b/coral-base-component/src/scripts/BaseComponent.js
@@ -745,16 +745,6 @@ const BaseComponent = (superClass) => class extends superClass {
   }
 
   /**
-   * checks whether disconnectedCallback needs to be executed or not ,skip if component is in connected state
-   * or disconnectedCallback already executed for the component or we ignore the callback for some reason
-   *
-   * @returns {Boolean} return true for skipped cases
-   */
-  _skipDisconnectedCallback() {
-    return this.isConnected || this._disconnected === true || this._ignoreConnectedCallback === true;
-  }
-
-  /**
    Returns {@link BaseComponent} tracking options.
 
    @return {TrackingEnum}

--- a/coral-base-component/src/scripts/BaseComponent.js
+++ b/coral-base-component/src/scripts/BaseComponent.js
@@ -775,8 +775,10 @@ const BaseComponent = (superClass) => class extends superClass {
     // A component that is reattached should respond to global events again
     if (this._disconnected) {
       delegateGlobalEvents.call(this);
-      this._disconnected = false;
     }
+    // set _disconnected to false instead of undefined
+    // would ensure that connectedCallback has executed for the component
+    this._disconnected = false;
 
     if (!this._rendered) {
       this.render();

--- a/coral-base-component/src/scripts/BaseComponent.js
+++ b/coral-base-component/src/scripts/BaseComponent.js
@@ -735,6 +735,26 @@ const BaseComponent = (superClass) => class extends superClass {
   }
 
   /**
+   * checks whether connectedCallback needs to be executed or not ,skip if component is not in connected state
+   * or connectedCallback already executed for the component or we are ignore the connectedCallback for some reason
+   *
+   * @returns {Boolean} return true for skipped cases
+   */
+  _skipConnectedCallback() {
+    return !this.isConnected || this._disconnected === false || this._ignoreConnectedCallback === true;
+  }
+
+  /**
+   * checks whether disconnectedCallback needs to be executed or not ,skip if component is in connected state
+   * or disconnectedCallback already executed for the component or we ignore the callback for some reason
+   *
+   * @returns {Boolean} return true for skipped cases
+   */
+  _skipDisconnectedCallback() {
+    return this.isConnected || this._disconnected === true || this._ignoreConnectedCallback === true;
+  }
+
+  /**
    Returns {@link BaseComponent} tracking options.
 
    @return {TrackingEnum}

--- a/coral-component-accordion/src/scripts/AccordionItem.js
+++ b/coral-component-accordion/src/scripts/AccordionItem.js
@@ -106,7 +106,6 @@ class AccordionItem extends BaseComponent(HTMLElement) {
     let _selected = this.hasAttribute('disabled') ? false : _value;
 
     if(this._selected === _selected) {
-      // do nothing if value not changed
       return;
     }
 

--- a/coral-component-accordion/src/scripts/AccordionItem.js
+++ b/coral-component-accordion/src/scripts/AccordionItem.js
@@ -102,7 +102,15 @@ class AccordionItem extends BaseComponent(HTMLElement) {
   }
 
   set selected(value) {
-    this._selected = this.hasAttribute('disabled') ? false : transform.booleanAttr(value);
+    let _value = transform.booleanAttr(value);
+    let _selected = this.hasAttribute('disabled') ? false : _value;
+
+    if(this._selected === _selected) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._selected = _selected;
     this._reflectAttribute('selected', this._selected);
 
     // Read it before applying is-open which adds additional padding

--- a/coral-component-autocomplete/src/scripts/AutocompleteItem.js
+++ b/coral-component-autocomplete/src/scripts/AutocompleteItem.js
@@ -49,7 +49,14 @@ class AutocompleteItem extends BaseComponent(HTMLElement) {
   }
 
   set value(value) {
-    this._value = transform.string(value);
+    let _value = transform.string(value);
+
+    if(this._value === _value) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._value = _value;
     this._reflectAttribute('value', this._value);
 
     this.trigger('coral-autocomplete-item:_valuechanged');
@@ -83,7 +90,14 @@ class AutocompleteItem extends BaseComponent(HTMLElement) {
   }
 
   set selected(value) {
-    this._selected = transform.booleanAttr(value);
+    let _selected = transform.booleanAttr(value);
+
+    if(this._selected === _selected) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._selected = _selected;
     this._reflectAttribute('selected', this._selected);
 
     this.trigger('coral-autocomplete-item:_selectedchanged');

--- a/coral-component-autocomplete/src/scripts/AutocompleteItem.js
+++ b/coral-component-autocomplete/src/scripts/AutocompleteItem.js
@@ -52,7 +52,6 @@ class AutocompleteItem extends BaseComponent(HTMLElement) {
     let _value = transform.string(value);
 
     if(this._value === _value) {
-      // do nothing if value not changed
       return;
     }
 
@@ -93,7 +92,6 @@ class AutocompleteItem extends BaseComponent(HTMLElement) {
     let _selected = transform.booleanAttr(value);
 
     if(this._selected === _selected) {
-      // do nothing if value not changed
       return;
     }
 

--- a/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
@@ -58,7 +58,6 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
     let _icon = transform.string(value);
 
     if(this._icon === _icon) {
-      // do nothing if value not changed
       return;
     }
 
@@ -127,7 +126,6 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
     let _selected = transform.booleanAttr(value);
 
     if(this._selected === _selected) {
-      // do nothing if value not changed
       return;
     }
     
@@ -163,7 +161,6 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
     let _displayMode = validate.enumeration(displayMode)(_value) && _value || displayMode.INHERIT;
 
     if(this._displayMode === _displayMode) {
-      // do nothing if value not changed
       return;
     }
 

--- a/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
@@ -55,7 +55,14 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
   }
 
   set icon(value) {
-    this._icon = transform.string(value);
+    let _icon = transform.string(value);
+
+    if(this._icon === _icon) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._icon = _icon;
     this._reflectAttribute('icon', this._icon);
 
     this.trigger('coral-cyclebutton-item:_iconchanged');
@@ -117,10 +124,15 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
   }
 
   set selected(value) {
-    value = transform.booleanAttr(value);
+    let _selected = transform.booleanAttr(value);
 
-    if (!value || value && !this.disabled) {
-      this._selected = value;
+    if(this._selected === _selected) {
+      // do nothing if value not changed
+      return;
+    }
+    
+    if (!_selected || _selected && !this.disabled) {
+      this._selected = _selected;
       this._reflectAttribute('selected', this.disabled ? false : this._selected);
 
       this.classList.toggle('is-selected', this._selected);
@@ -147,8 +159,15 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
   }
 
   set displayMode(value) {
-    value = transform.string(value).toLowerCase();
-    this._displayMode = validate.enumeration(displayMode)(value) && value || displayMode.INHERIT;
+    let _value = transform.string(value).toLowerCase();
+    let _displayMode = validate.enumeration(displayMode)(_value) && _value || displayMode.INHERIT;
+
+    if(this._displayMode === _displayMode) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._displayMode = _displayMode;
     this._reflectAttribute('displaymode', this._displayMode);
 
     this.trigger('coral-cyclebutton-item:_displaymodechanged');

--- a/coral-component-list/src/scripts/SelectListItem.js
+++ b/coral-component-list/src/scripts/SelectListItem.js
@@ -164,7 +164,6 @@ class SelectListItem extends BaseComponent(HTMLElement) {
     let _selected = transform.booleanAttr(value);
 
     if(this._selected === _selected) {
-      // do nothing if value not changed
       return;
     }
 

--- a/coral-component-list/src/scripts/SelectListItem.js
+++ b/coral-component-list/src/scripts/SelectListItem.js
@@ -161,7 +161,14 @@ class SelectListItem extends BaseComponent(HTMLElement) {
   }
 
   set selected(value) {
-    this._selected = transform.booleanAttr(value);
+    let _selected = transform.booleanAttr(value);
+
+    if(this._selected === _selected) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._selected = _selected;
     this._reflectAttribute('selected', this.disabled ? false : this._selected);
 
     this.classList.toggle('is-selected', this._selected);

--- a/coral-component-masonry/src/scripts/MasonryItem.js
+++ b/coral-component-masonry/src/scripts/MasonryItem.js
@@ -153,10 +153,14 @@ class MasonryItem extends BaseComponent(HTMLElement) {
     if (!this.isConnected) {
       return;
     }
+    // true if component connectedCallback has already been called
+    let isConnected = this._disconnected === false;
 
     super.connectedCallback();
+
     // Inform masonry immediately
-    this.trigger('coral-masonry-item:_connected');
+    // only trigger once while connecting
+    !isConnected && this.trigger('coral-masonry-item:_connected');
   }
 
   /** @ignore */

--- a/coral-component-masonry/src/scripts/MasonryItem.js
+++ b/coral-component-masonry/src/scripts/MasonryItem.js
@@ -150,17 +150,14 @@ class MasonryItem extends BaseComponent(HTMLElement) {
 
   /** @ignore */
   connectedCallback() {
-    if (!this.isConnected) {
+    if (this._skipConnectedCallback()) {
       return;
     }
-    // true if component connectedCallback has already been called
-    let isConnected = this._disconnected === false;
 
     super.connectedCallback();
 
     // Inform masonry immediately
-    // only trigger once while connecting
-    !isConnected && this.trigger('coral-masonry-item:_connected');
+    this.trigger('coral-masonry-item:_connected');
   }
 
   /** @ignore */

--- a/coral-component-masonry/src/tests/test.Masonry.Item.js
+++ b/coral-component-masonry/src/tests/test.Masonry.Item.js
@@ -142,6 +142,45 @@ describe('Masonry.Item', function () {
           done();
         }, 100);
       });
+
+      it('should avoid connectedCallback when encounter skipped cases', function(done){
+        const spy = sinon.spy();
+        const el = helpers.build(window.__html__['Masonry.with.div.wrapper.html']);
+        const masonry = el.querySelector("coral-masonry");
+        const items = masonry.querySelectorAll("coral-masonry-item");
+        const item1 = items[0];
+        const item2 = items[1];
+
+        masonry.on('coral-masonry-item:_connected', spy, true);
+
+        const newItem = new Masonry.Item();
+        newItem.content.innerHTML = "Hi";
+        masonry.appendChild(newItem);
+
+        expect(spy.calledOnce).to.be.true;
+
+        spy.resetHistory();
+
+        item1._ignoreConnectedCallback = true;
+        masonry.appendChild(item1);
+
+        expect(spy.notCalled).to.be.true;
+
+        masonry.removeChild(item2);
+
+        // let the removing transition to end
+        commons.transitionEnd(item2, () => {
+          helpers.next(function() {
+            spy.resetHistory();
+            // assume item is in connected state.
+            item2._disconnected = false;
+            masonry.appendChild(item2);
+
+            expect(spy.notCalled).to.be.true;
+            done();
+          });
+        });
+      });
     });
 
     describe('#coral-masonry-draghandle', function () {

--- a/coral-component-overlay/src/scripts/Overlay.js
+++ b/coral-component-overlay/src/scripts/Overlay.js
@@ -701,6 +701,8 @@ class Overlay extends BaseOverlay(BaseComponent(HTMLElement)) {
     if (this._ignoreConnectedCallback) {
       return;
     }
+    // true if component connectedCallback has already been called
+    let isConnected = this._disconnected === false;
 
     super.connectedCallback();
 
@@ -708,7 +710,9 @@ class Overlay extends BaseOverlay(BaseComponent(HTMLElement)) {
     this.target = this.target;
 
     // We need an additional frame to help popper read the correct offsets
-    window.requestAnimationFrame(() => {
+
+    // trigger only once when attaching or reattaching.
+     !isConnected && window.requestAnimationFrame(() => {
       // Force repositioning
       this.reposition(true);
 

--- a/coral-component-overlay/src/scripts/Overlay.js
+++ b/coral-component-overlay/src/scripts/Overlay.js
@@ -698,11 +698,9 @@ class Overlay extends BaseOverlay(BaseComponent(HTMLElement)) {
 
   /** @ignore */
   connectedCallback() {
-    if (this._ignoreConnectedCallback) {
+    if (this._skipConnectedCallback()) {
       return;
     }
-    // true if component connectedCallback has already been called
-    let isConnected = this._disconnected === false;
 
     super.connectedCallback();
 
@@ -710,9 +708,7 @@ class Overlay extends BaseOverlay(BaseComponent(HTMLElement)) {
     this.target = this.target;
 
     // We need an additional frame to help popper read the correct offsets
-
-    // trigger only once when attaching or reattaching.
-     !isConnected && window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
       // Force repositioning
       this.reposition(true);
 

--- a/coral-component-panelstack/src/scripts/Panel.js
+++ b/coral-component-panelstack/src/scripts/Panel.js
@@ -68,7 +68,14 @@ class Panel extends BaseComponent(HTMLElement) {
   }
 
   set selected(value) {
-    this._selected = transform.booleanAttr(value);
+    let _selected = transform.booleanAttr(value);
+
+    if(this._selected === _selected) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._selected = _selected;
     this._reflectAttribute('selected', this._selected);
 
     this.classList.toggle('is-selected', this._selected);

--- a/coral-component-panelstack/src/scripts/Panel.js
+++ b/coral-component-panelstack/src/scripts/Panel.js
@@ -71,7 +71,6 @@ class Panel extends BaseComponent(HTMLElement) {
     let _selected = transform.booleanAttr(value);
 
     if(this._selected === _selected) {
-      // do nothing if value not changed
       return;
     }
 

--- a/coral-component-quickactions/src/scripts/QuickActionsItem.js
+++ b/coral-component-quickactions/src/scripts/QuickActionsItem.js
@@ -83,7 +83,6 @@ class QuickActionsItem extends BaseComponent(HTMLElement) {
     let _href = transform.string(value);
 
     if(this._href === _href) {
-      // do nothing if value not changed
       return;
     }
     this._href = _href;
@@ -110,7 +109,6 @@ class QuickActionsItem extends BaseComponent(HTMLElement) {
     let _icon = transform.string(value);
 
     if(this._icon === _icon) {
-      // do nothing if value not changed
       return;
     }
     this._icon = _icon;
@@ -137,7 +135,6 @@ class QuickActionsItem extends BaseComponent(HTMLElement) {
     let _type = validate.enumeration(type)(_value) && _value || type.BUTTON;
 
     if(this._type === _type) {
-      // do nothing if value not changed
       return;
     }
     this._type = _type;

--- a/coral-component-quickactions/src/scripts/QuickActionsItem.js
+++ b/coral-component-quickactions/src/scripts/QuickActionsItem.js
@@ -80,7 +80,13 @@ class QuickActionsItem extends BaseComponent(HTMLElement) {
   }
 
   set href(value) {
-    this._href = transform.string(value);
+    let _href = transform.string(value);
+
+    if(this._href === _href) {
+      // do nothing if value not changed
+      return;
+    }
+    this._href = _href;
     this._reflectAttribute('href', this._href);
 
     this.trigger('coral-quickactions-item:_hrefchanged');
@@ -101,7 +107,13 @@ class QuickActionsItem extends BaseComponent(HTMLElement) {
   }
 
   set icon(value) {
-    this._icon = transform.string(value);
+    let _icon = transform.string(value);
+
+    if(this._icon === _icon) {
+      // do nothing if value not changed
+      return;
+    }
+    this._icon = _icon;
     this._reflectAttribute('icon', this._icon);
 
     this.trigger('coral-quickactions-item:_iconchanged');
@@ -121,8 +133,14 @@ class QuickActionsItem extends BaseComponent(HTMLElement) {
   }
 
   set type(value) {
-    value = transform.string(value).toLowerCase();
-    this._type = validate.enumeration(type)(value) && value || type.BUTTON;
+    let _value = transform.string(value).toLowerCase();
+    let _type = validate.enumeration(type)(_value) && _value || type.BUTTON;
+
+    if(this._type === _type) {
+      // do nothing if value not changed
+      return;
+    }
+    this._type = _type;
     this._reflectAttribute('type', this._type);
 
     this.trigger('coral-quickactions-item:_typechanged');

--- a/coral-component-select/src/scripts/SelectItem.js
+++ b/coral-component-select/src/scripts/SelectItem.js
@@ -81,7 +81,14 @@ class SelectItem extends BaseComponent(HTMLElement) {
   }
 
   set selected(value) {
-    this._selected = transform.booleanAttr(value);
+    let _selected = transform.booleanAttr(value);
+
+    if(this._selected === _selected) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._selected = _selected;
     this._reflectAttribute('selected', this._selected);
 
     this.trigger('coral-select-item:_selectedchanged');
@@ -110,7 +117,13 @@ class SelectItem extends BaseComponent(HTMLElement) {
   }
 
   set value(value) {
-    this._value = transform.string(value);
+    let _value = transform.string(value);
+    if(this._value === _value) {
+      // do nothing if value not changed
+      return;
+    }
+
+    this._value = _value;
     this._reflectAttribute('value', this._value);
 
     this.trigger('coral-select-item:_valuechanged');

--- a/coral-component-select/src/scripts/SelectItem.js
+++ b/coral-component-select/src/scripts/SelectItem.js
@@ -84,7 +84,6 @@ class SelectItem extends BaseComponent(HTMLElement) {
     let _selected = transform.booleanAttr(value);
 
     if(this._selected === _selected) {
-      // do nothing if value not changed
       return;
     }
 
@@ -119,7 +118,6 @@ class SelectItem extends BaseComponent(HTMLElement) {
   set value(value) {
     let _value = transform.string(value);
     if(this._value === _value) {
-      // do nothing if value not changed
       return;
     }
 

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -184,10 +184,15 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
   }
 
   set selected(value) {
-    value = transform.booleanAttr(value);
+    let _selected = transform.booleanAttr(value);
 
-    if (!value || value && !this.disabled) {
-      this._selected = value;
+    if(this._selected === _selected) {
+      // do nothing if value not changed
+      return;
+    }
+
+    if (!_selected || _selected && !this.disabled) {
+      this._selected = _selected;
       this._reflectAttribute('selected', this.disabled ? false : this._selected);
 
       this.classList.toggle('is-selected', this._selected);

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -187,7 +187,6 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     let _selected = transform.booleanAttr(value);
 
     if(this._selected === _selected) {
-      // do nothing if value not changed
       return;
     }
 

--- a/coral-component-tablist/src/scripts/TabList.js
+++ b/coral-component-tablist/src/scripts/TabList.js
@@ -149,7 +149,6 @@ class TabList extends BaseComponent(HTMLElement) {
       this._target = value;
 
       // we do in case the target was not yet in the DOM
-      // trigger once in an animation frame
       !(this._setTargetInQueue === true) && window.requestAnimationFrame(() => {
         delete this._setTargetInQueue;
 
@@ -396,19 +395,8 @@ class TabList extends BaseComponent(HTMLElement) {
   }
 
   _setLine() {
-<<<<<<< HEAD
-    // Debounce
-    if (this._timeout !== null) {
-      window.clearTimeout(this._timeout);
-    }
-
-    this._timeout = window.setTimeout(() => {
-      this._timeout = null;
-=======
-    // trigger once in an animation frame
     !(this._setLineInQueue === true) && window.requestAnimationFrame(() => {
       delete this._setLineInQueue;
->>>>>>> df381a6cc... fix(GRANITE-32187): Massive performance drop in complex dialog openings with coral spectrum
 
       const selectedItem = this.selectedItem;
 
@@ -438,19 +426,11 @@ class TabList extends BaseComponent(HTMLElement) {
           this._elements.line.style.height = `${height}px`;
           this._elements.line.style.transform = `translate(0, ${top}px)`;
         }
-<<<<<<< HEAD
-
-=======
->>>>>>> df381a6cc... fix(GRANITE-32187): Massive performance drop in complex dialog openings with coral spectrum
         this._elements.line.hidden = false;
       } else {
         // Hide line if no selected item
         this._elements.line.hidden = true;
       }
-<<<<<<< HEAD
-
-=======
->>>>>>> df381a6cc... fix(GRANITE-32187): Massive performance drop in complex dialog openings with coral spectrum
       this._previousOrientation = this.orientation;
     });
 

--- a/coral-component-tablist/src/scripts/TabList.js
+++ b/coral-component-tablist/src/scripts/TabList.js
@@ -149,9 +149,11 @@ class TabList extends BaseComponent(HTMLElement) {
       this._target = value;
 
       // we do in case the target was not yet in the DOM
-      window.requestAnimationFrame(() => {
-        const realTarget = getTarget(this._target);
+      // trigger once in an animation frame
+      !(this._setTargetInQueue === true) && window.requestAnimationFrame(() => {
+        delete this._setTargetInQueue;
 
+        const realTarget = getTarget(this._target);
         // we add proper accessibility if available
         if (realTarget) {
           const tabItems = this.items.getAll();
@@ -193,6 +195,7 @@ class TabList extends BaseComponent(HTMLElement) {
           }
         }
       });
+      this._setTargetInQueue = true;
     }
   }
 
@@ -393,6 +396,7 @@ class TabList extends BaseComponent(HTMLElement) {
   }
 
   _setLine() {
+<<<<<<< HEAD
     // Debounce
     if (this._timeout !== null) {
       window.clearTimeout(this._timeout);
@@ -400,6 +404,11 @@ class TabList extends BaseComponent(HTMLElement) {
 
     this._timeout = window.setTimeout(() => {
       this._timeout = null;
+=======
+    // trigger once in an animation frame
+    !(this._setLineInQueue === true) && window.requestAnimationFrame(() => {
+      delete this._setLineInQueue;
+>>>>>>> df381a6cc... fix(GRANITE-32187): Massive performance drop in complex dialog openings with coral spectrum
 
       const selectedItem = this.selectedItem;
 
@@ -429,15 +438,23 @@ class TabList extends BaseComponent(HTMLElement) {
           this._elements.line.style.height = `${height}px`;
           this._elements.line.style.transform = `translate(0, ${top}px)`;
         }
+<<<<<<< HEAD
 
+=======
+>>>>>>> df381a6cc... fix(GRANITE-32187): Massive performance drop in complex dialog openings with coral spectrum
         this._elements.line.hidden = false;
       } else {
         // Hide line if no selected item
         this._elements.line.hidden = true;
       }
+<<<<<<< HEAD
 
+=======
+>>>>>>> df381a6cc... fix(GRANITE-32187): Massive performance drop in complex dialog openings with coral spectrum
       this._previousOrientation = this.orientation;
-    }, this._wait);
+    });
+
+    this._setLineInQueue = true;
   }
 
   /** @private */

--- a/coral-component-taglist/src/scripts/Tag.js
+++ b/coral-component-taglist/src/scripts/Tag.js
@@ -229,7 +229,13 @@ class Tag extends BaseComponent(HTMLElement) {
   }
 
   set value(value) {
-    this._value = transform.string(value);
+    let _value = transform.string(value);
+
+    if(this._value === _value) {
+      // do nothing if value not changed
+      return;
+    }
+    this._value = _value;
     this._reflectAttribute('value', this._value);
 
     this.trigger('coral-tag:_valuechanged');
@@ -466,10 +472,14 @@ class Tag extends BaseComponent(HTMLElement) {
 
   /** @ignore */
   connectedCallback() {
+    // true if component connectedCallback has already been called
+    let isConnected = this._disconnected === false;
+
     super.connectedCallback();
 
     // Used to inform the tag list that it's added
-    this.trigger('coral-tag:_connected');
+    // only trigger once when component is attached or reattached
+    !isConnected && this.trigger('coral-tag:_connected');
   }
 
   /** @ignore */

--- a/coral-component-taglist/src/scripts/Tag.js
+++ b/coral-component-taglist/src/scripts/Tag.js
@@ -232,7 +232,6 @@ class Tag extends BaseComponent(HTMLElement) {
     let _value = transform.string(value);
 
     if(this._value === _value) {
-      // do nothing if value not changed
       return;
     }
     this._value = _value;
@@ -472,14 +471,14 @@ class Tag extends BaseComponent(HTMLElement) {
 
   /** @ignore */
   connectedCallback() {
-    // true if component connectedCallback has already been called
-    let isConnected = this._disconnected === false;
+    if (this._skipConnectedCallback()) {
+      return;
+    }
 
     super.connectedCallback();
 
     // Used to inform the tag list that it's added
-    // only trigger once when component is attached or reattached
-    !isConnected && this.trigger('coral-tag:_connected');
+    this.trigger('coral-tag:_connected');
   }
 
   /** @ignore */


### PR DESCRIPTION
## Description
While trying to display a complex dialog, there is seen a performance drop. The scripting part of the dialog itself takes around 3000ms( ~3sec).

The related changes done in this PR :
a) Minimise the triggering of event, hence we are only changing the value and triggering event if the new value is different from old /previous stored value.
b) Sometimes callback running in animationFrame gets executed twice/thrice, even if executing them only once is sufficient. Hence avoid running them excessively.

Future Prospects :
a) Forced reflow occurring at some part of code. Try to find and reduce them.
b) If possible try to reduce the animationFrame callbacks . 
c) Reduce duplicated code to reduce downloading and scripting time.

The connectedCallback of the element can be executed more than once as mentioned here : 
https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-conformance

## Related Issue
https://jira.corp.adobe.com/browse/GRANITE-32187

## Motivation and Context
There has been a performance gap between coralui3 and coral-spectrum and the same code structure takes around 3-4 times longer time to load with spectrum 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Review
@icaraps @indra2gurjar @CezCz 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
