### PR TITLE
fix(CUI-7441): Coral.CycleButton: fix menuitemradio and menuitem roles

### DIFF
--- a/coral-component-cyclebutton/src/scripts/CycleButton.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButton.js
@@ -255,7 +255,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
   _onItemAdded(item) {
     if (!this.selectedItem) {
       item.setAttribute('selected', '');
-    } else {
+    }
+    else {
       this._validateSelection(item);
     }
 
@@ -319,7 +320,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
         // We can trigger change events again
         this._preventTriggeringEvents = false;
       }
-    } else if (selectedItems.length > 1) {
+    }
+    else if (selectedItems.length > 1) {
       // If multiple items are selected, the last one wins
       item = selectedItems[selectedItems.length - 1];
 
@@ -422,7 +424,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
       if (ariaLabel && effectiveIcon !== '' && this._elements.button._elements.icon) {
         this._elements.button._elements.icon.setAttribute('aria-hidden', true);
       }
-    } else {
+    }
+    else {
       // handle display modes that include text
       if (effectiveDisplayMode === displayMode.TEXT) {
         this._elements.button.icon = '';
@@ -526,7 +529,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
 
       // Regions within the overlay should have role=presentation
       this._elements.overlay.content.setAttribute('role', 'presentation');
-    } else {
+    }
+    else {
       this._elements.button.removeAttribute('aria-controls');
       this._elements.button.removeAttribute('aria-haspopup');
       this._elements.button.removeAttribute('aria-expanded');
@@ -553,7 +557,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
       const index = items.indexOf(el);
       if (index > 0) {
         this._focusItem(items[index - 1]);
-      } else if (document.activeElement !== el) {
+      }
+      else if (document.activeElement !== el) {
         // make sure ButtonList doesn't wrap focus
         this._focusItem(el);
       }
@@ -569,7 +574,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
       const index = items.indexOf(el);
       if (index < items.length - 1) {
         this._focusItem(items[index + 1]);
-      } else if (document.activeElement !== el) {
+      }
+      else if (document.activeElement !== el) {
         // make sure ButtonList doesn't wrap focus
         this._focusItem(el);
       }
@@ -650,7 +656,7 @@ class CycleButton extends BaseComponent(HTMLElement) {
 
     selectListItem.disabled = item.disabled;
     selectListItem.selected = item.selected;
-    selectListItem.role = item.role;
+    selectListItem.setAttribute('role', item.getAttribute('role'));
     selectListItem.setAttribute('aria-checked', item.selected);
 
     selectListItem._originalItem = item;
@@ -665,7 +671,7 @@ class CycleButton extends BaseComponent(HTMLElement) {
 
     actionListItem.icon = action.icon;
     actionListItem.disabled = action.disabled;
-    actionListItem.role = action.role;
+    actionListItem.setAttribute('role', action.getAttribute('role'));
     actionListItem.tabIndex = action.tabIndex;
 
     // Needs to be reflected on the generated Action.
@@ -701,7 +707,6 @@ class CycleButton extends BaseComponent(HTMLElement) {
       selectListItem = this._getSelectListItem(item);
 
       selectListItem.icon = item.icon;
-      selectListItem.role = item.role;
       selectListItem.setAttribute('aria-checked', item.selected);
       selectListItem._elements.icon.setAttribute('aria-hidden', true);
 
@@ -721,7 +726,6 @@ class CycleButton extends BaseComponent(HTMLElement) {
         actionListItem = this._getActionListItem(action);
         actionListItem.disabled = action.disabled;
         actionListItem.icon = action.icon;
-        actionListItem.role = action.role;
         actionListItem._elements.icon.setAttribute('aria-hidden', true);
 
         actionList.items.add(actionListItem);
@@ -731,12 +735,11 @@ class CycleButton extends BaseComponent(HTMLElement) {
 
       if (itemCount > 0) {
         this._elements.separator.removeAttribute('hidden');
-        this._elements.selectList.setAttribute('role', 'group');
       }
-    } else {
+    }
+    else {
       this._elements.actionList.setAttribute('hidden', '');
       this._elements.separator.setAttribute('hidden', '');
-      this._elements.selectList.setAttribute('role', 'presentation');
     }
 
     commons.nextFrame(() => {
@@ -794,7 +797,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
         // SelectList menuitemradio group should be labeled by the container with aria-label,
         // Otherwise the selectList should not be labeled independantly from the menu
         this._elements.selectList[hasMenuItemRadioGroup ? 'setAttribute' : 'removeAttribute']('aria-labelledby', this.id);
-      } else {
+      }
+      else {
         //  With no aria-label, clean up aria-labelledby on _elements
         this._elements.button.removeAttribute('aria-labelledby');
         this._elements.overlay.setAttribute('aria-labelledby', this._elements.button.id);
@@ -812,7 +816,8 @@ class CycleButton extends BaseComponent(HTMLElement) {
         this._elements.overlay.setAttribute('aria-labelledby', value || this._elements.button.id);
         this._elements.selectList[this._hasMenuItemRadioGroup() ? 'setAttribute' : 'removeAttribute']('aria-labelledby', value || this._elements.button.id);
       }
-    } else {
+    }
+    else {
       super.attributeChangedCallback(name, oldValue, value);
     }
   }
@@ -848,8 +853,6 @@ class CycleButton extends BaseComponent(HTMLElement) {
       this.displayMode = displayMode.ICON;
     }
 
-    // adds the role to support accessibility
-    this.setAttribute('role', 'presentation');
     // checks the component's extended mode
     this._checkExtended();
 

--- a/coral-component-cyclebutton/src/templates/base.html
+++ b/coral-component-cyclebutton/src/templates/base.html
@@ -14,5 +14,5 @@
 <coral-popover tracking="off" smart id="{{data.menuId}}" handle="overlay" focusonshow="coral-selectlist" placement="bottom" aria-live="off" role="menu">
   <coral-selectlist role="group" tracking="off" class="_coral-CycleSelect-list" handle="selectList" id="{{data.commons.getUID()}}"></coral-selectlist>
   <div role="separator" handle="separator" class="_coral-CycleButton-separator" hidden></div>
-  <coral-buttonlist role="group" tracking="off" class="_coral-CycleSelect-buttonList" handle="actionList" hidden></coral-buttonlist>
+  <coral-buttonlist role="presentation" tracking="off" class="_coral-CycleSelect-buttonList" handle="actionList" hidden></coral-buttonlist>
 </coral-popover>

--- a/coral-component-cyclebutton/src/tests/test.CycleButton.js
+++ b/coral-component-cyclebutton/src/tests/test.CycleButton.js
@@ -735,8 +735,19 @@ describe('CycleButton', function () {
       el.querySelector('#btn1').click();
 
       expect(el._elements.actionList.hasAttribute('hidden')).to.be.false;
+      expect(el._elements.actionList.getAttribute('role')).to.equal('presentation');
       expect(el._elements.separator.hasAttribute('hidden')).to.be.false;
+      expect(el._elements.separator.getAttribute('role')).to.equal('separator');
+    });
 
+    it('should render appropriate role on selectList and actionList items', function () {
+      const el = helpers.build(SNIPPET_WITHACTIONS);
+      el.querySelector('#btn1').click();
+
+      expect(el._elements.selectList.getAttribute('role')).to.equal('group', 'selectList should have role="group"');
+      expect(el._elements.selectList.querySelectorAll('coral-selectlist-item[role="menuitemradio"]').length).to.equal(3, 'selectList items should have role="menuitemradio"');
+      expect(el._elements.actionList.getAttribute('role')).to.equal('presentation', 'actionList should have role="presentation"');
+      expect(el._elements.actionList.querySelectorAll('button[is="coral-buttonlist-item"][role="menuitem"]').length).to.equal(2, 'actionList items should have role="menuitem"');
     });
 
     it('should switch between inline/overlay selection when adding/removing nodes', function (done) {


### PR DESCRIPTION
Per https://jira.corp.adobe.com/browse/CUI-7441

## Description
In both the CoralUI and Coral Spectrum CycleButton implementations, the `menuitemradio` role on `coral-cyclebutton-item` and the `menuitem` role on `coral-cyclebutton-action` are not propagated to `coral-selectlist-item` and `button[is="coral-buttonlist-item"]` elements in the dropdown menu. Items within a menu should have a `menuitem*` role.

### Behavior can be seen in Coral Spectrum:
1. Open https://opensource.adobe.com/coral-spectrum/examples/#cyclebutton
2. Expand dropdown menu for the "With additional actions" CycleButton example.
3. Use the Web Inspector to inspect `coral-selectlist-item` elements in the `coral-selectlist[role="group"]` and `button[is="coral-buttonlist-item"]` in the `coral-buttonlist` contained within the `coral-popover[role="menu"]`.

#### Expected behavior
coral-selectlist-item elements should have role="menuitemradio"
button[is="coral-buttonlist-item"] elements should have role="menuitem"

#### Actual behavior
* `coral-selectlist-item` elements have `role="option"`, which is not appropriate for an item within `role="menu"`.
* `button[is="coral-buttonlist-item"]` elements have the implicit role of `button`, which is not appropriate for an item within `role="menu"`.

### Suggested fix
At CycleButton.js#L653 and CycleButton.js#L668, where we are defining items for the SelectList and actions for the ButtonList, we seem to expect the role from the `coral-cyclebutton-item` or `coral-cyclebutton-action` to get applied to the SelectList.Item or ButtonList.Item, but these components do not include getters and setters for the role attribute, so the role is not applied. We should instead either explicitly set the role attribute or add a getter/setter for role to SelectList.Item and ButtonList.Item.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7441

## Motivation and Context
Fixes accessibility implementation for items in the cycle button dropdown menu.

## How Has This Been Tested?
Tested against documentation examples.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
