### PR TITLE
fix(SITES-2869): Hidden or empty element receive focus

### DIFF
--- a/coral-component-accordion/src/scripts/AccordionItem.js
+++ b/coral-component-accordion/src/scripts/AccordionItem.js
@@ -137,12 +137,12 @@ const AccordionItem = Decorator(class extends BaseComponent(HTMLElement) {
 
     if(!this._selected) {
       this._elements.content.setAttribute('aria-hidden', 'true');
-      setTimeout(this._elements.content.style.visibility = 'hidden', 500);
+      this._elements.content.style.visibility = 'hidden';
     } else {
       this._elements.content.setAttribute('aria-hidden', 'false');
       this._elements.content.style.visibility = 'visible';
     }
-    
+
     this.trigger('coral-accordion-item:_selectedchanged');
   }
 

--- a/coral-component-accordion/src/scripts/AccordionItem.js
+++ b/coral-component-accordion/src/scripts/AccordionItem.js
@@ -135,6 +135,14 @@ const AccordionItem = Decorator(class extends BaseComponent(HTMLElement) {
       });
     }
 
+    if(!this._selected) {
+      this._elements.content.setAttribute('aria-hidden', 'true');
+      setTimeout(this._elements.content.style.visibility = 'hidden', 500);
+    } else {
+      this._elements.content.setAttribute('aria-hidden', 'false');
+      this._elements.content.style.visibility = 'visible';
+    }
+    
     this.trigger('coral-accordion-item:_selectedchanged');
   }
 


### PR DESCRIPTION
Hidden or empty element receive focus: removing focus from hidden radio buttons

## Description
Adding an if-statement in the accordion item component in order to check the state of the component and based on that, removing focus and hiding the content inside the accordion button. Improves user-experience for people using AT(ScreenReader, VoiceOver, etc.)

## Related Issue
https://jira.corp.adobe.com/browse/SITES-2869

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
