### PR TITLE
fix(CUI-7460): Intermittently rendering dialog resullt in error

### DIFF
--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -759,7 +759,8 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
         if(this._elements.wrapper.contains(content)) {
           this._elements.wrapper.insertBefore(headerWrapper, content);
         } else {
-          // try adding in next frame in case content is not the child of wrapper
+          // try adding in next frame
+          // so that content is a child of dialog wrapper
           commons.nextFrame(() => {
             this._elements.wrapper.insertBefore(headerWrapper, content);
           });


### PR DESCRIPTION
When loading the dialog sometimes, the content is not appended in the dialog wrapper and we try to insert the header wrapper before it, this result in javascript and lead to expected result.

## Description
This is a preventative check to add the headerWrapper if content is already appended or wait for a frame and then append headerWrapper.

## Related Issue
https://jira.corp.adobe.com/browse/CUI-7460

## Motivation and Context
CUI-7460 : [Hexaware] Facing issues while loading the Page in Production/Stage Author

## How Has This Been Tested?
Visually and running unit test cases to ensure no breaks.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
