### PR TITLE
ASSETS-6856 : Files: Share Link - Visual heading text Link Sharing is…

### DIFF
--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -189,6 +189,9 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
       tagName: 'coral-dialog-header',
       insert: function (header) {
         header.classList.add(`${CLASSNAME}-title`);
+        // Providing the ARIA attributes to coral dialog header
+        header.setAttribute('role', 'heading');
+        header.setAttribute('aria-level', '2');
         // Position the header between the drag zone and the type icon
         this._elements.headerWrapper.insertBefore(header, this._elements.dragZone.nextElementSibling);
       },


### PR DESCRIPTION
… not marked as a heading

<!--- Provide a general summary of your changes in the Title above -->

## Description
If we follow hierarchical structure of coral dialog, we will find coral-dialog-header, having text as "Link Sharing".

This coral-dialog-header does not have any role and heading level. So role="heading" and aria-level="2" is need to add. Combinedly, it acts as heading tag level 2

Therefore as a solution, I added both of the ARIA properties.

Steps to fix:
coral-dialog-header is a hierarchical component of "/coral/foundation/dialog" and it generated automatically by js file

So adding role and aria-level by js is best solution of it. Moreover, this is suggested by reporter in jira itself.

Jira: https://jira.corp.adobe.com/browse/ASSETS-6856



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Actual issue:
In AEM 6.6 (cloudready), if we click on "Share Link" option from action toolbar from asset detail page. Then a dialog will open with a form. It has text "Link Sharing" as dialog header. So this dialog header did not have any heading role. 

Solution:
Adding role and aria-level to the element.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
