### PR TITLE
fix(ASSETS-6903): Files: Asset information - IPTC Extension tab - 'Person Shown' form fields are not associated with a label

### DIFF
--- a/coral-component-multifield/examples/index.html
+++ b/coral-component-multifield/examples/index.html
@@ -134,6 +134,17 @@
         </coral-multifield>
       </div>
 
+      <h2 class="coral--Heading--S">With label element</h2>
+      <div class="markup">
+        <label id="labelElement" style="display:block;padding: 4px 0 5px;">Label Coral Multifield</label>
+        <coral-multifield aria-label="With label element">
+          <button coral-multifield-add type="button" is="coral-button">Add a field</button>
+          <template coral-multifield-template>
+            <input is="coral-textfield" aria-label="input" type="text"/>
+          </template>
+        </coral-multifield>
+      </div>
+
     </main>
   </body>
 </html>

--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -583,11 +583,14 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
 
   /**
    * update aria-posinset and aria-setsize for each item in the collection
+   * add corresponding aria-labelledby to the inside input element 
    * @private
    */
-  _updatePosInSet() {
+   _updatePosInSet() {
     const items = this.items.getAll();
     const setsize = items.length;
+    // get the label element 
+    const labelElement = this.parentNode.querySelector('label');
     items.forEach((item, i) => {
       item.setAttribute('aria-posinset', i + 1);
       item.setAttribute('aria-setsize', setsize);
@@ -596,6 +599,12 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
       // add aria-labelledby so that the item is labelled by its content and itself.
       if (!item.querySelector('coral-multifield')) {
         item.setAttribute('aria-labelledby', `${item.id}-content ${item.id}`);
+      }
+      // add aria-labelledby to the input element
+      const inputElement = item.querySelector('input');
+      if (inputElement) {
+        const inputAriaLabelledBy = labelElement && labelElement.id ? `${labelElement.id} ${item.id}` : item.id;
+        inputElement.setAttribute('aria-labelledby', inputAriaLabelledBy);
       }
     });
   }


### PR DESCRIPTION
## This is only a draft PR for checking if the approach is the right one.
The form field does not announce any labels and only announces "edit blank" (editable field and currently blank).
The form field label should be announced by the screen reader.

- review @Pareesh @RitwikSrivastava 

## Description
Took the ids of the label and coral-multifield-item elements and used them to set the aria-lebelledby of the input element.
An example is also provided, please check it.

## Related Issue
https://jira.corp.adobe.com/browse/ASSETS-6903
https://jira.corp.adobe.com/browse/ASSETS-6901 (similar to ASSETS-6903)

## Motivation and Context
The form field label should be announced by the screen reader.

## How Has This Been Tested?
Not tested yet.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
