### PR TITLE
GRANITE-36188: Authors are able to select date on disabled date picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /coral-*/src/styles/index.css
 /coral-*/README.md
 /coral-*/dist
+
+/.idea/

--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -477,7 +477,7 @@ const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLEleme
 
     this._elements.input.disabled = this._disabled;
     this._elements.hiddenInput.disabled = this._disabled;
-    this._elements.toggle.disabled = this._disabled;
+    this._elements.toggle.disabled = this._disabled || this._readOnly;
   }
 
   /**

--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -533,7 +533,7 @@ const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLEleme
 
     this._elements.hiddenInput.readOnly = this.readOnly;
     this._elements.input.readOnly = this._readOnly;
-    this._elements.toggle.disabled = this._readOnly;
+    this._elements.toggle.disabled = this._readOnly || this._disabled;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
On loading the UI for datepicker, read-only attribute is added by default during rendering, so if datepicker is disabled and readOnly section is called after that, then the calendar button is marked enabled from readOnly section which should be disabled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
GRANITE-36188: Authors are able to select date on disabled date picker

## Motivation and Context
Setting the disabled to true and then readonly to false, reenable the datepicker button which seems to be incorrect. Same goes for readonly to true and then disabled to false.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested Manually from the browser console by calling readOnly and disabled on the datepicker element.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
