### PR TITLE
fix: adding html title feature in columnitem

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -413,10 +413,12 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
 
     // @a11y accessibility state string should announce in document lang, rather than item lang.
     accessibilityState.setAttribute('lang', i18n.locale);
-    this.setAttribute('title', this.content.textContent.trim());
 
     // @a11y Item should be labelled by thumbnail, content, and accessibility state.
     this.setAttribute('aria-labelledby', thumbnail.id + ' ' + content.id);
+
+    //adding html title, on hovering over textcontent title will be visible
+    this.setAttribute('title', this.content.textContent.trim());
   }
 }
 

--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -413,6 +413,7 @@ class ColumnViewItem extends BaseLabellable(BaseComponent(HTMLElement)) {
 
     // @a11y accessibility state string should announce in document lang, rather than item lang.
     accessibilityState.setAttribute('lang', i18n.locale);
+    this.setAttribute('title', this.content.textContent.trim());
 
     // @a11y Item should be labelled by thumbnail, content, and accessibility state.
     this.setAttribute('aria-labelledby', thumbnail.id + ' ' + content.id);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
On hovering over textcontent of columnview item html title will be visible

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
