### PR TITLE
fix : [Performance] coral-dialog takes time to load 

### DIFF
--- a/coral-base-component/src/scripts/BaseComponent.js
+++ b/coral-base-component/src/scripts/BaseComponent.js
@@ -303,13 +303,13 @@ const getConstructorName = function (constructor) {
 };
 
 /**
-  This will recursively change the ignoreConnectedCallback
-  value for coral-components, since a parent has ignored
-  the callback all its items should ignore the callback hooks
-  @ignore
+ * recursively update the _ignoreConnectedCallback value
+ * for children coral-component, if parent has ignored the callback
+ * its child should also ignore the callback hooks
+ * @private
  */
 const _recursiveIgnoreConnectedCallback = function(el, value) {
-  let children = el.children;
+  let children = Array.from(el.children);
   for (let i = 0; i < children.length; i++) {
     let child = children[i];
     // todo better check for coral-component

--- a/coral-base-component/src/scripts/BaseComponent.js
+++ b/coral-base-component/src/scripts/BaseComponent.js
@@ -824,12 +824,20 @@ const BaseComponent = (superClass) => class extends superClass {
   }
 
   /**
-   called when we need to re-initialise things, when
-   connected/disconnected callback are skipped.
-   @param connected, true when element connectedcallback is getting skipped, else false
+   called when we need to suspend state and properties, when
+   disconnected callback are skipped.
    @private
    */
-  _updateCallback(connected) {
+  _suspendCallback() {
+    // do nothing
+  }
+
+  /**
+   called when we need to re-initialise state and properties, when
+   connected callback are skipped.
+   @private
+   */
+  _resumeCallback() {
     // do nothing
   }
 

--- a/coral-component-accordion/src/scripts/Accordion.js
+++ b/coral-component-accordion/src/scripts/Accordion.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 import {SelectableCollection} from '../../../coral-collection';
 import {transform, validate, Keys} from '../../../coral-utils';
 
@@ -48,7 +49,7 @@ const CLASSNAME = '_coral-Accordion';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Accordion extends BaseComponent(HTMLElement) {
+const Accordion = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -467,6 +468,6 @@ class Accordion extends BaseComponent(HTMLElement) {
    @property {AccordionItem} detail.selection
    The newly selected item(s).
    */
-}
+});
 
 export default Accordion;

--- a/coral-component-accordion/src/scripts/AccordionItem.js
+++ b/coral-component-accordion/src/scripts/AccordionItem.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 import base from '../templates/base';
 import {commons, transform, validate} from '../../../coral-utils';
 import {Icon} from '../../../coral-component-icon';
@@ -24,7 +25,7 @@ const CLASSNAME = '_coral-Accordion-item';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class AccordionItem extends BaseComponent(HTMLElement) {
+const AccordionItem = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -267,6 +268,6 @@ class AccordionItem extends BaseComponent(HTMLElement) {
     // Defaults
     this.selected = this.selected;
   }
-}
+});
 
 export default AccordionItem;

--- a/coral-component-actionbar/src/scripts/ActionBar.js
+++ b/coral-component-actionbar/src/scripts/ActionBar.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 import '../../../coral-component-popover';
 import getFirstSelectableWrappedItem from './getFirstSelectableWrappedItem';
 import {commons} from '../../../coral-utils';
@@ -25,7 +26,7 @@ const CLASSNAME = '_coral-ActionBar';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ActionBar extends BaseComponent(HTMLElement) {
+const ActionBar = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -618,6 +619,6 @@ class ActionBar extends BaseComponent(HTMLElement) {
     // force one layout
     this._onLayout();
   }
-}
+});
 
 export default ActionBar;

--- a/coral-component-actionbar/src/scripts/ActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/ActionBarContainer.js
@@ -11,6 +11,7 @@
  */
 
 import {commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 import {BaseComponent} from '../../../coral-base-component';
 import BaseActionBarContainer from './BaseActionBarContainer';
 import '../../../coral-component-list';
@@ -44,7 +45,7 @@ const position = {
 
  @deprecated
  */
-class ActionBarContainer extends BaseActionBarContainer(BaseComponent(HTMLElement)) {
+const ActionBarContainer = Decorator(class extends BaseActionBarContainer(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -134,6 +135,6 @@ class ActionBarContainer extends BaseActionBarContainer(BaseComponent(HTMLElemen
 
     this._attachMoreButtonToContainer();
   }
-}
+});
 
 export default ActionBarContainer;

--- a/coral-component-actionbar/src/scripts/ActionBarItem.js
+++ b/coral-component-actionbar/src/scripts/ActionBarItem.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ActionBar-item';
 
@@ -21,7 +22,7 @@ const CLASSNAME = '_coral-ActionBar-item';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ActionBarItem extends BaseComponent(HTMLElement) {
+const ActionBarItem = Decorator(class extends BaseComponent(HTMLElement) {
   // @compat
   get content() {
     return this;
@@ -43,6 +44,6 @@ class ActionBarItem extends BaseComponent(HTMLElement) {
 
     this.classList.add(CLASSNAME);
   }
-}
+});
 
 export default ActionBarItem;

--- a/coral-component-actionbar/src/scripts/ActionBarPrimary.js
+++ b/coral-component-actionbar/src/scripts/ActionBarPrimary.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 import getFirstSelectableWrappedItem from './getFirstSelectableWrappedItem';
 import ActionBarContainer from './BaseActionBarContainer';
 
@@ -23,7 +24,7 @@ const CLASSNAME = '_coral-ActionBar-primary';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ActionBarPrimary extends ActionBarContainer(BaseComponent(HTMLElement)) {
+const ActionBarPrimary = Decorator(class extends ActionBarContainer(BaseComponent(HTMLElement)) {
   /** @ignore */
   _returnElementsFromPopover() {
     let item = null;
@@ -66,6 +67,6 @@ class ActionBarPrimary extends ActionBarContainer(BaseComponent(HTMLElement)) {
 
     this._attachMoreButtonToContainer();
   }
-}
+});
 
 export default ActionBarPrimary;

--- a/coral-component-actionbar/src/scripts/ActionBarSecondary.js
+++ b/coral-component-actionbar/src/scripts/ActionBarSecondary.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 import getFirstSelectableWrappedItem from './getFirstSelectableWrappedItem';
 import ActionBarContainer from './BaseActionBarContainer';
 
@@ -23,7 +24,7 @@ const CLASSNAME = '_coral-ActionBar-secondary';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ActionBarSecondary extends ActionBarContainer(BaseComponent(HTMLElement)) {
+const ActionBarSecondary = Decorator(class extends ActionBarContainer(BaseComponent(HTMLElement)) {
   /** @ignore */
   _returnElementsFromPopover() {
     let item = null;
@@ -65,6 +66,6 @@ class ActionBarSecondary extends ActionBarContainer(BaseComponent(HTMLElement)) 
 
     this._attachMoreButtonToContainer();
   }
-}
+});
 
 export default ActionBarSecondary;

--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -17,6 +17,7 @@ import moreOverlay from '../templates/moreOverlay';
 import moreButton from '../templates/moreButton';
 import overlayContent from '../templates/overlayContent';
 import {commons, transform, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 // Matches private Coral classes in class attribute
 const REG_EXP = /_coral([^\s]+)/g;

--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -17,7 +17,6 @@ import moreOverlay from '../templates/moreOverlay';
 import moreButton from '../templates/moreButton';
 import overlayContent from '../templates/overlayContent';
 import {commons, transform, i18n} from '../../../coral-utils';
-import {Decorator} from '../../../coral-decorator';
 
 // Matches private Coral classes in class attribute
 const REG_EXP = /_coral([^\s]+)/g;

--- a/coral-component-alert/src/scripts/Alert.js
+++ b/coral-component-alert/src/scripts/Alert.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {Icon} from '../../../coral-component-icon';
 import {transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Alert} variants.
@@ -73,7 +74,7 @@ const capitalize = s => s.charAt(0).toUpperCase() + s.slice(1);
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Alert extends BaseComponent(HTMLElement) {
+const Alert = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -314,6 +315,6 @@ class Alert extends BaseComponent(HTMLElement) {
       this[contentZoneName] = this._elements[contentZoneName];
     }
   }
-}
+});
 
 export default Alert;

--- a/coral-component-anchorbutton/src/scripts/AnchorButton.js
+++ b/coral-component-anchorbutton/src/scripts/AnchorButton.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseButton} from '../../../coral-base-button';
 import {transform, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 // Key code
 const SPACE = 32;
@@ -29,7 +30,7 @@ const SPACE = 32;
  @extends {BaseComponent}
  @extends {BaseButton}
  */
-class AnchorButton extends BaseButton(BaseComponent(HTMLAnchorElement)) {
+const AnchorButton = Decorator(class extends BaseButton(BaseComponent(HTMLAnchorElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -116,6 +117,6 @@ class AnchorButton extends BaseButton(BaseComponent(HTMLAnchorElement)) {
       this.removeAttribute('aria-disabled');
     }
   }
-}
+});
 
 export default AnchorButton;

--- a/coral-component-autocomplete/src/scripts/Autocomplete.js
+++ b/coral-component-autocomplete/src/scripts/Autocomplete.js
@@ -24,6 +24,7 @@ import '../../../coral-component-wait';
 import base from '../templates/base';
 import loadIndicator from '../templates/loadIndicator';
 import {transform, validate, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Autocomplete';
 
@@ -80,7 +81,7 @@ const match = {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
+const Autocomplete = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -1995,6 +1996,6 @@ class Autocomplete extends BaseFormField(BaseComponent(HTMLElement)) {
 
    @typedef {CustomEvent} coral-autocomplete:hidesuggestions
    */
-}
+});
 
 export default Autocomplete;

--- a/coral-component-autocomplete/src/scripts/AutocompleteItem.js
+++ b/coral-component-autocomplete/src/scripts/AutocompleteItem.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.Autocomplete.Item
@@ -20,7 +21,7 @@ import {transform} from '../../../coral-utils';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class AutocompleteItem extends BaseComponent(HTMLElement) {
+const AutocompleteItem = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -129,6 +130,6 @@ class AutocompleteItem extends BaseComponent(HTMLElement) {
   static get observedAttributes() {
     return super.observedAttributes.concat(['selected', 'disabled', 'value']);
   }
-}
+});
 
 export default AutocompleteItem;

--- a/coral-component-banner/src/scripts/Banner.js
+++ b/coral-component-banner/src/scripts/Banner.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Banner';
 
@@ -46,7 +47,7 @@ for (const variantValue in variant) {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Banner extends BaseComponent(HTMLElement) {
+const Banner = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -177,6 +178,6 @@ class Banner extends BaseComponent(HTMLElement) {
     this.header = this._elements.header;
     this.content = this._elements.content;
   }
-}
+});
 
 export default Banner;

--- a/coral-component-button/src/scripts/Button.js
+++ b/coral-component-button/src/scripts/Button.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseButton} from '../../../coral-base-button';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.Button
@@ -22,7 +23,7 @@ import {BaseButton} from '../../../coral-base-button';
  @extends {BaseComponent}
  @extends {BaseButton}
  */
-class Button extends BaseButton(BaseComponent(HTMLButtonElement)) {
+const Button = Decorator(class extends BaseButton(BaseComponent(HTMLButtonElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -30,6 +31,6 @@ class Button extends BaseButton(BaseComponent(HTMLButtonElement)) {
     // Events
     this._delegateEvents(this._events);
   }
-}
+});
 
 export default Button;

--- a/coral-component-buttongroup/src/scripts/ButtonGroup.js
+++ b/coral-component-buttongroup/src/scripts/ButtonGroup.js
@@ -16,6 +16,7 @@ import {Button} from '../../../coral-component-button';
 import {SelectableCollection} from '../../../coral-collection';
 import base from '../templates/base';
 import {transform, validate, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link ButtonGroup} selection options.
@@ -61,7 +62,7 @@ const CLASSNAME = '_coral-ButtonGroup';
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class ButtonGroup extends BaseFormField(BaseComponent(HTMLElement)) {
+const ButtonGroup = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -889,6 +890,6 @@ class ButtonGroup extends BaseFormField(BaseComponent(HTMLElement)) {
     // Call onItemAdded and onCollectionChange on the existing items
     this.items._startHandlingItems();
   }
-}
+});
 
 export default ButtonGroup;

--- a/coral-component-calendar/src/scripts/Calendar.js
+++ b/coral-component-calendar/src/scripts/Calendar.js
@@ -19,6 +19,7 @@ import calendar from '../templates/calendar';
 import container from '../templates/container';
 import table from '../templates/table';
 import {transform, commons, i18n, Keys} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /** @ignore */
 function isDateInRange(date, startDate, endDate) {
@@ -180,7 +181,7 @@ const CLASSNAME = '_coral-Calendar';
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
+const Calendar = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -1104,6 +1105,6 @@ class Calendar extends BaseFormField(BaseComponent(HTMLElement)) {
       this._renderCalendar();
     }
   }
-}
+});
 
 export default Calendar;

--- a/coral-component-card/src/scripts/Card.js
+++ b/coral-component-card/src/scripts/Card.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import base from '../templates/base';
 import {commons, transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const COLOR_HINT_REG_EXP = /^#[0-9A-F]{6}$/i;
 
@@ -57,7 +58,7 @@ for (const variantValue in variant) {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Card extends BaseComponent(HTMLElement) {
+const Card = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -421,6 +422,6 @@ class Card extends BaseComponent(HTMLElement) {
       this.classList.toggle(`${CLASSNAME}--overflow`, this.info.childNodes.length && this.info.scrollHeight > this.clientHeight);
     });
   }
-}
+});
 
 export default Card;

--- a/coral-component-card/src/scripts/CardProperty.js
+++ b/coral-component-card/src/scripts/CardProperty.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import {commons} from '../../../coral-utils';
 import '../../../coral-component-icon';
 import icon from '../templates/icon';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Card-property';
 
@@ -24,7 +25,7 @@ const CLASSNAME = '_coral-Card-property';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class CardProperty extends BaseComponent(HTMLElement) {
+const CardProperty = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -163,6 +164,6 @@ class CardProperty extends BaseComponent(HTMLElement) {
     // Assign the content zones, moving them into place in the process
     this.content = content;
   }
-}
+});
 
 export default CardProperty;

--- a/coral-component-card/src/scripts/CardPropertyList.js
+++ b/coral-component-card/src/scripts/CardPropertyList.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.Card.PropertyList
@@ -19,7 +20,7 @@ import {BaseComponent} from '../../../coral-base-component';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class CardPropertyList extends BaseComponent(HTMLElement) {
+const CardPropertyList = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   render() {
     super.render();
@@ -31,6 +32,6 @@ class CardPropertyList extends BaseComponent(HTMLElement) {
       this.textContent = '';
     }
   }
-}
+});
 
 export default CardPropertyList;

--- a/coral-component-charactercount/src/scripts/CharacterCount.js
+++ b/coral-component-charactercount/src/scripts/CharacterCount.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {commons, transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-CharacterCount';
 
@@ -37,7 +38,7 @@ const target = {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class CharacterCount extends BaseComponent(HTMLElement) {
+const CharacterCount = Decorator(class extends BaseComponent(HTMLElement) {
   /**
    The target Textfield or Textarea for this component. It accepts values from {@link CharacterCountTargetEnum},
    as well as any DOM element or CSS selector.
@@ -154,6 +155,6 @@ class CharacterCount extends BaseComponent(HTMLElement) {
     // Refresh once connected
     this._refreshCharCount();
   }
-}
+});
 
 export default CharacterCount;

--- a/coral-component-checkbox/src/scripts/Checkbox.js
+++ b/coral-component-checkbox/src/scripts/Checkbox.js
@@ -15,6 +15,7 @@ import {BaseFormField} from '../../../coral-base-formfield';
 import {Icon} from '../../../coral-component-icon';
 import base from '../templates/base';
 import {transform, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const IS_IE_OR_EDGE = navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0 ||
   window.navigator.userAgent.indexOf('Edge') !== -1;
@@ -29,7 +30,7 @@ const CLASSNAME = '_coral-Checkbox';
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Checkbox extends BaseFormField(BaseComponent(HTMLElement)) {
+const Checkbox = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -419,6 +420,6 @@ class Checkbox extends BaseFormField(BaseComponent(HTMLElement)) {
     // We must do this because IE does not catch mutations when nodes are not in the DOM
     this._hideLabelIfEmpty();
   }
-}
+});
 
 export default Checkbox;

--- a/coral-component-checkboxgroup/src/scripts/CheckboxGroup.js
+++ b/coral-component-checkboxgroup/src/scripts/CheckboxGroup.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseFieldGroup} from '../../../coral-base-fieldgroup';
 import '../../../coral-component-checkbox';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.CheckboxGroup
@@ -22,7 +23,7 @@ import '../../../coral-component-checkbox';
  @extends {BaseComponent}
  @extends {BaseFieldGroup}
  */
-class CheckboxGroup extends BaseFieldGroup(BaseComponent(HTMLElement)) {
+const CheckboxGroup = Decorator(class extends BaseFieldGroup(BaseComponent(HTMLElement)) {
   /** @private */
   get _itemTagName() {
     // Used for Collection
@@ -38,6 +39,6 @@ class CheckboxGroup extends BaseFieldGroup(BaseComponent(HTMLElement)) {
   get selectedItems() {
     return this.items._getAllSelected('checked');
   }
-}
+});
 
 export default CheckboxGroup;

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -17,6 +17,7 @@ import '../../../coral-component-textfield';
 import '../../../coral-component-select';
 import base from '../templates/base';
 import {transform, commons, validate, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 // Default for display and value format
 const DEFAULT_HOUR_FORMAT = 'HH';
@@ -62,7 +63,7 @@ for (const variantValue in variant) {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Clock extends BaseFormField(BaseComponent(HTMLElement)) {
+const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -568,6 +569,6 @@ class Clock extends BaseFormField(BaseComponent(HTMLElement)) {
 
     this._syncDisplay();
   }
-}
+});
 
 export default Clock;

--- a/coral-component-coachmark/src/scripts/CoachMark.js
+++ b/coral-component-coachmark/src/scripts/CoachMark.js
@@ -16,6 +16,7 @@ import {Overlay} from '../../../coral-component-overlay';
 import '../../../coral-component-popover';
 import PopperJS from 'popper.js';
 import {transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link CoachMark} sizes.
@@ -59,7 +60,7 @@ const CLASSNAME = '_coral-CoachMarkIndicator';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class CoachMark extends BaseComponent(HTMLElement) {
+const CoachMark = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -208,6 +209,6 @@ class CoachMark extends BaseComponent(HTMLElement) {
     // Render template
     this.appendChild(this._template);
   }
-}
+});
 
 export default CoachMark;

--- a/coral-component-colorinput/src/scripts/ColorInput.js
+++ b/coral-component-colorinput/src/scripts/ColorInput.js
@@ -23,6 +23,7 @@ import './ColorInputColorProperties';
 import './ColorInputSwatches';
 import base from '../templates/base';
 import {validate, transform, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ColorInput';
 
@@ -112,7 +113,7 @@ const showDefaultColors = {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
+const ColorInput = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -961,6 +962,6 @@ class ColorInput extends BaseFormField(BaseComponent(HTMLElement)) {
       overlay.remove();
     }
   }
-}
+});
 
 export default ColorInput;

--- a/coral-component-colorinput/src/scripts/ColorInputColorProperties.js
+++ b/coral-component-colorinput/src/scripts/ColorInputColorProperties.js
@@ -18,6 +18,7 @@ import '../../../coral-component-textfield';
 import './ColorInputSlider';
 import propertiesSubview from '../templates/colorProperties';
 import {commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ColorInput-colorProperties';
 
@@ -29,7 +30,7 @@ const CLASSNAME = '_coral-ColorInput-colorProperties';
  @extends {BaseComponent}
  @extends {BaseColorInputAbstractSubview}
  */
-class ColorInputColorProperties extends BaseColorInputAbstractSubview(BaseComponent(HTMLElement)) {
+const ColorInputColorProperties = Decorator(class extends BaseColorInputAbstractSubview(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -219,6 +220,6 @@ class ColorInputColorProperties extends BaseColorInputAbstractSubview(BaseCompon
 
     this.appendChild(this._elements.propertiesSubview);
   }
-}
+});
 
 export default ColorInputColorProperties;

--- a/coral-component-colorinput/src/scripts/ColorInputItem.js
+++ b/coral-component-colorinput/src/scripts/ColorInputItem.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import Color from './Color';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.ColorInput.Item
@@ -21,7 +22,7 @@ import {transform} from '../../../coral-utils';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ColorInputItem extends BaseComponent(HTMLElement) {
+const ColorInputItem = Decorator(class extends BaseComponent(HTMLElement) {
   /**
    The value of the color. This value can be set in different formats (HEX, RGB, RGBA, HSB, HSL, HSLA and CMYK).
    Corrects a hex value, if it is represented by 3 or 6 characters with or without '#'.
@@ -89,6 +90,6 @@ class ColorInputItem extends BaseComponent(HTMLElement) {
     // adds the role to support accessibility
     this.setAttribute('role', 'option');
   }
-}
+});
 
 export default ColorInputItem;

--- a/coral-component-colorinput/src/scripts/ColorInputSlider.js
+++ b/coral-component-colorinput/src/scripts/ColorInputSlider.js
@@ -14,6 +14,7 @@ import {ExtensibleSlider, Slider} from '../../../coral-component-slider';
 import '../../../coral-component-tooltip';
 import sliderBase from '../templates/sliderBase';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAMES = ['_coral-ColorInput-slider', '_coral-Slider--color'];
 
@@ -23,7 +24,7 @@ const CLASSNAMES = ['_coral-ColorInput-slider', '_coral-Slider--color'];
  @htmltag coral-colorinput-slider
  @extends {Slider}
  */
-class ColorInputSlider extends ExtensibleSlider {
+const ColorInputSlider = Decorator(class extends ExtensibleSlider {
   /**
    The gradient shown as slider background as space separated values (at least 2 values needed).
    e.g: #ff0000 #ffff00 #00ff00 #00ffff #0000ff #ff00ff #ff0000
@@ -97,6 +98,6 @@ class ColorInputSlider extends ExtensibleSlider {
 
     this.classList.add(...CLASSNAMES);
   }
-}
+});
 
 export default ColorInputSlider;

--- a/coral-component-colorinput/src/scripts/ColorInputSwatch.js
+++ b/coral-component-colorinput/src/scripts/ColorInputSwatch.js
@@ -16,6 +16,7 @@ import Color from './Color';
 import '../../../coral-component-button';
 import colorButton from '../templates/colorButton';
 import {commons, i18n, transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ColorInput-swatch';
 
@@ -27,7 +28,7 @@ const CLASSNAME = '_coral-ColorInput-swatch';
  @extends {BaseComponent}
  @extends {BaseColorInputAbstractSubview}
  */
-class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLElement)) {
+const ColorInputSwatch = Decorator(class extends BaseColorInputAbstractSubview(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -193,6 +194,6 @@ class ColorInputSwatch extends BaseColorInputAbstractSubview(BaseComponent(HTMLE
 
     this.appendChild(this._elements.colorButton);
   }
-}
+});
 
 export default ColorInputSwatch;

--- a/coral-component-colorinput/src/scripts/ColorInputSwatches.js
+++ b/coral-component-colorinput/src/scripts/ColorInputSwatches.js
@@ -17,6 +17,7 @@ import Color from './Color';
 import {SelectableCollection} from '../../../coral-collection';
 import swatchesHeader from '../templates/swatchesHeader';
 import {commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ColorInput-swatches';
 
@@ -28,7 +29,7 @@ const CLASSNAME = '_coral-ColorInput-swatches';
  @extends {BaseComponent}
  @extends {BaseColorInputAbstractSubview}
  */
-class ColorInputSwatches extends BaseColorInputAbstractSubview(BaseComponent(HTMLElement)) {
+const ColorInputSwatches = Decorator(class extends BaseColorInputAbstractSubview(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -335,6 +336,6 @@ class ColorInputSwatches extends BaseColorInputAbstractSubview(BaseComponent(HTM
 
     this._oldSelection = this.selectedItem;
   }
-}
+});
 
 export default ColorInputSwatches;

--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -16,6 +16,7 @@ import ColumnViewCollection from './ColumnViewCollection';
 import isInteractiveTarget from './isInteractiveTarget';
 import selectionMode from './selectionMode';
 import {transform, validate, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-MillerColumns';
 
@@ -50,7 +51,7 @@ const scrollTo = (element, to, duration, scrollCallback) => {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ColumnView extends BaseComponent(HTMLElement) {
+const ColumnView = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -1396,6 +1397,6 @@ class ColumnView extends BaseComponent(HTMLElement) {
    @property {ColumnViewItem} detail.activeItem
    The currently active item of the ColumnView.
    */
-}
+});
 
 export default ColumnView;

--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -15,6 +15,7 @@ import ColumnViewCollection from './ColumnViewCollection';
 import isInteractiveTarget from './isInteractiveTarget';
 import selectionMode from './selectionMode';
 import {commons, transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-MillerColumns-item';
 
@@ -37,7 +38,7 @@ window.addEventListener('load', () => {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ColumnViewColumn extends BaseComponent(HTMLElement) {
+const ColumnViewColumn = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -610,6 +611,6 @@ class ColumnViewColumn extends BaseComponent(HTMLElement) {
       });
     }
   }
-}
+});
 
 export default ColumnViewColumn;

--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -16,6 +16,7 @@ import {BaseLabellable} from '../../../coral-base-labellable';
 import {Icon} from '../../../coral-component-icon';
 import {Checkbox} from '../../../coral-component-checkbox';
 import {commons, i18n, transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-AssetList-item';
 
@@ -46,7 +47,7 @@ const isChromeMacOS = !!window && !!window.chrome && /Mac/i.test(window.navigato
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
+const ColumnViewItem = Decorator(class extends BaseLabellable(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -420,6 +421,6 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
     //adding html title, on hovering over textcontent title will be visible
     this.setAttribute('title', this.content.textContent.trim());
   }
-}
+});
 
 export default ColumnViewItem;

--- a/coral-component-columnview/src/scripts/ColumnViewPreview.js
+++ b/coral-component-columnview/src/scripts/ColumnViewPreview.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-MillerColumns-item';
 
@@ -22,7 +23,7 @@ const CLASSNAME = '_coral-MillerColumns-item';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ColumnViewPreview extends BaseComponent(HTMLElement) {
+const ColumnViewPreview = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -134,6 +135,6 @@ class ColumnViewPreview extends BaseComponent(HTMLElement) {
       element.setAttribute('alt', '');
     }
   }
-}
+});
 
 export default ColumnViewPreview;

--- a/coral-component-cyclebutton/src/scripts/CycleButton.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButton.js
@@ -19,6 +19,7 @@ import {ButtonList, SelectList} from '../../../coral-component-list';
 import {SelectableCollection} from '../../../coral-collection';
 import base from '../templates/base';
 import {transform, validate, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link CycleButton} display options.
@@ -58,7 +59,7 @@ const CLASSNAME = '_coral-CycleSelect';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class CycleButton extends BaseComponent(HTMLElement) {
+const CycleButton = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -902,6 +903,6 @@ class CycleButton extends BaseComponent(HTMLElement) {
    @property {CycleButtonItem} detail.selection
    The newly selected item(s).
    */
-}
+});
 
 export default CycleButton;

--- a/coral-component-cyclebutton/src/scripts/CycleButtonAction.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButtonAction.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.CycleButton.Action
@@ -20,7 +21,7 @@ import {transform} from '../../../coral-utils';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class CycleButtonAction extends BaseComponent(HTMLElement) {
+const CycleButtonAction = Decorator(class extends BaseComponent(HTMLElement) {
   /**
    The Action's icon. See {@link Coral.Icon} for valid icon names.
 
@@ -80,6 +81,6 @@ class CycleButtonAction extends BaseComponent(HTMLElement) {
     this.setAttribute('role', 'menuitem');
     this.tabIndex = -1;
   }
-}
+});
 
 export default CycleButtonAction;

--- a/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButtonItem.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {commons, transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enum for {CycleButtonItem} display options.
@@ -41,7 +42,7 @@ const displayMode = {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class CycleButtonItem extends BaseComponent(HTMLElement) {
+const CycleButtonItem = Decorator(class extends BaseComponent(HTMLElement) {
   /**
    The Item's icon. See {@link Coral.Icon} for valid icon names.
 
@@ -216,6 +217,6 @@ class CycleButtonItem extends BaseComponent(HTMLElement) {
       this.displayMode = displayMode.INHERIT;
     }
   }
-}
+});
 
 export default CycleButtonItem;

--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -21,6 +21,7 @@ import '../../../coral-component-textfield';
 import base from '../templates/base';
 import overlayContent from '../templates/overlayContent';
 import {transform, commons, validate, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enum for {@link Datepicker} variant values.
@@ -105,7 +106,7 @@ const isNativeFormat = (format) => {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
+const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -874,6 +875,6 @@ class Datepicker extends BaseFormField(BaseComponent(HTMLElement)) {
       overlay.remove();
     }
   }
-}
+});
 
 export default Datepicker;

--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -17,6 +17,7 @@ import {Icon} from '../../../coral-component-icon';
 import '../../../coral-component-button';
 import base from '../templates/base';
 import {commons, transform, validate, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Dialog} closable options.
@@ -116,7 +117,7 @@ for (const variantValue in variant) {
  @extends {BaseComponent}
  @extends {BaseOverlay}
  */
-class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
+const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -796,6 +797,6 @@ class Dialog extends BaseOverlay(BaseComponent(HTMLElement)) {
     this.footer = footer;
     this.content = content;
   }
-}
+});
 
 export default Dialog;

--- a/coral-component-drawer/src/scripts/Drawer.js
+++ b/coral-component-drawer/src/scripts/Drawer.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import '../../../coral-component-button';
 import base from '../templates/base';
 import {commons, transform, validate, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Drawer} directions.
@@ -46,7 +47,7 @@ for (const directionValue in direction) {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Drawer extends BaseComponent(HTMLElement) {
+const Drawer = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -271,6 +272,6 @@ class Drawer extends BaseComponent(HTMLElement) {
 
    @typedef {CustomEvent} coral-drawer:close
    */
-}
+});
 
 export default Drawer;

--- a/coral-component-fileupload/src/scripts/FileUpload.js
+++ b/coral-component-fileupload/src/scripts/FileUpload.js
@@ -15,6 +15,7 @@ import {BaseFormField} from '../../../coral-base-formfield';
 import FileUploadItem from './FileUploadItem';
 import base from '../templates/base';
 import {transform, commons, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-FileUpload';
 
@@ -56,7 +57,7 @@ const method = {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class FileUpload extends BaseFormField(BaseComponent(HTMLElement)) {
+const FileUpload = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -1091,6 +1092,6 @@ class FileUpload extends BaseFormField(BaseComponent(HTMLElement)) {
       commons.addResizeListener(this, this._positionInputOnDropZone);
     });
   }
-}
+});
 
 export default FileUpload;

--- a/coral-component-icon/src/scripts/Icon.js
+++ b/coral-component-icon/src/scripts/Icon.js
@@ -17,7 +17,7 @@ import SPECTRUM_ICONS_PATH from '../resources/spectrum-icons.svg';
 import SPECTRUM_ICONS_COLOR_PATH from '../resources/spectrum-icons-color.svg';
 import SPECTRUM_CSS_ICONS_PATH from '../resources/spectrum-css-icons.svg';
 import loadIcons from './loadIcons';
-
+import {Decorator} from '../../../coral-decorator';
 import {SPECTRUM_ICONS, SPECTRUM_ICONS_COLOR, SPECTRUM_CSS_ICONS} from './iconCollection';
 
 const SPECTRUM_ICONS_IDENTIFIER = 'spectrum-';
@@ -175,7 +175,7 @@ const sizeMap = {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Icon extends BaseComponent(HTMLElement) {
+const Icon = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -557,7 +557,7 @@ class Icon extends BaseComponent(HTMLElement) {
       this._hasRawImage = false;
     }
   }
-}
+});
 
 // Load icon collections by default
 const iconCollections = [SPECTRUM_ICONS_COLOR];

--- a/coral-component-list/src/scripts/AnchorList.js
+++ b/coral-component-list/src/scripts/AnchorList.js
@@ -13,6 +13,7 @@
 import {commons} from '../../../coral-utils';
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseList} from '../../../coral-base-list';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-AnchorList';
 
@@ -24,7 +25,7 @@ const CLASSNAME = '_coral-AnchorList';
  @extends {BaseComponent}
  @extends {BaseList}
  */
-class AnchorList extends BaseList(BaseComponent(HTMLElement)) {
+const AnchorList = Decorator(class extends BaseList(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -57,6 +58,6 @@ class AnchorList extends BaseList(BaseComponent(HTMLElement)) {
 
     this.classList.add(CLASSNAME);
   }
-}
+});
 
 export default AnchorList;

--- a/coral-component-list/src/scripts/AnchorListItem.js
+++ b/coral-component-list/src/scripts/AnchorListItem.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseListItem} from '../../../coral-base-list';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-AnchorList-item';
 
@@ -23,7 +24,7 @@ const CLASSNAME = '_coral-AnchorList-item';
  @extends {BaseComponent}
  @extends {BaseListItem}
  */
-class AnchorListItem extends BaseListItem(BaseComponent(HTMLAnchorElement)) {
+const AnchorListItem = Decorator(class extends BaseListItem(BaseComponent(HTMLAnchorElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -85,6 +86,6 @@ class AnchorListItem extends BaseListItem(BaseComponent(HTMLAnchorElement)) {
 
     this.classList.add(CLASSNAME);
   }
-}
+});
 
 export default AnchorListItem;

--- a/coral-component-list/src/scripts/ButtonList.js
+++ b/coral-component-list/src/scripts/ButtonList.js
@@ -13,6 +13,7 @@
 import {commons} from '../../../coral-utils';
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseList} from '../../../coral-base-list';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ButtonList';
 
@@ -24,7 +25,7 @@ const CLASSNAME = '_coral-ButtonList';
  @extends {BaseComponent}
  @extends {BaseList}
  */
-class ButtonList extends BaseList(BaseComponent(HTMLElement)) {
+const ButtonList = Decorator(class extends BaseList(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -57,6 +58,6 @@ class ButtonList extends BaseList(BaseComponent(HTMLElement)) {
 
     this.classList.add(CLASSNAME);
   }
-}
+});
 
 export default ButtonList;

--- a/coral-component-list/src/scripts/ButtonListItem.js
+++ b/coral-component-list/src/scripts/ButtonListItem.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseListItem} from '../../../coral-base-list';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ButtonList-item';
 
@@ -23,7 +24,7 @@ const CLASSNAME = '_coral-ButtonList-item';
  @extends {BaseComponent}
  @extends {BaseListItem}
  */
-class ButtonListItem extends BaseListItem(BaseComponent(HTMLButtonElement)) {
+const ButtonListItem = Decorator(class extends BaseListItem(BaseComponent(HTMLButtonElement)) {
   /**
    Inherited from {@link BaseComponent#trackingElement}.
    */
@@ -44,6 +45,6 @@ class ButtonListItem extends BaseListItem(BaseComponent(HTMLButtonElement)) {
 
     this.classList.add(CLASSNAME);
   }
-}
+});
 
 export default ButtonListItem;

--- a/coral-component-list/src/scripts/List.js
+++ b/coral-component-list/src/scripts/List.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseList} from '../../../coral-base-list';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.List
@@ -21,7 +22,7 @@ import {BaseList} from '../../../coral-base-list';
  @extends {BaseComponent}
  @extends {BaseList}
  */
-class List extends BaseList(BaseComponent(HTMLElement)) {
+const List = Decorator(class extends BaseList(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -29,6 +30,6 @@ class List extends BaseList(BaseComponent(HTMLElement)) {
     // Events
     this._delegateEvents(this._events);
   }
-}
+});
 
 export default List;

--- a/coral-component-list/src/scripts/ListDivider.js
+++ b/coral-component-list/src/scripts/ListDivider.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Menu-divider';
 
@@ -21,7 +22,7 @@ const CLASSNAME = '_coral-Menu-divider';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class ListDivider extends BaseComponent(HTMLElement) {
+const ListDivider = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   render() {
     super.render();
@@ -31,6 +32,6 @@ class ListDivider extends BaseComponent(HTMLElement) {
     // a11y
     this.setAttribute('role', 'separator');
   }
-}
+});
 
 export default ListDivider;

--- a/coral-component-list/src/scripts/ListItem.js
+++ b/coral-component-list/src/scripts/ListItem.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseListItem} from '../../../coral-base-list';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.List.Item
@@ -21,7 +22,7 @@ import {BaseListItem} from '../../../coral-base-list';
  @extends {BaseComponent}
  @extends {BaseListItem}
  */
-class ListItem extends BaseListItem(BaseComponent(HTMLElement)) {
+const ListItem = Decorator(class extends BaseListItem(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -29,6 +30,6 @@ class ListItem extends BaseListItem(BaseComponent(HTMLElement)) {
     // Events
     this._delegateEvents(this._events);
   }
-}
+});
 
 export default ListItem;

--- a/coral-component-list/src/scripts/SelectList.js
+++ b/coral-component-list/src/scripts/SelectList.js
@@ -15,6 +15,7 @@ import {SelectableCollection} from '../../../coral-collection';
 import '../../../coral-component-wait';
 import loadIndicator from '../templates/loadIndicator';
 import {transform, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const KEYPRESS_TIMEOUT_DURATION = 1000;
 
@@ -51,7 +52,7 @@ const CLASSNAME = '_coral-Menu';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SelectList extends BaseComponent(HTMLElement) {
+const SelectList = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -566,6 +567,6 @@ class SelectList extends BaseComponent(HTMLElement) {
    @property {SelectListItem} detail.selection
    The newly selected item(s).
    */
-}
+});
 
 export default SelectList;

--- a/coral-component-list/src/scripts/SelectListGroup.js
+++ b/coral-component-list/src/scripts/SelectListGroup.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {SelectableCollection} from '../../../coral-collection';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-SelectList-group';
 
@@ -23,7 +24,7 @@ const CLASSNAME = '_coral-SelectList-group';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SelectListGroup extends BaseComponent(HTMLElement) {
+const SelectListGroup = Decorator(class extends BaseComponent(HTMLElement) {
   /**
    The label of the group. It reflects the <code>label</code> attribute to the DOM.
 
@@ -73,6 +74,6 @@ class SelectListGroup extends BaseComponent(HTMLElement) {
 
     this.setAttribute('role', 'group');
   }
-}
+});
 
 export default SelectListGroup;

--- a/coral-component-list/src/scripts/SelectListItem.js
+++ b/coral-component-list/src/scripts/SelectListItem.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import {transform} from '../../../coral-utils';
 import {Icon} from '../../../coral-component-icon';
 import checkIcon from '../templates/checkIcon';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Menu-item';
 
@@ -36,7 +37,7 @@ const VALID_ARIA_SELECTED_ROLES_REGEXP = new RegExp(`^(${VALID_ARIA_SELECTED_ROL
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SelectListItem extends BaseComponent(HTMLElement) {
+const SelectListItem = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -245,6 +246,6 @@ class SelectListItem extends BaseComponent(HTMLElement) {
     // Assign the content zones, moving them into place in the process
     this.content = content;
   }
-}
+});
 
 export default SelectListItem;

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -626,8 +626,6 @@ const Masonry = Decorator(class extends BaseComponent(HTMLElement) {
         // Skip layout if a layout was forced in between
         if (this._layoutScheduled) {
           this._doLayout();
-          // Cancel potentially scheduled layout if the current layout was enforced by calling doLayout directly
-          this._layoutScheduled = false;
         }
       });
 

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -736,7 +736,8 @@ const Masonry = Decorator(class extends BaseComponent(HTMLElement) {
     // Update items, so that column indexes are correctly set
     this._updateAriaRoleForItems(this.ariaGrid);
     this._updateAriaColumnCountForParent(this.ariaGrid);
-
+    // set to false in case forced layouting is done between animation call
+    this._layoutScheduled = false;
     // Prevent endless observation loop (skip mutations which have been caused by the layout)
     this._observer.takeRecords();
   }

--- a/coral-component-masonry/src/scripts/MasonryItem.js
+++ b/coral-component-masonry/src/scripts/MasonryItem.js
@@ -75,7 +75,7 @@ const MasonryItem = Decorator(class extends BaseComponent(HTMLElement) {
   }
 
   set showRemoveTransition(value) {
-    this._showRemoveTransition = transform.booleanAttr(value);
+    this._showRemoveTransition = transform.boolean(value);
   }
 
 
@@ -195,7 +195,7 @@ const MasonryItem = Decorator(class extends BaseComponent(HTMLElement) {
     super._resumeCallback();
     // In case an already connected element is switched to new parent,
     // we would be ignoring the connected callback,
-    // as the item will be connected to new parent and new parent should be informed immediately
+    // as the item will be connected to new parent, the new parent should be informed immediately
     this._messenger.postMessage('coral-masonry-item:_connected');
   }
 

--- a/coral-component-masonry/src/tests/test.Masonry.Item.js
+++ b/coral-component-masonry/src/tests/test.Masonry.Item.js
@@ -158,16 +158,20 @@ describe('Masonry.Item', function () {
         expect(spy.calledOnce).to.be.true;
 
         const spy1 = sinon.spy(item1._messenger, 'postMessage').withArgs('coral-masonry-item:_connected');
-        const spy2 = sinon.spy(item1, '_updateCallback');
+        const suspendSpy1 = sinon.spy(item1, '_suspendCallback');
+        const resumeSpy1 = sinon.spy(item1, '_resumeCallback');
+
         item1._ignoreConnectedCallback = true;
         masonry.appendChild(item1);
         item1._ignoreConnectedCallback = false;
+
         expect(spy1.calledOnce).to.be.true;
-        // updateCallback should be called more than once
-        expect(spy2.called).to.be.true;
+        expect(suspendSpy1.calledOnce).to.be.true;
+        expect(resumeSpy1.calledOnce).to.be.true;
 
         const spy3 = sinon.spy(item2._messenger, 'postMessage').withArgs('coral-masonry-item:_connected');
-        const spy4 = sinon.spy(item2, '_updateCallback');
+        const suspendSpy3 = sinon.spy(item2, '_suspendCallback');
+        const resumeSpy3 = sinon.spy(item2, '_resumeCallback');
 
         const spy5 = sinon.spy(newItem, 'connectedCallback');
         newItem.showRemoveTransition = false;
@@ -186,18 +190,12 @@ describe('Masonry.Item', function () {
           helpers.next(function() {
             // because of showing transition element is connected again
             expect(spy3.calledOnce).to.be.true;
-            expect(spy4.called).to.be.true;
+            expect(resumeSpy3.calledOnce).to.be.true;
+            // suspend will not execute b/c trying to remove a disconnected element.
+            expect(suspendSpy3.called).to.be.false;
+
             expect(item2._disconnected).to.be.true;
             expect(item2._masonry).to.be.null;
-
-            spy3.resetHistory();
-            spy4.resetHistory();
-            // assume item is in connected state.
-            item2._disconnected = false;
-            masonry.appendChild(item2);
-
-            expect(spy3.calledOnce).to.be.true;
-            expect(spy4.calledOnce).to.be.true;
             done();
           });
         });

--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -9,11 +9,11 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
+import '../../../coral-component-textfield';
 import {BaseComponent} from '../../../coral-base-component';
 import MultifieldCollection from './MultifieldCollection';
-import '../../../coral-component-textfield';
 import {commons, i18n, validate, transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Multifield';
 const IS_DRAGGING_CLASS = 'is-dragging';
@@ -32,7 +32,7 @@ const TEMPLATE_SUPPORT = 'content' in document.createElement('template');
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Multifield extends BaseComponent(HTMLElement) {
+const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -681,6 +681,6 @@ class Multifield extends BaseComponent(HTMLElement) {
    @property {MultifieldItem} detail.before
    Ordered item was inserted before this sibling item. If <code>null</code>, the item was inserted at the end.
    */
-}
+});
 
 export default Multifield;

--- a/coral-component-multifield/src/scripts/MultifieldItem.js
+++ b/coral-component-multifield/src/scripts/MultifieldItem.js
@@ -15,6 +15,7 @@ import '../../../coral-component-button';
 import item from '../templates/item';
 import {DragAction} from '../../../coral-dragaction';
 import {i18n, transform, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Multifield-item';
 
@@ -26,7 +27,7 @@ const CLASSNAME = '_coral-Multifield-item';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class MultifieldItem extends BaseComponent(HTMLElement) {
+const MultifieldItem = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -161,6 +162,6 @@ class MultifieldItem extends BaseComponent(HTMLElement) {
     dragAction.axis = 'vertical';
     dragAction.handle = this._elements.move;
   }
-}
+});
 
 export default MultifieldItem;

--- a/coral-component-numberinput/src/scripts/NumberInput.js
+++ b/coral-component-numberinput/src/scripts/NumberInput.js
@@ -17,6 +17,7 @@ import '../../../coral-component-textfield';
 import {Icon} from '../../../coral-component-icon';
 import base from '../templates/base';
 import {transform, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Stepper';
 let clearLiveRegionTimeout;
@@ -83,7 +84,7 @@ const handleDecimalOperation = (operator, value1, value2) => {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class NumberInput extends BaseFormField(BaseComponent(HTMLElement)) {
+const NumberInput = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -833,6 +834,6 @@ class NumberInput extends BaseFormField(BaseComponent(HTMLElement)) {
 
     this.appendChild(frag);
   }
-}
+});
 
 export default NumberInput;

--- a/coral-component-overlay/src/scripts/Overlay.js
+++ b/coral-component-overlay/src/scripts/Overlay.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import {BaseOverlay} from '../../../coral-base-overlay';
 import PopperJS from 'popper.js';
 import {transform, validate, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const DEPRECATED_ALIGN = 'Coral.Overlay: alignAt and alignMy have been deprecated. Please use the offset, inner and placement properties instead.';
 const DEPRECATED_FLIP_FIT = 'Coral.Overlay.collision.FLIP_FIT has been deprecated. Please use Coral.Overlay.collision.FLIP instead.';
@@ -741,6 +742,6 @@ class ExtensibleOverlay extends BaseOverlay(BaseComponent(HTMLElement)) {
    */
 }
 
-const Overlay = ExtensibleOverlay; /* Decorator(ExtensibleOverlay); */
+const Overlay = Decorator(ExtensibleOverlay);
 
 export {Overlay, ExtensibleOverlay};

--- a/coral-component-panelstack/src/scripts/Panel.js
+++ b/coral-component-panelstack/src/scripts/Panel.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Panel';
 
@@ -22,7 +23,7 @@ const CLASSNAME = '_coral-Panel';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Panel extends BaseComponent(HTMLElement) {
+const Panel = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -116,6 +117,6 @@ class Panel extends BaseComponent(HTMLElement) {
     // Assign the content zone so the insert function will be called
     this.content = content;
   }
-}
+});
 
 export default Panel;

--- a/coral-component-panelstack/src/scripts/PanelStack.js
+++ b/coral-component-panelstack/src/scripts/PanelStack.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {SelectableCollection} from '../../../coral-collection';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-PanelStack';
 
@@ -22,7 +23,7 @@ const CLASSNAME = '_coral-PanelStack';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class PanelStack extends BaseComponent(HTMLElement) {
+const PanelStack = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -142,6 +143,6 @@ class PanelStack extends BaseComponent(HTMLElement) {
    @property {Panel} detail.oldSelection
    The prior selected panel.
    */
-}
+});
 
 export default PanelStack;

--- a/coral-component-popover/src/scripts/Popover.js
+++ b/coral-component-popover/src/scripts/Popover.js
@@ -16,6 +16,7 @@ import {Icon} from '../../../coral-component-icon';
 import '../../../coral-component-dialog';
 import base from '../templates/base';
 import {commons, transform, validate, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Popover';
 
@@ -92,7 +93,7 @@ for (const placementKey in placement) {
  @htmltag coral-popover
  @extends {Overlay}
  */
-class Popover extends ExtensibleOverlay {
+const Popover = Decorator(class extends ExtensibleOverlay {
   /** @ignore */
   constructor() {
     super();
@@ -593,6 +594,6 @@ class Popover extends ExtensibleOverlay {
     this.content = content;
     this.footer = footer;
   }
-}
+});
 
 export default Popover;

--- a/coral-component-popover/src/scripts/PopoverSeparator.js
+++ b/coral-component-popover/src/scripts/PopoverSeparator.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAMES = ['coral-Rule', 'coral-Rule--subsection2'];
 
@@ -21,12 +22,12 @@ const CLASSNAMES = ['coral-Rule', 'coral-Rule--subsection2'];
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class PopoverSeparator extends BaseComponent(HTMLElement) {
+const PopoverSeparator = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   connectedCallback() {
     super.connectedCallback();
     this.classList.add(...CLASSNAMES);
   }
-}
+});
 
 export default PopoverSeparator;

--- a/coral-component-progress/src/scripts/Progress.js
+++ b/coral-component-progress/src/scripts/Progress.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import base from '../templates/base';
 import {commons, transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Progress} sizes.
@@ -63,7 +64,7 @@ const CLASSNAME = '_coral-BarLoader';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Progress extends BaseComponent(HTMLElement) {
+const Progress = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -433,6 +434,6 @@ class Progress extends BaseComponent(HTMLElement) {
 
    @typedef {CustomEvent} coral-progress:change
    */
-}
+});
 
 export default Progress;

--- a/coral-component-quickactions/src/scripts/QuickActionsItem.js
+++ b/coral-component-quickactions/src/scripts/QuickActionsItem.js
@@ -183,14 +183,15 @@ const QuickActionsItem = Decorator(class extends BaseComponent(HTMLElement) {
   }
 
   /** @ignore */
-  _updateCallback(connected) {
-    super._updateCallback(connected);
+  _suspendCallback() {
+    super._suspendCallback();
+    this._messenger.disconnect();
+  }
 
-    if(connected) {
-      this._messenger.connect();
-    } else {
-      this._messenger.disconnect();
-    }
+  /** @ignore */
+  _resumeCallback() {
+    this._messenger.connect();
+    super._resumeCallback();
   }
 
   /** @ignore */

--- a/coral-component-radio/src/scripts/Radio.js
+++ b/coral-component-radio/src/scripts/Radio.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import {BaseFormField} from '../../../coral-base-formfield';
 import base from '../templates/base';
 import {transform, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Radio';
 
@@ -25,7 +26,7 @@ const CLASSNAME = '_coral-Radio';
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Radio extends BaseFormField(BaseComponent(HTMLElement)) {
+const Radio = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -378,6 +379,6 @@ class Radio extends BaseFormField(BaseComponent(HTMLElement)) {
     // We must do this because IE does not catch mutations when nodes are not in the DOM
     this._hideLabelIfEmpty();
   }
-}
+});
 
 export default Radio;

--- a/coral-component-radiogroup/src/scripts/RadioGroup.js
+++ b/coral-component-radiogroup/src/scripts/RadioGroup.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseFieldGroup} from '../../../coral-base-fieldgroup';
 import '../../../coral-component-radio';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link RadioGroup} orientations.
@@ -40,7 +41,7 @@ const orientation = {
  @extends {BaseComponent}
  @extends {BaseFieldGroup}
  */
-class RadioGroup extends BaseFieldGroup(BaseComponent(HTMLElement)) {
+const RadioGroup = Decorator(class extends BaseFieldGroup(BaseComponent(HTMLElement)) {
   /**
    Orientation of the radio group. See {@link RadioGroupOrientationEnum}.
 
@@ -73,6 +74,6 @@ class RadioGroup extends BaseFieldGroup(BaseComponent(HTMLElement)) {
   static get orientation() {
     return orientation;
   }
-}
+});
 
 export default RadioGroup;

--- a/coral-component-search/src/scripts/Search.js
+++ b/coral-component-search/src/scripts/Search.js
@@ -17,6 +17,7 @@ import '../../../coral-component-button';
 import {Icon} from '../../../coral-component-icon';
 import base from '../templates/base';
 import {transform, validate, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Search';
 
@@ -43,7 +44,7 @@ const variant = {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Search extends BaseFormField(BaseComponent(HTMLElement)) {
+const Search = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -393,6 +394,6 @@ class Search extends BaseFormField(BaseComponent(HTMLElement)) {
 
    @typedef {CustomEvent} coral-search:clear
    */
-}
+});
 
 export default Search;

--- a/coral-component-select/src/scripts/Select.js
+++ b/coral-component-select/src/scripts/Select.js
@@ -20,6 +20,7 @@ import {Icon} from '../../../coral-component-icon';
 import '../../../coral-component-popover';
 import base from '../templates/base';
 import {transform, validate, commons, i18n, Keys} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Select} variants.
@@ -79,7 +80,7 @@ const arrayDiff = function (a, b) {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Select extends BaseFormField(BaseComponent(HTMLElement)) {
+const Select = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -1486,6 +1487,6 @@ class Select extends BaseFormField(BaseComponent(HTMLElement)) {
 
    @typedef {CustomEvent} coral-select:hideitems
    */
-}
+});
 
 export default Select;

--- a/coral-component-select/src/scripts/SelectItem.js
+++ b/coral-component-select/src/scripts/SelectItem.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.Select.Item
@@ -20,7 +21,7 @@ import {transform} from '../../../coral-utils';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SelectItem extends BaseComponent(HTMLElement) {
+const SelectItem = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -152,6 +153,6 @@ class SelectItem extends BaseComponent(HTMLElement) {
   static get observedAttributes() {
     return super.observedAttributes.concat(['selected', 'disabled', 'value']);
   }
-}
+});
 
 export default SelectItem;

--- a/coral-component-sidenav/src/scripts/SideNav.js
+++ b/coral-component-sidenav/src/scripts/SideNav.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {SelectableCollection} from '../../../coral-collection';
 import {transform, validate, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-SideNav';
 
@@ -43,7 +44,7 @@ const variant = {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SideNav extends BaseComponent(HTMLElement) {
+const SideNav = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -362,6 +363,6 @@ class SideNav extends BaseComponent(HTMLElement) {
    @property {SideNavItem} detail.selection
    The newly selected item.
    */
-}
+});
 
 export default SideNav;

--- a/coral-component-sidenav/src/scripts/SideNavItem.js
+++ b/coral-component-sidenav/src/scripts/SideNavItem.js
@@ -17,6 +17,7 @@ import {BaseLabellable} from '../../../coral-base-labellable';
 import {transform} from '../../../coral-utils';
 import item from '../templates/item';
 import '../../../coral-component-icon';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.SideNav.Item
@@ -25,7 +26,7 @@ import '../../../coral-component-icon';
  @extends {HTMLAnchorElement}
  @extends {BaseComponent}
  */
-class SideNavItem extends BaseLabellable(BaseComponent(HTMLAnchorElement)) {
+const SideNavItem = Decorator(class extends BaseLabellable(BaseComponent(HTMLAnchorElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -146,6 +147,6 @@ class SideNavItem extends BaseLabellable(BaseComponent(HTMLAnchorElement)) {
     // Assign the content zones, moving them into place in the process
     this.content = content;
   }
-}
+});
 
 export default SideNavItem;

--- a/coral-component-sidenav/src/scripts/SideNavLevel.js
+++ b/coral-component-sidenav/src/scripts/SideNavLevel.js
@@ -12,6 +12,7 @@
 
 import {commons} from '../../../coral-utils';
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-SideNav';
 
@@ -22,7 +23,7 @@ const CLASSNAME = '_coral-SideNav';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SideNavLevel extends BaseComponent(HTMLElement) {
+const SideNavLevel = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   static get observedAttributes() {
     return super.observedAttributes.concat(['_expanded']);
@@ -88,6 +89,6 @@ class SideNavLevel extends BaseComponent(HTMLElement) {
     // a11y
     this.setAttribute('role', 'region');
   }
-}
+});
 
 export default SideNavLevel;

--- a/coral-component-slider/src/scripts/RangedSlider.js
+++ b/coral-component-slider/src/scripts/RangedSlider.js
@@ -13,6 +13,7 @@
 import {ExtensibleSlider, Slider} from './Slider';
 import range from '../templates/range';
 import {commons, transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  @class Coral.RangedSlider
@@ -20,7 +21,7 @@ import {commons, transform} from '../../../coral-utils';
  @htmltag coral-rangedslider
  @extends {Slider}
  */
-class RangedSlider extends ExtensibleSlider {
+const RangedSlider = Decorator(class extends ExtensibleSlider {
   /**
    Ranged sliders are always filled.
 
@@ -210,6 +211,6 @@ class RangedSlider extends ExtensibleSlider {
     // Set filled attribute by default
     this.setAttribute('filled', '');
   }
-}
+});
 
 export default RangedSlider;

--- a/coral-component-slider/src/scripts/Slider.js
+++ b/coral-component-slider/src/scripts/Slider.js
@@ -15,6 +15,7 @@ import {BaseFormField} from '../../../coral-base-formfield';
 import {Collection} from '../../../coral-collection';
 import base from '../templates/base';
 import {transform, validate, events, commons, Keys} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Slider';
 const CLASSNAME_HANDLE = '_coral-Slider-handle';
@@ -43,6 +44,7 @@ const orientation = {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
+
 class ExtensibleSlider extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
@@ -937,6 +939,6 @@ class ExtensibleSlider extends BaseFormField(BaseComponent(HTMLElement)) {
   }
 }
 
-const Slider = ExtensibleSlider; /* Decorator(ExtensibleSlider); */
+const Slider = Decorator(ExtensibleSlider);
 
 export {ExtensibleSlider, Slider};

--- a/coral-component-slider/src/scripts/SliderItem.js
+++ b/coral-component-slider/src/scripts/SliderItem.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 import {transform} from '../../../coral-utils';
 
 const CLASSNAME = '_coral-Slider-item';
@@ -22,7 +23,7 @@ const CLASSNAME = '_coral-Slider-item';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SliderItem extends BaseComponent(HTMLElement) {
+const SliderItem = Decorator(class extends BaseComponent(HTMLElement) {
   /**
    The slider's item value.
    This should contain a number formatted as a string (e.g.: "10") or an empty string.
@@ -58,6 +59,6 @@ class SliderItem extends BaseComponent(HTMLElement) {
 
     this.classList.add(CLASSNAME);
   }
-}
+});
 
 export default SliderItem;

--- a/coral-component-splitbutton/src/scripts/SplitButton.js
+++ b/coral-component-splitbutton/src/scripts/SplitButton.js
@@ -16,6 +16,7 @@ import '../../../coral-component-anchorbutton';
 import '../../../coral-component-popover';
 import '../../../coral-component-list';
 import {transform, validate, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link SplitButton} variants.
@@ -48,7 +49,7 @@ const CLASSNAME = '_coral-SplitButton';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class SplitButton extends BaseComponent(HTMLElement) {
+const SplitButton = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -163,6 +164,6 @@ class SplitButton extends BaseComponent(HTMLElement) {
     this._updateLeftVariant();
     this._updateInnerButtons();
   }
-}
+});
 
 export default SplitButton;

--- a/coral-component-status/src/scripts/Status.js
+++ b/coral-component-status/src/scripts/Status.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Status} variants.
@@ -90,7 +91,7 @@ for (const colorValue in color) {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Status extends BaseComponent(HTMLElement) {
+const Status = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -259,6 +260,6 @@ class Status extends BaseComponent(HTMLElement) {
     // Assign the content zone moving it into place
     this.label = label;
   }
-}
+});
 
 export default Status;

--- a/coral-component-steplist/src/scripts/Step.js
+++ b/coral-component-steplist/src/scripts/Step.js
@@ -16,6 +16,7 @@ import step from '../templates/step';
 import {transform, commons} from '../../../coral-utils';
 import getTarget from './getTarget';
 import StepList from './StepList';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Steplist-item';
 
@@ -26,7 +27,7 @@ const CLASSNAME = '_coral-Steplist-item';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Step extends BaseComponent(HTMLElement) {
+const Step = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -418,6 +419,6 @@ class Step extends BaseComponent(HTMLElement) {
       overlay.remove();
     }
   }
-}
+});
 
 export default Step;

--- a/coral-component-steplist/src/scripts/StepList.js
+++ b/coral-component-steplist/src/scripts/StepList.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import {SelectableCollection} from '../../../coral-collection';
 import {transform, validate, commons, i18n} from '../../../coral-utils';
 import getTarget from './getTarget';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link StepList} interaction options.
@@ -57,7 +58,7 @@ const CLASSNAME = '_coral-Steplist';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class StepList extends BaseComponent(HTMLElement) {
+const StepList = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -571,6 +572,6 @@ class StepList extends BaseComponent(HTMLElement) {
    @property {Step} detail.oldSelection
    The previously selected Step.
    */
-}
+});
 
 export default StepList;

--- a/coral-component-switch/src/scripts/Switch.js
+++ b/coral-component-switch/src/scripts/Switch.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import {BaseFormField} from '../../../coral-base-formfield';
 import base from '../templates/base';
 import {transform, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-ToggleSwitch';
 
@@ -25,7 +26,7 @@ const CLASSNAME = '_coral-ToggleSwitch';
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Switch extends BaseFormField(BaseComponent(HTMLElement)) {
+const Switch = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -317,6 +318,6 @@ class Switch extends BaseFormField(BaseComponent(HTMLElement)) {
     // We must do this because IE does not catch mutations when nodes are not in the DOM
     this._hideLabelIfEmpty();
   }
-}
+});
 
 export default Switch;

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -22,6 +22,7 @@ import '../../../coral-component-button';
 import {Checkbox} from '../../../coral-component-checkbox';
 import base from '../templates/base';
 import {SelectableCollection} from '../../../coral-collection';
+import {Decorator} from '../../../coral-decorator';
 import {
   isTableHeaderCell,
   isTableCell,
@@ -90,7 +91,7 @@ const KEY_SPACE = Keys.keyToCode('space');
  @extends {HTMLTableElement}
  @extends {BaseComponent}
  */
-class Table extends BaseComponent(HTMLTableElement) {
+const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
   /** @ignore */
   constructor() {
     super();
@@ -2787,6 +2788,6 @@ class Table extends BaseComponent(HTMLTableElement) {
    @property {Array.<TableRow>} detail.selection
    The item selection. When {@link Table#multiple}, it includes an Array.
    */
-}
+});
 
 export default Table;

--- a/coral-component-table/src/scripts/TableBody.js
+++ b/coral-component-table/src/scripts/TableBody.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import BaseTableSection from './BaseTableSection';
 import {getRows} from './TableUtil';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Table-body';
 
@@ -25,7 +26,7 @@ const CLASSNAME = '_coral-Table-body';
  @extends {BaseComponent}
  @extends {BaseTableSection}
  */
-class TableBody extends BaseTableSection(BaseComponent(HTMLTableSectionElement)) {
+const TableBody = Decorator(class extends BaseTableSection(BaseComponent(HTMLTableSectionElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -59,6 +60,6 @@ class TableBody extends BaseTableSection(BaseComponent(HTMLTableSectionElement))
 
    @private
    */
-}
+});
 
 export default TableBody;

--- a/coral-component-table/src/scripts/TableCell.js
+++ b/coral-component-table/src/scripts/TableCell.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import {commons, transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Table-cell';
 
@@ -23,7 +24,7 @@ const CLASSNAME = '_coral-Table-cell';
  @extends {HTMLTableCellElement}
  @extends {BaseComponent}
  */
-class TableCell extends BaseComponent(HTMLTableCellElement) {
+const TableCell = Decorator(class extends BaseComponent(HTMLTableCellElement) {
   // @compat
   get content() {
     return this;
@@ -175,6 +176,6 @@ class TableCell extends BaseComponent(HTMLTableCellElement) {
 
    @private
    */
-}
+});
 
 export default TableCell;

--- a/coral-component-table/src/scripts/TableColumn.js
+++ b/coral-component-table/src/scripts/TableColumn.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {alignment} from './TableUtil';
 import {commons, transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Table-column';
 
@@ -63,7 +64,7 @@ const sortableType = {
  @extends {HTMLTableColElement}
  @extends {BaseComponent}
  */
-class TableColumn extends BaseComponent(HTMLTableColElement) {
+const TableColumn = Decorator(class extends BaseComponent(HTMLTableColElement) {
   /**
    The column cells alignment. The alignment should take the {@link i18n} configuration into account.
 
@@ -373,6 +374,6 @@ class TableColumn extends BaseComponent(HTMLTableColElement) {
 
    @private
    */
-}
+});
 
 export default TableColumn;

--- a/coral-component-table/src/scripts/TableFoot.js
+++ b/coral-component-table/src/scripts/TableFoot.js
@@ -12,6 +12,7 @@
 
 import {BaseComponent} from '../../../coral-base-component';
 import BaseTableSection from './BaseTableSection';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Table-foot';
 
@@ -24,13 +25,13 @@ const CLASSNAME = '_coral-Table-foot';
  @extends {BaseComponent}
  @extends {BaseTableSection}
  */
-class TableFoot extends BaseTableSection(BaseComponent(HTMLTableSectionElement)) {
+const TableFoot = Decorator(class extends BaseTableSection(BaseComponent(HTMLTableSectionElement)) {
   /** @ignore */
   render() {
     super.render();
 
     this.classList.add(CLASSNAME);
   }
-}
+});
 
 export default TableFoot;

--- a/coral-component-table/src/scripts/TableHead.js
+++ b/coral-component-table/src/scripts/TableHead.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import BaseTableSection from './BaseTableSection';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Table-head';
 
@@ -25,7 +26,7 @@ const CLASSNAME = '_coral-Table-head';
  @extends {BaseComponent}
  @extends {BaseTableSection}
  */
-class TableHead extends BaseTableSection(BaseComponent(HTMLTableSectionElement)) {
+const TableHead = Decorator(class extends BaseTableSection(BaseComponent(HTMLTableSectionElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -85,6 +86,6 @@ class TableHead extends BaseTableSection(BaseComponent(HTMLTableSectionElement))
 
    @private
    */
-}
+});
 
 export default TableHead;

--- a/coral-component-table/src/scripts/TableHeaderCell.js
+++ b/coral-component-table/src/scripts/TableHeaderCell.js
@@ -11,6 +11,7 @@
  */
 
 import {BaseComponent} from '../../../coral-base-component';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Table-headerCell';
 
@@ -22,7 +23,7 @@ const CLASSNAME = '_coral-Table-headerCell';
  @extends {HTMLTableCellElement}
  @extends {BaseComponent}
  */
-class TableHeaderCell extends BaseComponent(HTMLTableCellElement) {
+const TableHeaderCell = Decorator(class extends BaseComponent(HTMLTableCellElement) {
   /** @ignore */
   constructor() {
     super();
@@ -96,6 +97,6 @@ class TableHeaderCell extends BaseComponent(HTMLTableCellElement) {
 
    @private
    */
-}
+});
 
 export default TableHeaderCell;

--- a/coral-component-table/src/scripts/TableRow.js
+++ b/coral-component-table/src/scripts/TableRow.js
@@ -14,6 +14,7 @@ import accessibilityState from '../templates/accessibilityState';
 import {BaseComponent} from '../../../coral-base-component';
 import {SelectableCollection} from '../../../coral-collection';
 import {transform, commons, i18n} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Table-row';
 
@@ -25,7 +26,7 @@ const CLASSNAME = '_coral-Table-row';
  @extends {HTMLTableRowElement}
  @extends {BaseComponent}
  */
-class TableRow extends BaseComponent(HTMLTableRowElement) {
+const TableRow = Decorator(class extends BaseComponent(HTMLTableRowElement) {
   /** @ignore */
   constructor() {
     super();
@@ -564,6 +565,6 @@ class TableRow extends BaseComponent(HTMLTableRowElement) {
 
    @private
    */
-}
+});
 
 export default TableRow;

--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -16,6 +16,7 @@ import base from '../templates/base';
 import {transform, commons} from '../../../coral-utils';
 import {Icon} from '../../../coral-component-icon';
 import getTarget from './getTarget';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Tabs-item';
 
@@ -26,7 +27,7 @@ const CLASSNAME = '_coral-Tabs-item';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
+const Tab = Decorator(class extends BaseLabellable(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -370,6 +371,6 @@ class Tab extends BaseLabellable(BaseComponent(HTMLElement)) {
     // Assign the content zones, moving them into place in the process
     this.label = label;
   }
-}
+});
 
 export default Tab;

--- a/coral-component-tabview/src/scripts/TabView.js
+++ b/coral-component-tabview/src/scripts/TabView.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import '../../../coral-component-panelstack';
 import '../../../coral-component-tablist';
 import {commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link TabView} orientations.
@@ -42,7 +43,7 @@ const CLASSNAME = '_coral-TabView';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class TabView extends BaseComponent(HTMLElement) {
+const TabView = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -222,6 +223,6 @@ class TabView extends BaseComponent(HTMLElement) {
    @param {Tab} event.detail.oldSelection
    The prior selected tab panel item.
    */
-}
+});
 
 export default TabView;

--- a/coral-component-taglist/src/scripts/Tag.js
+++ b/coral-component-taglist/src/scripts/Tag.js
@@ -15,6 +15,7 @@ import '../../../coral-component-button';
 import {Icon} from '../../../coral-component-icon';
 import base from '../templates/base';
 import {transform, validate, events, i18n, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Tags-item';
 const LABEL_CLASSNAME = '_coral-Label';
@@ -145,7 +146,7 @@ const getOffsetCenter = (element) => {
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Tag extends BaseComponent(HTMLElement) {
+const Tag = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -540,6 +541,6 @@ class Tag extends BaseComponent(HTMLElement) {
 
    @private
    */
-}
+});
 
 export default Tag;

--- a/coral-component-taglist/src/scripts/TagList.js
+++ b/coral-component-taglist/src/scripts/TagList.js
@@ -15,6 +15,7 @@ import {BaseFormField} from '../../../coral-base-formfield';
 import Tag from './Tag';
 import {Collection} from '../../../coral-collection';
 import {transform, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Tags';
 // Collection
@@ -41,7 +42,7 @@ const itemValueFromDOM = function (item) {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class TagList extends BaseFormField(BaseComponent(HTMLElement)) {
+const TagList = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -552,6 +553,6 @@ class TagList extends BaseFormField(BaseComponent(HTMLElement)) {
       this._prepareItem(item);
     });
   }
-}
+});
 
 export default TagList;

--- a/coral-component-textarea/src/scripts/Textarea.js
+++ b/coral-component-textarea/src/scripts/Textarea.js
@@ -15,6 +15,7 @@ import {BaseFormField} from '../../../coral-base-formfield';
 // todo ideally there should be a coral-base-textfield to inherit from
 import '../../../coral-component-textfield';
 import {transform, validate, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-Textfield';
 
@@ -49,7 +50,7 @@ for (const variantValue in variant) {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Textarea extends BaseFormField(BaseComponent(HTMLTextAreaElement)) {
+const Textarea = Decorator(class extends BaseFormField(BaseComponent(HTMLTextAreaElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -141,6 +142,6 @@ class Textarea extends BaseFormField(BaseComponent(HTMLTextAreaElement)) {
       this.variant = variant.DEFAULT;
     }
   }
-}
+});
 
 export default Textarea;

--- a/coral-component-textfield/src/scripts/Textfield.js
+++ b/coral-component-textfield/src/scripts/Textfield.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {BaseFormField} from '../../../coral-base-formfield';
 import {transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Textfield} variants.
@@ -48,7 +49,7 @@ for (const variantValue in variant) {
  @extends {BaseComponent}
  @extends {BaseFormField}
  */
-class Textfield extends BaseFormField(BaseComponent(HTMLInputElement)) {
+const Textfield = Decorator(class extends BaseFormField(BaseComponent(HTMLInputElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -106,6 +107,6 @@ class Textfield extends BaseFormField(BaseComponent(HTMLInputElement)) {
       this.variant = variant.DEFAULT;
     }
   }
-}
+});
 
 export default Textfield;

--- a/coral-component-toast/src/scripts/Toast.js
+++ b/coral-component-toast/src/scripts/Toast.js
@@ -16,6 +16,7 @@ import {Icon} from '../../../coral-component-icon';
 import {Button} from '../../../coral-component-button';
 import base from '../templates/base';
 import {transform, validate, commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Toast} variants.
@@ -123,7 +124,7 @@ const isButton = node => (node.nodeName === 'BUTTON' && node.getAttribute('is') 
  @extends {BaseComponent}
  @extends {BaseOverlay}
  */
-class Toast extends BaseOverlay(BaseComponent(HTMLElement)) {
+const Toast = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
   /** @ignore */
   constructor() {
     super();
@@ -553,6 +554,6 @@ class Toast extends BaseOverlay(BaseComponent(HTMLElement)) {
       }
     }
   }
-}
+});
 
 export default Toast;

--- a/coral-component-tooltip/src/scripts/Tooltip.js
+++ b/coral-component-tooltip/src/scripts/Tooltip.js
@@ -14,6 +14,7 @@ import {ExtensibleOverlay, Overlay} from '../../../coral-component-overlay';
 import Vent from '@adobe/vent';
 import base from '../templates/base';
 import {commons, transform, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const arrowMap = {
   left: 'left',
@@ -82,7 +83,7 @@ for (const key in Overlay.placement) {
  @htmltag coral-tooltip
  @extends {Overlay}
  */
-class Tooltip extends ExtensibleOverlay {
+const Tooltip = Decorator(class extends ExtensibleOverlay {
   /** @ignore */
   constructor() {
     super();
@@ -427,6 +428,6 @@ class Tooltip extends ExtensibleOverlay {
     // Assign the content zone so the insert function will be called
     this.content = content;
   }
-}
+});
 
 export default Tooltip;

--- a/coral-component-tree/src/scripts/Tree.js
+++ b/coral-component-tree/src/scripts/Tree.js
@@ -14,6 +14,7 @@ import {BaseComponent} from '../../../coral-base-component';
 import {SelectableCollection} from '../../../coral-collection';
 import TreeItem from './TreeItem';
 import {transform} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-TreeView';
 
@@ -26,7 +27,7 @@ const CLASSNAME = '_coral-TreeView';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Tree extends BaseComponent(HTMLElement) {
+const Tree = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -560,6 +561,6 @@ class Tree extends BaseComponent(HTMLElement) {
    @property {TreeItem} detail.item
    The collapsed item.
    */
-}
+});
 
 export default Tree;

--- a/coral-component-tree/src/scripts/TreeItem.js
+++ b/coral-component-tree/src/scripts/TreeItem.js
@@ -15,6 +15,7 @@ import {Collection} from '../../../coral-collection';
 import {Icon} from '../../../coral-component-icon';
 import treeItem from '../templates/treeItem';
 import {transform, commons, i18n, validate} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-TreeView-item';
 
@@ -50,7 +51,7 @@ const IS_TOUCH_DEVICE = 'ontouchstart' in window || navigator.maxTouchPoints > 0
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class TreeItem extends BaseComponent(HTMLElement) {
+const TreeItem = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -477,6 +478,6 @@ class TreeItem extends BaseComponent(HTMLElement) {
 
    @private
    */
-}
+});
 
 export default TreeItem;

--- a/coral-component-wait/src/scripts/Wait.js
+++ b/coral-component-wait/src/scripts/Wait.js
@@ -13,6 +13,7 @@
 import {BaseComponent} from '../../../coral-base-component';
 import {transform, validate} from '../../../coral-utils';
 import base from '../templates/base';
+import {Decorator} from '../../../coral-decorator';
 
 /**
  Enumeration for {@link Wait} variants.
@@ -58,7 +59,7 @@ const CLASSNAME = '_coral-CircleLoader';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class Wait extends BaseComponent(HTMLElement) {
+const Wait = Decorator(class extends BaseComponent(HTMLElement) {
   constructor() {
     super();
 
@@ -299,6 +300,6 @@ class Wait extends BaseComponent(HTMLElement) {
 
    @typedef {CustomEvent} coral-wait:change
    */
-}
+});
 
 export default Wait;

--- a/coral-component-wizardview/src/scripts/WizardView.js
+++ b/coral-component-wizardview/src/scripts/WizardView.js
@@ -15,6 +15,7 @@ import {Collection} from '../../../coral-collection';
 import '../../../coral-component-steplist';
 import '../../../coral-component-panelstack';
 import {commons} from '../../../coral-utils';
+import {Decorator} from '../../../coral-decorator';
 
 const CLASSNAME = '_coral-WizardView';
 
@@ -26,7 +27,7 @@ const CLASSNAME = '_coral-WizardView';
  @extends {HTMLElement}
  @extends {BaseComponent}
  */
-class WizardView extends BaseComponent(HTMLElement) {
+const WizardView = Decorator(class extends BaseComponent(HTMLElement) {
   /** @ignore */
   constructor() {
     super();
@@ -380,6 +381,6 @@ class WizardView extends BaseComponent(HTMLElement) {
    @property {Step} event.detail.oldSelection
    The prior selected step list item.
    */
-}
+});
 
 export default WizardView;

--- a/coral-decorator/src/scripts/Decorator.js
+++ b/coral-decorator/src/scripts/Decorator.js
@@ -29,6 +29,7 @@ const Decorator = (superClass) => class extends superClass {
       return;
     } else if (this._disconnected === false || this._ignoreConnectedCallback === true) {
       // either component is being moved around DOM or callback are ignored.
+      // only update component.
       this._updateCallback(true);
     } else {
       // normal flow

--- a/coral-decorator/src/scripts/Decorator.js
+++ b/coral-decorator/src/scripts/Decorator.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Adobe. All rights reserved.
+ * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -11,15 +11,20 @@
  */
 
 /**
-  Decorator will be used to intercept any call before passing it to actual element.
-  kind of wrapper around each decorated component
-  @private
+ * Decorator will be used to intercept any call before passing it to actual element.
+ * kind of wrapper around each coral component
+ * @private
  */
 const Decorator = (superClass) => class extends superClass {
 
   /** @ignore */
-  _updateCallback(connected) {
-    super._updateCallback(connected);
+  _resumeCallback() {
+    super._resumeCallback();
+  }
+
+  /** @ignore */
+  _suspendCallback() {
+    super._suspendCallback();
   }
 
   /** @ignore */
@@ -28,9 +33,10 @@ const Decorator = (superClass) => class extends superClass {
       // component is not connected do nothing
       return;
     } else if (this._disconnected === false || this._ignoreConnectedCallback === true) {
-      // either component is being moved around DOM or callback are ignored.
-      // only update component.
-      this._updateCallback(true);
+      // either component is being moved around DOM or callback are ignored, resume suspended component
+      // use this hook to only change required state and properties.
+      // avoid executing whole connect and disconnect hooks
+      this._resumeCallback();
     } else {
       // normal flow
       super.connectedCallback();
@@ -43,9 +49,10 @@ const Decorator = (superClass) => class extends superClass {
       // component is already disconnected do nothing
       return;
     } else if(this.isConnected || this._ignoreConnectedCallback === true) {
-      // either component is being moved around DOM or callback are ignored.
-      // only update component.
-      this._updateCallback();
+      // either component is being moved around DOM or callback are ignored, only suspend component.
+      // use this hook to only change required state and properties.
+      // avoid executing whole connect and disconnect hooks
+      this._suspendCallback();
     } else {
       // normal flow
       super.disconnectedCallback();

--- a/coral-decorator/src/scripts/Decorator.js
+++ b/coral-decorator/src/scripts/Decorator.js
@@ -24,21 +24,31 @@ const Decorator = (superClass) => class extends superClass {
 
   /** @ignore */
   connectedCallback() {
-    if (!this.isConnected || this._disconnected === false || this._ignoreConnectedCallback === true) {
-      this._updateCallback(true);
+    if(!this.isConnected) {
+      // component is not connected do nothing
       return;
+    } else if (this._disconnected === false || this._ignoreConnectedCallback === true) {
+      // either component is being moved around DOM or callback are ignored.
+      this._updateCallback(true);
+    } else {
+      // normal flow
+      super.connectedCallback();
     }
-    super.connectedCallback();
   }
 
   /** @ignore */
   disconnectedCallback() {
-    if (this.isConnected || this._disconnected === true || this._ignoreConnectedCallback === true) {
-      this._updateCallback(false);
+    if(this._disconnected === true) {
+      // component is already disconnected do nothing
       return;
+    } else if(this.isConnected || this._ignoreConnectedCallback === true) {
+      // either component is being moved around DOM or callback are ignored.
+      // only update component.
+      this._updateCallback(true);
+    } else {
+      // normal flow
+      super.connectedCallback();
     }
-
-    super.disconnectedCallback();
   }
 };
 

--- a/coral-decorator/src/scripts/Decorator.js
+++ b/coral-decorator/src/scripts/Decorator.js
@@ -45,7 +45,7 @@ const Decorator = (superClass) => class extends superClass {
     } else if(this.isConnected || this._ignoreConnectedCallback === true) {
       // either component is being moved around DOM or callback are ignored.
       // only update component.
-      this._updateCallback(true);
+      this._updateCallback();
     } else {
       // normal flow
       super.disconnectedCallback();

--- a/coral-decorator/src/scripts/Decorator.js
+++ b/coral-decorator/src/scripts/Decorator.js
@@ -30,7 +30,7 @@ const Decorator = (superClass) => class extends superClass {
   /** @ignore */
   connectedCallback() {
     if(!this.isConnected) {
-      // component is not connected do nothing
+      // component is not connected  do nothing
       return;
     } else if (this._disconnected === false || this._ignoreConnectedCallback === true) {
       // either component is being moved around DOM or callback are ignored, resume suspended component

--- a/coral-decorator/src/scripts/Decorator.js
+++ b/coral-decorator/src/scripts/Decorator.js
@@ -39,7 +39,7 @@ const Decorator = (superClass) => class extends superClass {
 
   /** @ignore */
   disconnectedCallback() {
-    if(this._disconnected === true) {
+    if(!(this._disconnected === false)) {
       // component is already disconnected do nothing
       return;
     } else if(this.isConnected || this._ignoreConnectedCallback === true) {

--- a/coral-decorator/src/scripts/Decorator.js
+++ b/coral-decorator/src/scripts/Decorator.js
@@ -48,7 +48,7 @@ const Decorator = (superClass) => class extends superClass {
       this._updateCallback(true);
     } else {
       // normal flow
-      super.connectedCallback();
+      super.disconnectedCallback();
     }
   }
 };

--- a/coral-messenger/src/scripts/Messenger.js
+++ b/coral-messenger/src/scripts/Messenger.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Adobe. All rights reserved.
+ * Copyright 2021 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -23,11 +23,11 @@ const SCOPE_SELECTOR = ':scope > ';
  * coral internal events and not any DOM based or public events.
  *
  * Limitations :
-   - This doesnot support the case where any change in child property,
-     needs to be notified to two or more parents.
-     This is achievable, but not currently supported.
-   - Do not use messenger for generic events like click, hover, etc.
-  @private
+ * - This doesnot support the case where any change in child property, needs to be notified
+ *   to two or more parents. This is achievable, but not currently supported.
+ * - Use this to post message only coral internal events.
+ * - Do not use for DOM events or public events.
+ * @private
  */
 
 class Messenger {
@@ -39,33 +39,37 @@ class Messenger {
     this._clearListeners();
   }
 
-  /* checks whether Messenger is connected or not.
-    @returns {Boolean} true if connected
-    @private
+  /**
+   checks whether Messenger is connected or not.
+   @returns {Boolean} true if connected
+   @private
    */
   get isConnected() {
     return this._connected === true;
   }
 
-  /* checks whether the event is silenced or not
-    @returns {Boolean} true if silenced
-    @private
+  /**
+   checks whether the event is silenced or not
+   @returns {Boolean} true if silenced
+   @private
    */
   get isSilenced() {
     return this._element._silenced === true;
   }
 
-  /* specifies the list of listener attached to messenger.
-    @returns {Array} array of listeners
-    @private
+  /**
+   specifies the list of listener attached to messenger.
+   @returns {Array} array of listeners
+   @private
    */
   get listeners() {
     return this._listeners;
   }
 
-  /* add a message to the queue only if messenger is not connected
-    message will be added only if element is not connected.
-    @private
+  /**
+   add a message to the queue only if messenger is not connected
+   message will be added only if element is not connected.
+   @private
    */
   _addMessageToQueue(message, detail) {
     if(!this.isConnected) {
@@ -76,9 +80,10 @@ class Messenger {
     }
   }
 
-  /* executes the stored queue messages.
-    It will be executed when element is connected.
-    @private
+  /**
+   executes the stored queue messages.
+   It will be executed when element is connected.
+   @private
    */
   _executeQueue() {
     this._queue.forEach((options) => {
@@ -87,24 +92,27 @@ class Messenger {
     this._clearQueue();
   }
 
-  /* empty the stored queue message
-    @private
+  /**
+   empty the stored queue message
+   @private
    */
   _clearQueue() {
     this._queue = [];
   }
 
-  /* clears the listeners
-    @private
+  /**
+   clears the listeners
+   @private
    */
   _clearListeners() {
     this._listeners = [];
   }
 
-  /* element should call this method when they are connected in DOM.
-     its the responsibility of the element to call this hook
-    @triggers `${element.tagName.toLowerCase()}:_messengerconnected`
-    @private
+  /**
+   element should call this method when they are connected in DOM.
+   its the responsibility of the element to call this hook
+   @triggers `${element.tagName.toLowerCase()}:_messengerconnected`
+   @private
    */
   connect() {
     if(!this.isConnected) {
@@ -120,10 +128,11 @@ class Messenger {
     }
   }
 
-  /* add the listener to messenger
-     this handler will be passed when messengerconnect event is trigger
-     the handler needs to be executed by listeners.
-    @private
+  /**
+   add the listener to messenger
+   this handler will be passed when messengerconnect event is trigger
+   the handler needs to be executed by listeners.
+   @private
    */
   registerListener(listener) {
     if(listener) {
@@ -131,10 +140,11 @@ class Messenger {
     }
   }
 
-  /* post the provided message to all listener.
-    @param {String} message which should be posted
-    @param {Object} additional detail which needs to be posted.
-    @private
+  /**
+   post the provided message to all listener.
+   @param {String} message which should be posted
+   @param {Object} additional detail which needs to be posted.
+   @private
    */
   _postMessage(message, detail) {
     let element = this._element;
@@ -172,8 +182,9 @@ class Messenger {
     });
   }
 
-  /* post the provided message to all listener,
-     along with validating silencing and storing in queue
+  /**
+    post the provided message to all listener,
+    along with validating silencing and storing in queue
     @param {String} message which should be posted
     @param {Object} additional detail which needs to be posted.
     @private
@@ -188,11 +199,19 @@ class Messenger {
       return;
     }
 
+    // element got disconnect and messenger not notified.
+    if(!this._element.isConnected) {
+      // disconnect messenger and again post the same message,
+      // message will get store in queue.
+      this.disconnect();
+      this.postMessage(message, detail);
+    }
     this._postMessage(message, detail);
   }
 
-  /* element should call this method when they are disconnected from DOM.
-    its the responsibility of the element to call this hook
+  /**
+    element should call this method when they are disconnected from DOM.
+    Its the responsibility of the element to call this hook
     @private
    */
   disconnect() {

--- a/coral-messenger/src/scripts/Messenger.js
+++ b/coral-messenger/src/scripts/Messenger.js
@@ -40,36 +40,36 @@ class Messenger {
   }
 
   /**
-   checks whether Messenger is connected or not.
-   @returns {Boolean} true if connected
-   @private
+   * checks whether Messenger is connected or not.
+   * @returns {Boolean} true if connected
+   * @private
    */
   get isConnected() {
     return this._connected === true;
   }
 
   /**
-   checks whether the event is silenced or not
-   @returns {Boolean} true if silenced
-   @private
+   * checks whether the event is silenced or not
+   * @returns {Boolean} true if silenced
+   * @private
    */
   get isSilenced() {
     return this._element._silenced === true;
   }
 
   /**
-   specifies the list of listener attached to messenger.
-   @returns {Array} array of listeners
-   @private
+   * specifies the list of listener attached to messenger.
+   * @returns {Array} array of listeners
+   * @private
    */
   get listeners() {
     return this._listeners;
   }
 
   /**
-   add a message to the queue only if messenger is not connected
-   message will be added only if element is not connected.
-   @private
+   * add a message to the queue only if messenger is not connected
+   * message will be added only if element is not connected.
+   * @private
    */
   _addMessageToQueue(message, detail) {
     if(!this.isConnected) {
@@ -81,9 +81,9 @@ class Messenger {
   }
 
   /**
-   executes the stored queue messages.
-   It will be executed when element is connected.
-   @private
+   * executes the stored queue messages.
+   * It will be executed when element is connected.
+   * @private
    */
   _executeQueue() {
     this._queue.forEach((options) => {
@@ -93,26 +93,26 @@ class Messenger {
   }
 
   /**
-   empty the stored queue message
-   @private
+   * empty the stored queue message
+   * @private
    */
   _clearQueue() {
     this._queue = [];
   }
 
   /**
-   clears the listeners
-   @private
+   * clears the listeners
+   * @private
    */
   _clearListeners() {
     this._listeners = [];
   }
 
   /**
-   element should call this method when they are connected in DOM.
-   its the responsibility of the element to call this hook
-   @triggers `${element.tagName.toLowerCase()}:_messengerconnected`
-   @private
+   * element should call this method when they are connected in DOM.
+   * its the responsibility of the element to call this hook
+   * @triggers `${element.tagName.toLowerCase()}:_messengerconnected`
+   * @private
    */
   connect() {
     if(!this.isConnected) {
@@ -129,10 +129,10 @@ class Messenger {
   }
 
   /**
-   add the listener to messenger
-   this handler will be passed when messengerconnect event is trigger
-   the handler needs to be executed by listeners.
-   @private
+   * add the listener to messenger
+   * this handler will be passed when messengerconnect event is trigger
+   * the handler needs to be executed by listeners.
+   * @private
    */
   registerListener(listener) {
     if(listener) {
@@ -141,10 +141,10 @@ class Messenger {
   }
 
   /**
-   post the provided message to all listener.
-   @param {String} message which should be posted
-   @param {Object} additional detail which needs to be posted.
-   @private
+   * post the provided message to all listener.
+   * @param {String} message which should be posted
+   * @param {Object} additional detail which needs to be posted.
+   * @private
    */
   _postMessage(message, detail) {
     let element = this._element;
@@ -183,11 +183,11 @@ class Messenger {
   }
 
   /**
-    post the provided message to all listener,
-    along with validating silencing and storing in queue
-    @param {String} message which should be posted
-    @param {Object} additional detail which needs to be posted.
-    @private
+    * post the provided message to all listener,
+    * along with validating silencing and storing in queue
+    * @param {String} message which should be posted
+    * @param {Object} additional detail which needs to be posted.
+    * @private
    */
   postMessage(message, detail) {
     if(this.isSilenced) {
@@ -205,14 +205,16 @@ class Messenger {
       // message will get store in queue.
       this.disconnect();
       this.postMessage(message, detail);
+      return;
     }
+
     this._postMessage(message, detail);
   }
 
   /**
-    element should call this method when they are disconnected from DOM.
-    Its the responsibility of the element to call this hook
-    @private
+    * element should call this method when they are disconnected from DOM.
+    * Its the responsibility of the element to call this hook
+    * @private
    */
   disconnect() {
     if(this.isConnected) {


### PR DESCRIPTION
The performance of loading and showing a coral-dialog is lagging the behind the older coralui version.
When we show a dialog we tends to move the dialog to be a direct child of body element. This leads to twice execution of connected and disconnected callback, even when its unnecessary. Earlier we were only ignoring the callbacks for dialog but its child callbacks/hooks were getting executed. 

We have ignored the callbacks of the all the coral-dialog childs, so that callbacks/hooks gets executed only once. This would improve the performance of coral-dialog.

Follow-up PR of https://github.com/adobe/coral-spectrum/pull/163

Decorator.js : https://github.com/adobe/coral-spectrum/pull/170/files#diff-03b8d169563242e2e1d45183307d46bdf91c857c510c7a0d689d41d02ed72efa

Future prospect: Add performance testing to coral-spectrum.

## Description
We added a recursive function to set the _ignoreConnectedCallback value of the child component to true/false. Every final coral-component have a common subClass Decorator. This would be used to intercept any call before it goes to exact component. 

## Related Issue
GRANITE-35104(internal issue) : Dialog taking longer time to load 

## Motivation and Context
The current corla-dialog takes some time to load and show. We are targeting to improve the dialog as well overall colra-performance. 

## How Has This Been Tested?
We have either updated or added the testcases for the change to detect any break functionality. The testcase were added in #163 .

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
