### PR TITLE
fix: performance improvement

### DIFF
--- a/coral-collection/src/scripts/Collection.js
+++ b/coral-collection/src/scripts/Collection.js
@@ -345,21 +345,21 @@ class Collection {
 
   /**
    Handles the collection changes. It automatically triggers the collection change event.
-   @param {Array<HTMLElement>} addedItems The items that was added to the collection
-   @param {Array<HTMLElement>} removedItems The items that was removed from the collection
+   @param {Array<HTMLElement>} addedNodes The items that was added to the collection
+   @param {Array<HTMLElement>} removedNodes The items that was removed from the collection
    @emits {coral-collection:change}
    @protected
    */
-  _onCollectionMutation(addedItems, removedItems) {
+  _onCollectionMutation(addedNodes, removedNodes) {
     // if options._onCollectionChange was provided, we call the function
     if (typeof this._onCollectionChange === 'function') {
-      this._onCollectionChange.call(this._host, addedItems, removedItems);
+      this._onCollectionChange.call(this._host, addedNodes, removedNodes);
     }
 
     // the usage of trigger assumes that the host is a coral component
     this._host.trigger('coral-collection:change', {
-      addedItems: addedItems,
-      removedItems: removedItems
+      addedItems: addedNodes,
+      removedItems: removedNodes
     });
   }
 

--- a/coral-collection/src/scripts/Collection.js
+++ b/coral-collection/src/scripts/Collection.js
@@ -384,12 +384,19 @@ class Collection {
       // detects them
       this._handleItems = true;
 
-      this._observer.observe(this._container, {
-        // we only need to observe for items that were added and removed, no need to check attributes and contents
-        childList: true,
-        // we need to listen to subtree mutations as items may not be direct children
-        subtree: true
-      });
+      if (this._onlyHandleChildren) {
+        this._observer.observe(this._container, {
+          // we only need to observe for items that were added and removed, no need to check attributes and contents
+          childList: true,
+        });
+      } else {
+        this._observer.observe(this._container, {
+          // we only need to observe for items that were added and removed, no need to check attributes and contents
+          childList: true,
+          // we need to listen to subtree mutations as items may not be direct children
+          subtree: true
+        });
+      }
 
       // by default we handle the initial items unless otherwise indicated
       if (skipInitialItems !== true) {

--- a/coral-collection/src/scripts/Collection.js
+++ b/coral-collection/src/scripts/Collection.js
@@ -351,7 +351,7 @@ class Collection {
    @protected
    */
   _onCollectionMutation(addedNodes, removedNodes) {
-    // if options._onCollectionChange was provided, we call the function
+    // if options.onCollectionChange was provided, we call the function
     if (typeof this._onCollectionChange === 'function') {
       this._onCollectionChange.call(this._host, addedNodes, removedNodes);
     }

--- a/coral-collection/src/tests/test.Collection.js
+++ b/coral-collection/src/tests/test.Collection.js
@@ -63,6 +63,7 @@ describe('Collection', function () {
           host: this,
           itemTagName: 'coral-collection-test-item',
           itemSelector: ':scope > coral-collection-test-item',
+          onlyHandleChildren: true,
           filter: filter,
           onItemAdded: onItemAddedNestedSpy,
           onItemRemoved: onItemRemovedNestedSpy,

--- a/coral-component-accordion/src/scripts/Accordion.js
+++ b/coral-component-accordion/src/scripts/Accordion.js
@@ -113,6 +113,7 @@ const Accordion = Decorator(class extends BaseComponent(HTMLElement) {
         itemTagName: 'coral-accordion-item',
         // allows accordions to be nested
         itemSelector: ':scope > coral-accordion-item',
+        onlyHandleChildren: true,
         onItemAdded: this._validateSelection,
         onItemRemoved: this._validateSelection
       });

--- a/coral-component-buttongroup/src/scripts/ButtonGroup.js
+++ b/coral-component-buttongroup/src/scripts/ButtonGroup.js
@@ -113,6 +113,7 @@ const ButtonGroup = Decorator(class extends BaseFormField(BaseComponent(HTMLElem
         itemBaseTagName: 'button',
         itemTagName: 'coral-button',
         itemSelector: ITEM_SELECTOR,
+        onlyHandleChildren: true,
         onItemAdded: this._onItemAdded,
         onItemRemoved: this._onItemRemoved,
         onCollectionChange: this._onCollectionChange

--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -1006,7 +1006,7 @@ const ColumnView = Decorator(class extends BaseComponent(HTMLElement) {
       if (item.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
         // we use the property since the item may not be ready
         item.setAttribute('_selectionmode', this.selectionMode);
-        this.trigger('coral-collection:add', {item});
+        //this.trigger('coral-collection:add', {item});
         this._updateAriaLevel(item);
       }
     }
@@ -1017,7 +1017,7 @@ const ColumnView = Decorator(class extends BaseComponent(HTMLElement) {
       item = removedNodes[j];
       // @todo: should I handle it specially if it was selected? should a selection and active event be triggered?
       if (item.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
-        this.trigger('coral-collection:remove', {item});
+        // this.trigger('coral-collection:remove', {item});
       }
     }
   }

--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -128,7 +128,8 @@ const ColumnView = Decorator(class extends BaseComponent(HTMLElement) {
     if (!this._columns) {
       this._columns = new ColumnViewCollection({
         host: this,
-        itemTagName: 'coral-columnview-column'
+        itemTagName: 'coral-columnview-column',
+        onlyHandleChildren: true
       });
     }
 

--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -1006,7 +1006,7 @@ const ColumnView = Decorator(class extends BaseComponent(HTMLElement) {
       if (item.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
         // we use the property since the item may not be ready
         item.setAttribute('_selectionmode', this.selectionMode);
-        //this.trigger('coral-collection:add', {item});
+        this.trigger('coral-collection:add', {item});
         this._updateAriaLevel(item);
       }
     }
@@ -1017,7 +1017,7 @@ const ColumnView = Decorator(class extends BaseComponent(HTMLElement) {
       item = removedNodes[j];
       // @todo: should I handle it specially if it was selected? should a selection and active event be triggered?
       if (item.tagName === 'CORAL-COLUMNVIEW-COLUMN') {
-        // this.trigger('coral-collection:remove', {item});
+        this.trigger('coral-collection:remove', {item});
       }
     }
   }

--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -511,11 +511,11 @@ const ColumnViewColumn = Decorator(class extends BaseComponent(HTMLElement) {
   /** @private */
   _handleMutation(mutations) {
     const mutationsCount = mutations.length;
-    for (let i = 0 ; i < mutationsCount ; i++) {
+    /* for (let i = 0 ; i < mutationsCount ; i++) {
       const mutation = mutations[i];
       // we handle the collection events
       this._triggerCollectionEvents(mutation.addedNodes, mutation.removedNodes);
-    }
+    } */
 
     this._setStateFromDOM();
 

--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -129,7 +129,8 @@ const ColumnViewColumn = Decorator(class extends BaseComponent(HTMLElement) {
         host: this,
         container: this._elements.content,
         itemTagName: 'coral-columnview-item',
-        onItemAdded: this._toggleItemSelection
+        onItemAdded: this._toggleItemSelection,
+        onCollectionChange: this._handleMutation
       });
     }
 
@@ -509,14 +510,7 @@ const ColumnViewColumn = Decorator(class extends BaseComponent(HTMLElement) {
   }
 
   /** @private */
-  _handleMutation(mutations) {
-    const mutationsCount = mutations.length;
-    /* for (let i = 0 ; i < mutationsCount ; i++) {
-      const mutation = mutations[i];
-      // we handle the collection events
-      this._triggerCollectionEvents(mutation.addedNodes, mutation.removedNodes);
-    } */
-
+  _handleMutation() {
     this._setStateFromDOM();
 
     // in case items were added removed and selection changed
@@ -524,26 +518,6 @@ const ColumnViewColumn = Decorator(class extends BaseComponent(HTMLElement) {
 
     // checks if more items can be added after the childlist change
     this._tryToLoadAdditionalItems();
-  }
-
-  /** @private */
-  _triggerCollectionEvents(addedNodes, removedNodes) {
-    let item;
-    const addedNodesCount = addedNodes.length;
-    for (let i = 0 ; i < addedNodesCount ; i++) {
-      item = addedNodes[i];
-      if (item.tagName === 'CORAL-COLUMNVIEW-ITEM') {
-        this.trigger('coral-collection:add', {item});
-      }
-    }
-
-    const removedNodesCount = removedNodes.length;
-    for (let j = 0 ; j < removedNodesCount ; j++) {
-      item = removedNodes[j];
-      if (item.tagName === 'CORAL-COLUMNVIEW-ITEM') {
-        this.trigger('coral-collection:remove', {item});
-      }
-    }
   }
 
   get _contentZones() {

--- a/coral-component-columnview/src/scripts/ColumnViewColumn.js
+++ b/coral-component-columnview/src/scripts/ColumnViewColumn.js
@@ -72,13 +72,6 @@ const ColumnViewColumn = Decorator(class extends BaseComponent(HTMLElement) {
     this._onDebouncedScroll = this._onDebouncedScroll.bind(this);
     this._toggleItemSelection = this._toggleItemSelection.bind(this);
 
-    this._observer = new MutationObserver(this._handleMutation.bind(this));
-    // items outside the scroll area are not supported
-    this._observer.observe(this._elements.content, {
-      // only watch the childList, items will tell us if selected/value/content changes
-      childList: true
-    });
-
     // Init the collection mutation observer
     this.items._startHandlingItems(true);
   }

--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -63,8 +63,6 @@ const ColumnViewItem = Decorator(class extends BaseLabellable(BaseComponent(HTML
       // Templates
       accessibilityState.call(this._elements, {commons});
     }
-
-    super._observeLabel();
   }
 
   /**
@@ -183,6 +181,8 @@ const ColumnViewItem = Decorator(class extends BaseLabellable(BaseComponent(HTML
         // creates a new icon element
         if (!this._elements.icon) {
           this._elements.icon = new Icon();
+          // register observer only if there present an icon field.
+          super._observeLabel();
         }
   
         this._elements.icon.icon = this.icon;

--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -200,6 +200,7 @@ const Masonry = Decorator(class extends BaseComponent(HTMLElement) {
         itemTagName: 'coral-masonry-item',
         // allows masonry to be nested
         itemSelector: ':scope > coral-masonry-item:not([_removing]):not([_placeholder])',
+        onlyHandleChildren: true,
         onItemAdded: this._validateSelection,
         onItemRemoved: this._validateSelection
       });

--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -116,6 +116,7 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
         itemTagName: 'coral-multifield-item',
         // allows multifields to be nested
         itemSelector: ':scope > coral-multifield-item',
+        onlyHandleChildren: true,
         onItemAdded: this._onItemAdded,
         onItemRemoved: this._onItemRemoved
       });

--- a/coral-component-panelstack/src/scripts/PanelStack.js
+++ b/coral-component-panelstack/src/scripts/PanelStack.js
@@ -55,6 +55,7 @@ const PanelStack = Decorator(class extends BaseComponent(HTMLElement) {
         itemTagName: 'coral-panel',
         // allows panels to be nested
         itemSelector: ':scope > coral-panel',
+        onlyHandleChildren: true,
         onItemAdded: this._validateSelection,
         onItemRemoved: this._validateSelection
       });

--- a/coral-component-tree/src/scripts/TreeItem.js
+++ b/coral-component-tree/src/scripts/TreeItem.js
@@ -114,6 +114,7 @@ const TreeItem = Decorator(class extends BaseComponent(HTMLElement) {
         host: this,
         itemTagName: 'coral-tree-item',
         itemSelector: ':scope > coral-tree-item',
+        onlyHandleChildren: true,
         container: this._elements.subTreeContainer,
         filter: this._filterItem.bind(this),
         onItemAdded: this._onItemAdded,

--- a/coral-component-wizardview/src/scripts/WizardView.js
+++ b/coral-component-wizardview/src/scripts/WizardView.js
@@ -83,6 +83,7 @@ const WizardView = Decorator(class extends BaseComponent(HTMLElement) {
         itemTagName: 'coral-panelstack',
         // allows panelstack to be nested
         itemSelector: ':scope > coral-panelstack[coral-wizardview-panelstack]',
+        onlyHandleChildren: true,
         onItemAdded: this._onItemAdded
       });
     }
@@ -104,6 +105,7 @@ const WizardView = Decorator(class extends BaseComponent(HTMLElement) {
         itemTagName: 'coral-steplist',
         // allows steplist to be nested
         itemSelector: ':scope > coral-steplist[coral-wizardview-steplist]',
+        onlyHandleChildren: true,
         onItemAdded: this._onItemAdded
       });
     }


### PR DESCRIPTION
Change 1 : 
The mutation observer of collection observe all the changes happen in childlist as well as subtree. In some scenario, only listening to childlist is sufficient, for component whose items needs to be direct children.
https://github.com/adobe/coral-spectrum/pull/191/files#diff-3404a6f72ee6d617fc6a006eff08b6d76095d3206fcd4e3fc6b6644362070324R387 

Change 2 : 
The collection change triggers two event `coral-collection:add` when item is added and `coral-collection:remove` when item is removed. Sometimes we only require to know that collection is changed, adding `coral-collection:change` event to ensure that collection has been changed.
https://github.com/adobe/coral-spectrum/pull/191/files#diff-3404a6f72ee6d617fc6a006eff08b6d76095d3206fcd4e3fc6b6644362070324R353 

## Description
For component whose items needs to be direct children, we only needs to listen/observe the items added/removed that are direct and no need to listen to whole subtree. 

Addition of `coral-collection:change` event, in some scenario we only need to know what items are added and removed instead of listening to `coral-collection:add`/`coral-collection:remove` for each item. We are adding an event that will be triggered once per collection mutations instead of per item.

## Related Issue
CQ-4334595,
GRANITE-36730,
CQ-4334508

## Motivation and Context
We need a single event for whole collection changes instead of listening to event per item. Hence adding an `coral-collection:change` event. 

For collection mutation observer, for some components we only need to listen to direct children addition/deletion. 

## How Has This Been Tested?
For event `coral-collection:change` we have added testcases.
For only observing childlist, we are testing with existing testcases

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
