### PR TITLE
fix(CQ-4340781): Blank screen for view Page Properties - Coral Tab not being selected

### DIFF
--- a/coral-component-tablist/src/scripts/Tab.js
+++ b/coral-component-tablist/src/scripts/Tab.js
@@ -185,14 +185,10 @@ const Tab = Decorator(class extends BaseLabellable(BaseComponent(HTMLElement)) {
   }
 
   set selected(value) {
-    let _selected = transform.booleanAttr(value);
+    value = transform.booleanAttr(value);
 
-    if(this._selected === _selected) {
-      return;
-    }
-
-    if (!_selected || _selected && !this.disabled) {
-      this._selected = _selected;
+    if (!value || value && !this.disabled) {
+      this._selected = value;
       this._reflectAttribute('selected', this.disabled ? false : this._selected);
 
       this.classList.toggle('is-selected', this._selected);

--- a/coral-component-tablist/src/scripts/TabList.js
+++ b/coral-component-tablist/src/scripts/TabList.js
@@ -149,9 +149,7 @@ class TabList extends BaseComponent(HTMLElement) {
       this._target = value;
 
       // we do in case the target was not yet in the DOM
-      !(this._setTargetInQueue === true) && window.requestAnimationFrame(() => {
-        delete this._setTargetInQueue;
-
+      window.requestAnimationFrame(() => {
         const realTarget = getTarget(this._target);
         // we add proper accessibility if available
         if (realTarget) {
@@ -194,7 +192,6 @@ class TabList extends BaseComponent(HTMLElement) {
           }
         }
       });
-      this._setTargetInQueue = true;
     }
   }
 
@@ -395,9 +392,7 @@ class TabList extends BaseComponent(HTMLElement) {
   }
 
   _setLine() {
-    !(this._setLineInQueue === true) && window.requestAnimationFrame(() => {
-      delete this._setLineInQueue;
-
+    window.requestAnimationFrame(() => {
       const selectedItem = this.selectedItem;
 
       // Position line under the selected item
@@ -433,8 +428,6 @@ class TabList extends BaseComponent(HTMLElement) {
       }
       this._previousOrientation = this.orientation;
     });
-
-    this._setLineInQueue = true;
   }
 
   /** @private */

--- a/coral-component-tabview/src/scripts/TabView.js
+++ b/coral-component-tabview/src/scripts/TabView.js
@@ -128,8 +128,26 @@ const TabView = Decorator(class extends BaseComponent(HTMLElement) {
         tagName: 'coral-panelstack',
         insert: function (panels) {
           this.appendChild(panels);
+          this._onNewPanelStack(panels);
         }
       });
+    }
+  }
+
+  /**
+   * This helps in syncing the tablist with new panelstack.
+   * This helpful when panelstack is changed for tabview dynamically. 
+   * @param {*} panels new/updated panelstack
+   */
+  _onNewPanelStack(panels) {
+    const tabs = this._elements.tabList;
+
+    // Bind the tablist and panel stack together, using the panel id
+    panels.id = panels.id || commons.getUID();
+    tabs.setAttribute('target', `#${panels.id}`);
+
+    if(tabs.selectedItem) {
+      tabs.selectedItem.selected = true;
     }
   }
 

--- a/coral-component-tabview/src/scripts/TabView.js
+++ b/coral-component-tabview/src/scripts/TabView.js
@@ -137,7 +137,7 @@ const TabView = Decorator(class extends BaseComponent(HTMLElement) {
   /**
    * This helps in syncing the tablist with new panelstack.
    * This helpful when panelstack is changed for tabview dynamically. 
-   * @param {*} panels new/updated panelstack
+   * @param {PanelStack} panels new/updated panelstack
    */
   _onNewPanelStack(panels) {
     const tabs = this._elements.tabList;


### PR DESCRIPTION
…eing selected

When loading the properties page in aem, sometimes the coral-panelstack does not gets selected. This results in a blank page. This issue seems to be coral-panelstack getting constructed twice and the newer constructed panelstack replaces the old created panelstack but the tablist target has already been set to the older one.

## Description
The change is a workaround to sync the tablist target with new panelstack and update the selection.  

## Related Issue
https://jira.corp.adobe.com/browse/CQ-4340781

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
