### PR TITLE
fix(GRANITE-37908): Intermittently action bar options don't show up on selection of items in tableview.

### DIFF
--- a/coral-component-table/src/scripts/TableRow.js
+++ b/coral-component-table/src/scripts/TableRow.js
@@ -455,7 +455,7 @@ const TableRow = Decorator(class extends BaseComponent(HTMLTableRowElement) {
   /** @private */
   _toggleOrderable(orderable) {
     if (orderable) {
-      this._setHandle('coral-table-roworder');
+      this._setHandle('coral-table-roworder', 0);
     }
     // Remove DragAction instance
     else if (this.dragAction) {
@@ -470,17 +470,27 @@ const TableRow = Decorator(class extends BaseComponent(HTMLTableRowElement) {
     }
   }
 
+  _setHandleAndSync(handle) {
+    // Specify handle directly on the row if none found
+    if (!this.querySelector(`[${handle}]`)) {
+      this.setAttribute(handle, '');
+    }
+    this._syncSelectHandle();
+    this._syncAriaLabelledby();
+    this._syncAriaSelectedState();
+  }
+
   /** @private */
-  _setHandle(handle) {
-    setTimeout(() => {
-      // Specify handle directly on the row if none found
-      if (!this.querySelector(`[${handle}]`)) {
-        this.setAttribute(handle, '');
-      }
-      this._syncSelectHandle();
-      this._syncAriaLabelledby();
-      this._syncAriaSelectedState();
-    }, 0);
+  _setHandle(handle, timeout) {
+    if(typeof timeout === "number") {
+      setTimeout(() => {
+        this._setHandleAndSync(handle);
+      }, timeout);
+    } else {
+      requestAnimationFrame(() => {
+        this._setHandleAndSync(handle);
+      });
+    }
   }
 
   /** @private */

--- a/coral-component-table/src/scripts/TableRow.js
+++ b/coral-component-table/src/scripts/TableRow.js
@@ -472,7 +472,7 @@ const TableRow = Decorator(class extends BaseComponent(HTMLTableRowElement) {
 
   /** @private */
   _setHandle(handle) {
-    requestAnimationFrame(() => {
+    setTimeout(() => {
       // Specify handle directly on the row if none found
       if (!this.querySelector(`[${handle}]`)) {
         this.setAttribute(handle, '');
@@ -480,7 +480,7 @@ const TableRow = Decorator(class extends BaseComponent(HTMLTableRowElement) {
       this._syncSelectHandle();
       this._syncAriaLabelledby();
       this._syncAriaSelectedState();
-    });
+    }, 0);
   }
 
   /** @private */

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -1449,7 +1449,7 @@ describe('Table', function () {
 
         expect(getIndexOf(row)).to.equal(0);
 
-        helpers.next(() => {
+        setTimeout(() => {
           dragRowTo(row, 1);
 
           // Wait for dragging
@@ -1461,7 +1461,7 @@ describe('Table', function () {
 
             done();
           });
-        });
+        }, 10);
       });
 
       it('should prevent the row from being inserted at the dragged position', function (done) {

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -311,13 +311,13 @@ describe('Table', function () {
         var table = helpers.build(window.__html__['Table.base.html']);
         table.orderable = true;
 
-        helpers.next(() => {
+        setTimeout(() => {
           table.items.getAll().forEach(function (item) {
             expect(item.hasAttribute('coral-table-roworder')).to.be.true;
           });
 
           done();
-        });
+        }, 10);
       });
 
       it('should remove orderable mode', function () {
@@ -1191,7 +1191,7 @@ describe('Table', function () {
 
         expect(getIndexOf(row)).to.equal(0);
 
-        helpers.next(() => {
+        setTimeout(() => {
           dragRowTo(row, 1);
 
           expect(eventSpy.callCount).to.equal(1);
@@ -1200,7 +1200,7 @@ describe('Table', function () {
           expect(eventSpy.args[0][0].detail.before).to.equal(row.nextElementSibling);
 
           done();
-        });
+        }, 10);
       });
     });
 
@@ -1216,9 +1216,9 @@ describe('Table', function () {
           done();
         });
 
-        helpers.next(() => {
+        setTimeout(() => {
           dragRowTo(table.body.rows[0], 1);
-        });
+        }, 10);
       });
     });
 
@@ -2275,9 +2275,9 @@ describe('Table', function () {
           done();
         });
 
-        helpers.next(() => {
+        setTimeout(() => {
           dragRowTo(table.body.rows[0], 1);
-        });
+        }, 10);
       });
 
       it('should destroy the dragaction', function () {

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -1170,14 +1170,13 @@ describe('Table', function () {
         table.on('coral-table:roworder', eventSpy);
         var row = table.body.rows[1];
 
-        helpers.next(() => {
+        setTimeout(() => {
           dragRowTo(row, -1);
 
           expect(eventSpy.callCount).to.equal(1);
           expect(eventSpy.args[0][0].detail.row).to.equal(row);
-
           done();
-        });
+        }, 10);
       });
 
       it('should pass the sibling row to allow reverting', function (done) {
@@ -1425,7 +1424,7 @@ describe('Table', function () {
 
         expect(getIndexOf(row)).to.equal(1);
 
-        helpers.next(() => {
+        setTimeout(() => {
           dragRowTo(row, -1);
 
           // Wait for dragging
@@ -1437,7 +1436,7 @@ describe('Table', function () {
 
             done();
           });
-        });
+        }, 10);
       });
 
       it('should drag the row to the bottom', function (done) {
@@ -1478,7 +1477,7 @@ describe('Table', function () {
 
         expect(getIndexOf(row)).to.equal(0);
 
-        helpers.next(() => {
+        setTimeout(() => {
           dragRowTo(row, 1);
 
           // Wait for dragging
@@ -1491,7 +1490,7 @@ describe('Table', function () {
 
             done();
           });
-        });
+        }, 0);
       });
 
       it('should not initialize dragging logic if the order handle is disabled', function () {


### PR DESCRIPTION
…how up on selection of assets

Sometimes,  when loading the table view with some around 100 items. The requestAnimationFrame gets executed before the [coral-table-roworder] item gets loaded in DOM. As a result, [coral-table-roworder] this attribute gets added to table item row (tr). 
This change syncs `coral-table-roworder` on setTimeout instead of requestAnimationFrame. 

## Description
When the tableview is loaded, sometimes intermittently actionBar does not gets loaded on selecting items. This happens b/c 
`coral-table-roworder` gets appended to table row even when there exists a [coral-table-roworder] element.

## Related Issue
https://jira.corp.adobe.com/browse/GRANITE-37908

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
This has been tested visually and testcases are updated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
