### PR TITLE
fix(#165): placeholder text color contrast

### DIFF
--- a/coral-component-select/src/styles/index.styl
+++ b/coral-component-select/src/styles/index.styl
@@ -79,3 +79,19 @@ coral-select-item {
     opacity: 0.01;
   }
 }
+
+.coral--dark ._coral-Dropdown-label.is-placeholder {
+  color: var(--spectrum-dark-global-color-gray-700);
+}
+
+.coral--darkest ._coral-Dropdown-label.is-placeholder {
+  color: var(--spectrum-darkest-global-color-gray-700);
+}
+
+.coral--light ._coral-Dropdown-label.is-placeholder {
+  color: var(--spectrum-light-global-color-gray-700);
+}
+
+.coral--lightest ._coral-Dropdown-label.is-placeholder {
+  color: var(--spectrum-lightest-global-color-gray-700);
+}

--- a/coral-component-textfield/examples/index.html
+++ b/coral-component-textfield/examples/index.html
@@ -67,6 +67,11 @@
         <input type="text" is="coral-textfield" aria-label="text input">
       </div>
 
+      <h2 class="coral--Heading--S">Placeholder</h2>
+      <div class="markup">
+        <input type="text" is="coral-textfield" placeholder="Placeholder" aria-label="text input">
+      </div>
+
       <h2 class="coral--Heading--S">Disabled</h2>
       <div class="markup">
         <input type="text" is="coral-textfield" disabled aria-label="text input">

--- a/coral-component-textfield/src/styles/index.styl
+++ b/coral-component-textfield/src/styles/index.styl
@@ -23,3 +23,21 @@
 @require '@adobe/spectrum-css/dist/components/inputgroup/multiStops/lightest.css';
 @require '@adobe/spectrum-css/dist/components/inputgroup/multiStops/dark.css';
 @require '@adobe/spectrum-css/dist/components/inputgroup/multiStops/darkest.css';
+
+@require '../../../coral-theme-spectrum/src/styles/vars.css';
+
+.coral--dark ._coral-Textfield::placeholder {
+  color: var(--spectrum-dark-global-color-gray-700);
+}
+
+.coral--darkest ._coral-Textfield::placeholder {
+  color: var(--spectrum-darkest-global-color-gray-700);
+}
+
+.coral--light ._coral-Textfield::placeholder {
+  color: var(--spectrum-light-global-color-gray-700);
+}
+
+.coral--lightest ._coral-Textfield::placeholder {
+  color: var(--spectrum-lightest-global-color-gray-700);
+}


### PR DESCRIPTION
## Description
### Expected Behavior

Placeholder text for Search, Select, Textarea and Textfield components should comply with [WCAG 2.1 AA contrast ratio requirements](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) with a contrast ratio between the foreground text color and the background color or at least 4.5:1.

### Actual Behavior

Currently, Coral-Spectrum uses `var(--spectrum-global-color-gray-600);`  from Spectrum-CSS, for the `::placeholder` text color in Search, Select, Textarea and Textfield components, which results in placeholder text with a contrast ratio of 3:1, which does not comply with [WCAG 2.1 AA contrast ratio requirements](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).

Spectrum-CSS includes a fix for this in v3.0.1, (see https://github.com/adobe/spectrum-css/commit/011ca5408ae5eb32bb55e1cf79c06e40171fd17c), updating Coral-Spectrum to use this version of Spectrum-CSS is not trivial.
 
A simpler suggested fix would be to change the value in Coral-Spectrum to use `var(--spectrum-global-color-gray-700);` to satisfy the requirement.

### Reproduce Scenario (including but not limited to)

#### Steps to Reproduce
1. Go to https://opensource.adobe.com/coral-spectrum/examples/#textfield, https://opensource.adobe.com/coral-spectrum/examples/#textarea, https://opensource.adobe.com/coral-spectrum/examples/#select, https://opensource.adobe.com/coral-spectrum/examples/#clock.
2. Inspect the placeholder text element in the sub-dom for any of the enabled textfield examples that use placeholder.
3. Observe that the color specified in CSS for the placeholder element has a contrast ratio of 3:1, for the `.coral-lightest` theme it's `rgb(149, 149, 149)`.

#### Browser name/version/os
Version 89.0.4389.114 (Official Build) (x86_64) on macOS

#### Coral Spectrum version
v4.10.16

#### Sample Code that illustrates the problem (use the Playground if possible)
[Coral Spectrum Playground Example](https://opensource.adobe.com/coral-spectrum/playground/#?livereload=true&screen=vertical&code=MTY1LDg0LDc3LDExMSwyMTIsNDgsMjAsNjAsMTE5LDEyNywxOTcsMTk1LDIzMSwyMzgsOTAsMjQ0LDg4LDU3LDE0NSwyMDIsMTc4LDkyLDE2OCwxNjAsMTYyLDIyOSwxOTIsMjA5LDE3NywyMjMsMTEwLDkyLDI4LDU5LDE3OCw5NSwxMDQsODMsMTk2LDEyNywxOTksMjA2LDE5OSw2Niw2NCw1LDE3MywxMjIsNzMsMjgsMTIzLDYwLDUxLDE1OCwyNDcsOTgsMjQxLDIzNCwyMzcsMTk5LDIzNywyMjEsMTUxLDE1NSwyOSwyMTIsMjEyLDIxNiwxMTQsMzcsMjMwLDIzLDc0LDkzLDE3NCwyMDYsNCwyNSwxNzgsODgsMjIyLDg4LDE2OSwxNzYsMjQ2LDg2LDk5LDAsMTk0LDcxLDIsMjI5LDE3MywxNSwyMzMsMjMzLDQwLDIwMCw3MiwxMjgsMTQzLDE3OCwxMDUsNDUsMTAsNjIsMTk0LDg3LDAsMTk0LDI2LDI0NywyMSwyLDIxOCwxMzAsNjksMjM0LDQ1LDE5OCwyNiwxNDUsMjQsMjEyLDEsMjQ3LDUsMTcxLDEzNywyMTgsMTIwLDIwMSwxODUsMTExLDIwOSw2OSwyMjMsNSwxMzMsMjcsMTY5LDEyNSwxMzMsMjcsMjI5LDI3LDE3NCwxMjQsMTQ0LDExOCwyOSw5MSw4NCwyMCwxODYsMTM0LDE4Myw4NiwyNDYsMTM1LDIyNCw1OSwxNjcsMTg1LDU0LDE0NSwxODQsMTM4LDExMywxMzIsMTA4LDIxMCwxMzYsMjQxLDY1LDQzLDE3MCw5Niw5MCwxMzAsMjQsMjEyLDIwMywxODQsMjM5LDEwMywyMzQsMjUxLDIwMCw3NCwxOTMsNzEsMjE4LDE1NiwxOTQsMTEyLDEzMiw1Miw1NiwxNzEsMTg4LDIzOCwyMjUsMTIzLDI2LDE1Niw1Myw1MCwyOCwxNDAsMTg3LDEzMiwyMTUsMSwxNTUsMjQ0LDI1MywzNSwxNjEsMjQ4LDQsMTksMTI0LDc2LDc5LDEyLDEwNCwxMDEsMTAxLDE0MCw1LDI3LDE2NSwyMTUsMjE0LDI4LDEwNiwxOTQsNzIsNDQsMjExLDE4MiwxNTMsODIsODgsODksMTYxLDEzMywxODksMTUsNSwxNzksMTAyLDE1OSwyMTQsMTI0LDIzMiwyMTcsMTE0LDIxOSw1OSwxMzEsODYsOTUsMTAzLDI4LDQzLDE3NSwxOSw2LDExMCw1MSw3MiwyNDAsOTcsMjM1LDY0LDk4LDkyLDIxOSwxNywyNCwxODksMjI0LDEwNCwxMjcsMTQ5LDE3Myw5Niw1OSw3MSwxNjksMTIyLDEyNSwxMzgsNCw1MCw0LDM4LDE0MCwxNDcsMTMsMjIsMTA4LDE1OSw1LDI0LDE1MiwxNjMsOTgsMTc0LDI0Miw1NiwyMDEsMTc5LDgzLDIyMiwxNCw2NSw2MywxMTEsMjQ4LDIyNiwxMDAsMTk5LDg5LDY1LDYsMTQ4LDc1LDIxMSwyMyw0NywxMTgsMTU3LDU3LDExNSwyNDUsMjMwLDI0MSwxMDgsMTI3LDI1LDExOSwyMiw4NSwxNjksMjQyLDIwLDI1MCwyNDUsNDgsMjQzLDE1LDI1NSwyMTksMTcsMjQ3LDE4NywyNDksMTY5LDE0NSwyMDgsMTY2LDc4LDkwLDI2LDIyMiwyMTQsMjIyLDcxLDQsMjMzLDk2LDE2MiwxMDMsNDgsMTA4LDE3OSwxNjgsMjIzLDI0NCwxMjcsMTA2LDEwMiwxNzQsMzcsMjE3LDIxOCwxNiw1NCwyNDAsNzcsMjE4LDQ2LDE1NywxNDMsMTU4LDIxMCw3MywyMzgsMTY0LDEyMywxNDYsMjA2LDcyLDg4LDE5NSwxMDMsMTUxLDg2LDUzLDEyNCwxOTQsMTgyLDE3MSwxNzIsODEsMjI0LDI0Nyw0OCwxNzUsMTU4LDE5NSw3LDMxLDE2OCwxMjYsNzIsNDEsMTAsMjU0LDIzLDIyNSwxMjcsMTE2LDgyLDc2LDE3MiwxNTYsMjAwLDE3NSwxMzAsMTcyLDk2LDIxNSwxNTIsMzIsODMsMTU1LDE1OCw3OCwxMTcsMTY4LDE5NCwxNDUsMjM0LDE4OSwxMTMsNywyMzcsMTU1LDIxMSw3MywxODYsNDAsMTQzLDM2LDE4MywxNDgsMTQxLDIyOCwxNjMsOTQsNTMsMjQsMTQwLDE0Niw0MSw5MCwxMyw4NCw5OSwxODYsOTIsMTY2LDI0LDgyLDM5LDE5NCw2NywxMDksODQsMTMsMzgsOTMsMiwxNDgsMjE0LDIyNyw1NywxMjAsMTM1LDE2OSw3NSwyMDAsMTIwLDI0NywxNDAsMjU0LDExNCwxMjIsMjM4LDE4LDE5MywyNDMsNzksNTksMjUyLDE5NSwxOTUsNjksMjQ4LDE5&)


## Related Issue
#165 

## Motivation and Context
This fix addresses numerous color contrast accessibility issues identified in AEM.

## How Has This Been Tested?
Tested using color contrast evaluation tools against example pages:

- http://localhost:9001/examples/#select
- http://localhost:9001/examples/#textfield, 
- http://localhost:9001/examples/#textarea
- http://localhost:9001/examples/#clock
- http://localhost:9001/examples/#search

## Screenshots (if appropriate):

### Current behavior:
![Current behavior using Gray-600](https://user-images.githubusercontent.com/154077/114214938-f901ee80-9932-11eb-8a3e-86e840304524.png)

### Desired behavior:
![Current behavior using Gray-700](https://user-images.githubusercontent.com/154077/114215337-7d547180-9933-11eb-84ab-c09430bebef2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
