### PR TITLE
fix(ASSETS-6921): Hours and Minutes validation error label not available

### DIFF
--- a/coral-component-clock/i18n/translations.js
+++ b/coral-component-clock/i18n/translations.js
@@ -16,7 +16,8 @@ export default {
     "pm": "pm",
     "Hours": "Hours",
     "Minutes": "Minutes",
-    "AM/PM": "AM/PM"
+    "AM/PM": "AM/PM",
+    "invalidTime": "Please enter a valid time"
   },
   "de-DE": {
     "am": "vormittags",

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -86,6 +86,7 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
     // Add aria-errormessage attribute to coral-clock element
     this.errorID = (this.id || commons.getUID()) + "-coral-clock-error-label";
     this.setAttribute("aria-errormessage", this.errorID);
+    this.setAttribute("aria-live", "off");
 
     // Prevent typing in specific characters which can be added to number inputs
     const forbiddenChars = ["-", "+", "e", ",", "."];
@@ -251,12 +252,12 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
 
     if (this._elements.hours.invalid || this._elements.minutes.invalid) {
       errorLabel.setAttribute("id", this.errorID);
-      errorLabel.setAttribute("aria-live", "assertive");
+      this.setAttribute("aria-live", "assertive");
       errorLabel.hidden = false;
       errorLabel.style.display = "table-caption";
       errorLabel.style["caption-side"] = "bottom";
     } else {
-      errorLabel.setAttribute("aria-live", "off");
+      this.setAttribute("aria-live", "off");
       errorLabel.hidden = true;
     }
   }

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -82,6 +82,10 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
 
     // Pre-define labellable element
     this._labellableElement = this;
+
+    // Add aria-errormessage attribute to coral-clock element
+    this.errorID = (this.id || commons.getUID()) + "-coral-clock-error-label";
+    this.setAttribute("aria-errormessage", this.errorID);
   }
 
   /**
@@ -234,30 +238,17 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
     this._elements.hours.invalid = this._invalid;
     this._elements.minutes.invalid = this._invalid;
 
-    const createErrorMessage = () => {
-      const errorLabel = document.createElement("label");
-      const errorText = document.createTextNode("Please enter a valid time");
-      errorLabel.appendChild(errorText);
-      errorLabel.setAttribute("aria-errormessage", this.id);
-      errorLabel.setAttribute("id", "clock-error-label");
-      errorLabel.classList.add("coral-Form-errorlabel");
-      errorLabel.style.display = "table-row";
-      this.parentNode.appendChild(errorLabel);
-    };
-
-    const errorMessage = document.getElementById("clock-error-label");
-
-    const removeErrorMessage = () => {
-      errorMessage.remove();
-    };
+    const ERROR_LABEL_ELEMENT_CLASS = ".coral-Form-errorlabel";
+    const errorLabel = document.querySelector(ERROR_LABEL_ELEMENT_CLASS);
 
     if (this._elements.hours.invalid || this._elements.minutes.invalid) {
-      if (!errorMessage) {
-        createErrorMessage();
-      }
+      errorLabel.setAttribute("id", this.errorID);
+      errorLabel.setAttribute("aria-live", "assertive");
+      errorLabel.hidden = false;
+      errorLabel.style.display = "table-row";
     } else {
-      if (errorMessage) {
-        removeErrorMessage();}
+      errorLabel.setAttribute("aria-live", "off");
+      errorLabel.hidden = true;
     }
   }
 

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -85,7 +85,6 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
 
     // Add aria-errormessage attribute to coral-clock element
     this.errorID = (this.id || commons.getUID()) + "-coral-clock-error-label";
-    this.setAttribute("aria-errormessage", this.errorID);
 
     // Prevent typing in specific characters which can be added to number inputs
     const forbiddenChars = ["-", "+", "e", ",", "."];
@@ -245,6 +244,8 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
 
     this._elements.hours.invalid = this._invalid;
     this._elements.minutes.invalid = this._invalid;
+    this._elements.hours.setAttribute("aria-errormessage", this.errorID);
+    this._elements.minutes.setAttribute("aria-errormessage", this.errorID);
 
     const ERROR_LABEL_ELEMENT_CLASS = "._coral-Clock .coral-Form-errorlabel";
     const errorLabel = this.querySelector(ERROR_LABEL_ELEMENT_CLASS);

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -233,6 +233,32 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
 
     this._elements.hours.invalid = this._invalid;
     this._elements.minutes.invalid = this._invalid;
+
+    const createErrorMessage = () => {
+      const errorLabel = document.createElement("label");
+      const errorText = document.createTextNode("Please enter a valid time");
+      errorLabel.appendChild(errorText);
+      errorLabel.setAttribute("aria-errormessage", this.id);
+      errorLabel.setAttribute("id", "clock-error-label");
+      errorLabel.classList.add("coral-Form-errorlabel");
+      errorLabel.style.display = "table-row";
+      this.parentNode.appendChild(errorLabel);
+    };
+
+    const errorMessage = document.getElementById("clock-error-label");
+
+    const removeErrorMessage = () => {
+      errorMessage.remove();
+    };
+
+    if (this._elements.hours.invalid || this._elements.minutes.invalid) {
+      if (!errorMessage) {
+        createErrorMessage();
+      }
+    } else {
+      if (errorMessage) {
+        removeErrorMessage();}
+    }
   }
 
   /**

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -86,7 +86,6 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
     // Add aria-errormessage attribute to coral-clock element
     this.errorID = (this.id || commons.getUID()) + "-coral-clock-error-label";
     this.setAttribute("aria-errormessage", this.errorID);
-    this.setAttribute("aria-live", "off");
 
     // Prevent typing in specific characters which can be added to number inputs
     const forbiddenChars = ["-", "+", "e", ",", "."];
@@ -252,12 +251,12 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
 
     if (this._elements.hours.invalid || this._elements.minutes.invalid) {
       errorLabel.setAttribute("id", this.errorID);
-      this.setAttribute("aria-live", "assertive");
+      errorLabel.setAttribute("aria-live", "assertive");
       errorLabel.hidden = false;
       errorLabel.style.display = "table-caption";
       errorLabel.style["caption-side"] = "bottom";
     } else {
-      this.setAttribute("aria-live", "off");
+      errorLabel.setAttribute("aria-live", "off");
       errorLabel.hidden = true;
     }
   }

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -87,16 +87,13 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
     this.errorID = (this.id || commons.getUID()) + "-coral-clock-error-label";
     this.setAttribute("aria-errormessage", this.errorID);
 
-    // Removes 'e' from the input if typed in.
-    // 'e' can be typed in input of type 'number' and will invalidate the input but
-    // only by adding a red border & icon, and not setting 'invalid' and 'aria-invalid' attributes.
-    // That way the error text does not get displayed.
-    this.addEventListener("keyup", (e) => {
-      if (e.key === "e") {
-        this.value = "";
+    // Prevent typing in specific characters which can be added to number inputs
+    const forbiddenChars = ["-", "+", "e", ",", "."];
+    this.addEventListener("keydown", (e) => {
+      if (forbiddenChars.includes(e.key)) {
+        e.preventDefault();
       }
     });
-
   }
 
   /**

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -86,6 +86,17 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
     // Add aria-errormessage attribute to coral-clock element
     this.errorID = (this.id || commons.getUID()) + "-coral-clock-error-label";
     this.setAttribute("aria-errormessage", this.errorID);
+
+    // Removes 'e' from the input if typed in.
+    // 'e' can be typed in input of type 'number' and will invalidate the input but
+    // only by adding a red border & icon, and not setting 'invalid' and 'aria-invalid' attributes.
+    // That way the error text does not get displayed.
+    this.addEventListener("keyup", (e) => {
+      if (e.key === "e") {
+        this.value = "";
+      }
+    });
+
   }
 
   /**
@@ -238,14 +249,15 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
     this._elements.hours.invalid = this._invalid;
     this._elements.minutes.invalid = this._invalid;
 
-    const ERROR_LABEL_ELEMENT_CLASS = ".coral-Form-errorlabel";
+    const ERROR_LABEL_ELEMENT_CLASS = "._coral-Clock .coral-Form-errorlabel";
     const errorLabel = document.querySelector(ERROR_LABEL_ELEMENT_CLASS);
 
     if (this._elements.hours.invalid || this._elements.minutes.invalid) {
       errorLabel.setAttribute("id", this.errorID);
       errorLabel.setAttribute("aria-live", "assertive");
       errorLabel.hidden = false;
-      errorLabel.style.display = "table-row";
+      errorLabel.style.display = "table-caption";
+      errorLabel.style["caption-side"] = "bottom";
     } else {
       errorLabel.setAttribute("aria-live", "off");
       errorLabel.hidden = true;

--- a/coral-component-clock/src/scripts/Clock.js
+++ b/coral-component-clock/src/scripts/Clock.js
@@ -248,7 +248,7 @@ const Clock = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)) 
     this._elements.minutes.invalid = this._invalid;
 
     const ERROR_LABEL_ELEMENT_CLASS = "._coral-Clock .coral-Form-errorlabel";
-    const errorLabel = document.querySelector(ERROR_LABEL_ELEMENT_CLASS);
+    const errorLabel = this.querySelector(ERROR_LABEL_ELEMENT_CLASS);
 
     if (this._elements.hours.invalid || this._elements.minutes.invalid) {
       errorLabel.setAttribute("id", this.errorID);

--- a/coral-component-clock/src/templates/base.html
+++ b/coral-component-clock/src/templates/base.html
@@ -13,3 +13,4 @@
   <coral-select-item value="am"></coral-select-item>
   <coral-select-item value="pm"></coral-select-item>
 </coral-select>
+<label class="coral-Form-errorlabel" hidden >{{data.i18n.get('invalidTime')}}</label>

--- a/coral-component-clock/src/tests/test.Clock.js
+++ b/coral-component-clock/src/tests/test.Clock.js
@@ -417,6 +417,27 @@ describe('Clock', function () {
           expect(el.getAttribute('aria-labelledby')).to.equal(labelId + ' ' + el._elements.valueAsText.id);
         });
       });
+
+      describe('#invalid', function () {
+        it('Should show error message when clock has invalid state', function () {
+          var clock = document.getElementsByTagName('coral-clock')[0];
+          // Checks that error is hidden by default
+          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.true;
+          // Checks that error is shown when clock is invalid
+          el.invalid = true;
+          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.false;
+          // Check that error is hidden when clock is valid
+          el.invalid = false;
+          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.true;
+        });
+
+        it('Should disallow typing "e" in hours/minutes inputs', function () {
+          el.value = '10:55';
+          expect(el.value).to.equal('10:55');
+          el.value = 'e:ee';
+          expect(el.value).to.equal('');
+        })
+      })
     });
 
     describe('Markup', function () {
@@ -636,28 +657,8 @@ describe('Clock', function () {
       });
       describe('#required', function () {
       });
-
       describe('#invalid', function () {
-        it('Should show error message when clock has invalid state', function () {
-          var clock = document.getElementsByTagName('coral-clock')[0];
-          // Checks that error is hidden by default
-          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.true;
-          // Checks that error is shown when clock is invalid
-          el.invalid = true;
-          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.false;
-          // Check that error is hidden when clock is valid
-          el.invalid = false;
-          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.true;
-        });
-
-        it('Should disallow typing "e" in hours/minutes inputs', function () {
-          el.value = '10:55';
-          expect(el.value).to.equal('10:55');
-          el.value = 'e:ee';
-          expect(el.value).to.equal('');
-        })
       });
-
       describe('#labelledby', function () {
         it('should combine labelledby and _elements.valueAsText.id in the aria-labelledby attribute', function () {
           helpers.build(window.__html__['Clock.labelledby.html']);

--- a/coral-component-clock/src/tests/test.Clock.js
+++ b/coral-component-clock/src/tests/test.Clock.js
@@ -636,8 +636,28 @@ describe('Clock', function () {
       });
       describe('#required', function () {
       });
+
       describe('#invalid', function () {
+        it('Should show error message when clock has invalid state', function () {
+          var clock = document.getElementsByTagName('coral-clock')[0];
+          // Checks that error is hidden by default
+          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.true;
+          // Checks that error is shown when clock is invalid
+          el.invalid = true;
+          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.false;
+          // Check that error is hidden when clock is valid
+          el.invalid = false;
+          expect(clock.querySelector('.coral-Form-errorlabel').hidden).to.be.true;
+        });
+
+        it('Should disallow typing "e" in hours/minutes inputs', function () {
+          el.value = '10:55';
+          expect(el.value).to.equal('10:55');
+          el.value = 'e:ee';
+          expect(el.value).to.equal('');
+        })
       });
+
       describe('#labelledby', function () {
         it('should combine labelledby and _elements.valueAsText.id in the aria-labelledby attribute', function () {
           helpers.build(window.__html__['Clock.labelledby.html']);


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/ASSETS-6921
https://jira.corp.adobe.com/browse/ASSETS-6920
https://jira.corp.adobe.com/browse/ASSETS-6852

## Description
Added an error label to coral clock that is displayed whenever the hours and/or minutes inputs are invalid.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually  & with screen reader

## Screenshots (if appropriate):
![Screen Shot 2022-08-17 at 19 08 27](https://user-images.githubusercontent.com/74657799/185189163-a0d6efcd-b999-4fc8-b211-dae7b3bd4cb6.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
