### PR TITLE
CQ-4290733 : [Visual Requirements-AEM Dynamic Media-Image Set Editor]…

### DIFF
--- a/coral-component-button/src/styles/index.styl
+++ b/coral-component-button/src/styles/index.styl
@@ -10,8 +10,27 @@
  * governing permissions and limitations under the License.
  */
 
+@require '../../../coral-theme-spectrum/src/styles/vars.css';
+
 // Avoid FOUC
 button[is="coral-button"] {
   background-color: transparent;
   border-color: transparent;
 }
+
+.coral--light ._coral-ActionButton--quiet:disabled,
+.coral--light ._coral-ActionButton--quiet.is-disabled,
+.coral--light ._coral-Tool:disabled {
+     color: var(--spectrum-light-global-color-gray-700);
+  }
+
+.coral--light ._coral-ActionButton:disabled ._coral-Icon,
+.coral--light ._coral-ActionButton.is-disabled ._coral-Icon,
+.coral--light ._coral-Tool:disabled ._coral-Icon {
+     color: var(--spectrum-light-global-color-gray-700);
+    }
+.coral--light ._coral-ActionButton:disabled ._coral-ActionButton-hold,
+.coral--light ._coral-ActionButton.is-disabled ._coral-ActionButton-hold,
+.coral--light ._coral-Tool:disabled ._coral-ActionButton-hold {
+     color: var(--spectrum-light-global-color-gray-700);
+    }

--- a/coral-component-button/src/styles/index.styl
+++ b/coral-component-button/src/styles/index.styl
@@ -19,18 +19,11 @@ button[is="coral-button"] {
 }
 
 .coral--light ._coral-ActionButton--quiet:disabled,
-.coral--light ._coral-ActionButton--quiet.is-disabled,
-.coral--light ._coral-Tool:disabled {
-     color: var(--spectrum-light-global-color-gray-700);
-  }
+.coral--light ._coral-ActionButton--quiet.is-disabled {
+    color: var(--spectrum-light-global-color-gray-700);
+}
 
 .coral--light ._coral-ActionButton:disabled ._coral-Icon,
-.coral--light ._coral-ActionButton.is-disabled ._coral-Icon,
-.coral--light ._coral-Tool:disabled ._coral-Icon {
-     color: var(--spectrum-light-global-color-gray-700);
-    }
-.coral--light ._coral-ActionButton:disabled ._coral-ActionButton-hold,
-.coral--light ._coral-ActionButton.is-disabled ._coral-ActionButton-hold,
-.coral--light ._coral-Tool:disabled ._coral-ActionButton-hold {
-     color: var(--spectrum-light-global-color-gray-700);
-    }
+.coral--light ._coral-ActionButton.is-disabled ._coral-Icon {
+    color: var(--spectrum-light-global-color-gray-700);
+}


### PR DESCRIPTION
…: Luminosity ratio fails for multiple controls, does not meets minimum luminosity ratio 4.5:1.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Expected Behavior

Multiple control coral button label and icon components should comply with WCAG 2.1 AA contrast ratio requirements with a contrast ratio between the foreground text color and the background color or at least 4.5:1.

Actual Behavior:

Currently, Coral-Spectrum uses var(--spectrum-global-color-gray-500); from Spectrum-CSS, for the ::coral label text and coral icon components, which results in contrast ratio less that 4.5:1, which does not comply with WCAG 2.1 AA contrast ratio requirements.

A simpler suggested fix would be to change the value in Coral-Spectrum to use var(--spectrum-global-color-gray-700); to satisfy the requirement.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
