### PR TITLE
fix(CQ-4341758): intermittently columnview does not allow selection

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnView.js
+++ b/coral-component-columnview/src/scripts/ColumnView.js
@@ -38,7 +38,7 @@ const scrollTo = (element, to, duration, scrollCallback) => {
         scrollCallback();
       }
     } else {
-      scrollTo(element, to, duration - 10);
+      scrollTo(element, to, duration - 10, scrollCallback);
     }
   }, 10);
 };


### PR DESCRIPTION
When using columnview components, it has been observed that intermittently it may not allow users to select a page. Specifically when loaded with horizontal scrollbar.

## Description
When columnview is loaded with horizontal scrollbar, if select an item the column is scrolled into view but scrollcallback was not getting called. This was because it was not passed when recursion scrollTo call was made.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
