### PR TITLE
fix(GRANITE-36119): Asset selection checkbox doesn't appear for all the assets in list view

### DIFF
--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -2472,6 +2472,21 @@ const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
   /**  @private */
   _handleMutations(mutations) {
     mutations.forEach((mutation) => {
+      // Sync added nodes
+      for (let k = 0 ; k < mutation.addedNodes.length ; k++) {
+        const addedNode = mutation.addedNodes[k];
+
+        if (isTableBody(addedNode)) {
+          this._onBodyContentChanged({
+            target: addedNode,
+            detail: {
+              addedNodes: getRows([addedNode]),
+              removedNodes: []
+            }
+          });
+        }
+      }
+
       // Sync removed nodes
       for (let k = 0 ; k < mutation.removedNodes.length ; k++) {
         const removedNode = mutation.removedNodes[k];
@@ -2653,7 +2668,7 @@ const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
     this._allowSorting = true;
     const column = this._isSorted();
     if (column) {
-      column._doSort(true);
+      column._doSort && column._doSort(true);
     }
 
     // @compat

--- a/coral-component-table/src/tests/test.Table.js
+++ b/coral-component-table/src/tests/test.Table.js
@@ -905,7 +905,8 @@ describe('Table', function () {
         // Wait for MO
         helpers.next(function () {
           // One event for the added row and one for the added body
-          expect(eventSpy.callCount).to.equal(1);
+          // change will trigger twice one for body mutation and second for row mutation.
+          expect(eventSpy.callCount).to.equal(2);
           expect(eventSpy.args[0][0].detail.oldSelection).to.deep.equal([]);
           expect(eventSpy.args[0][0].detail.selection).to.deep.equal(table.selectedItems);
           done();


### PR DESCRIPTION
Sometimes while loading the tableview, checkbox doesn't appear. This could be related to the fact that we disable the observer while loading the table template and as result the record might been dropping or the mutation might not be recorded as the observer is again set to on while body is appended. In some cases body mutation happens after the table has rendered as a result the already attached row are not correctly initialised.

## Description
When handling the mutation for body, we need take into account the addition of body element and the rows it currently contains. This way we can ensure the correct initialisation of all row element.

## Related Issue
GRANITE-36119

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Since this is a intermittent issue, we have tested it visually. The issue seems to be frequent in safari.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
