### PR TITLE
fix(ASSETS-6913): Add aria-label to more button element

### DIFF
--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -50,7 +50,7 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
     // Templates
     this._elements = {};
     this._itemsInPopover = [];
-    moreButton.call(this._elements);
+    moreButton.call(this._elements, {i18n});
     moreOverlay.call(this._elements, {commons});
     overlayContent.call(this._elements, {
       items: this._itemsInPopover,

--- a/coral-component-actionbar/src/templates/moreButton.html
+++ b/coral-component-actionbar/src/templates/moreButton.html
@@ -1,3 +1,3 @@
-<button is="coral-button" handle="moreButton" type="button" variant="quietaction" class="_coral-ActionBar-button" icon="more" coral-actionbar-more aria-expanded="false" aria-haspopup="true">
+<button is="coral-button" handle="moreButton" type="button" variant="quietaction" class="_coral-ActionBar-button" icon="more" coral-actionbar-more aria-expanded="false" aria-haspopup="true" aria-label="{{data.i18n.get('More')}}">
   <coral-button-label handle="moreButtonLabel"></coral-button-label>
 </button>

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -118,7 +118,7 @@ describe('ActionBar', function () {
       expect(bar.querySelectorAll('coral-popover').length).to.equal(2);
     });
 
-    it('should generate 2 more buttons that are "hidden" (offscreen) by default', function () {
+    it('should generate 2 more buttons that are "hidden" (offscreen) by default and have aria-label', function () {
       const bar = helpers.build(window.__html__['ActionBar.empty.html']);
 
       var leftButton = bar.primary.querySelectorAll('button[is="coral-button"][coral-actionbar-more]');
@@ -130,6 +130,9 @@ describe('ActionBar', function () {
       //test that both more buttons are offscreen by default (offscreen in order to still calc their width)
       expect(rightButton[0].hasAttribute('coral-actionbar-offscreen')).to.be.true;
       expect(leftButton[0].hasAttribute('coral-actionbar-offscreen')).to.be.true;
+      //test that both more buttons have aria-label
+      expect(rightButton[0].getAttribute('aria-label')).to.equal('More');
+      expect(leftButton[0].getAttribute('aria-label')).to.equal('More');
     });
 
     it('should be possible to instantiate a complex actionbar using markup', function () {


### PR DESCRIPTION
Asset information - Basic tab - '...' (more) button in the action bar does not have a programmatic text.
The screen reader should announce a programmatic label, such as "More".
@review @Pareesh 

## Description
Added aria label to '...' (more) button in the action bar.

## Related Issue
https://jira.corp.adobe.com/browse/ASSETS-6913

## Motivation and Context
The screen reader should announce a programmatic label for '...' (more) button in the action bar,  such as "More".

## How Has This Been Tested?
Checked if '...' (more) button has an aria-label attribute equal to "More".

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
