### PR TITLE
fix(ASSETS-6857): Set the tabindex attribute of calendar button according to the disabled attribute value

### DIFF
--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -478,6 +478,7 @@ const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLEleme
     this._elements.input.disabled = this._disabled;
     this._elements.hiddenInput.disabled = this._disabled;
     this._elements.toggle.disabled = this._disabled || this.readOnly;
+    this._elements.toggle.setAttribute("tabindex", !this._elements.toggle.disabled ? "0" : "-1");
   }
 
   /**
@@ -534,6 +535,7 @@ const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLEleme
     this._elements.hiddenInput.readOnly = this.readOnly;
     this._elements.input.readOnly = this._readOnly;
     this._elements.toggle.disabled = this._readOnly || this.disabled;
+    this._elements.toggle.setAttribute("tabindex", !this._elements.toggle.disabled ? "0" : "-1");
   }
 
   /**

--- a/coral-component-datepicker/src/tests/test.Datepicker.js
+++ b/coral-component-datepicker/src/tests/test.Datepicker.js
@@ -72,6 +72,19 @@ describe('Datepicker', function () {
       });
 
       describe('#disabled', function () {
+        it('should not be able to tab to calendar button with disabled set to true', function () {
+          el.disabled = true;
+
+          expect(el._elements.toggle.disabled).to.be.true;
+          expect(el._elements.toggle.getAttribute('tabindex')).to.equal('-1');
+        });
+
+        it('should be able to tab to calendar button with disabled set to false', function () {
+          el.disabled = false;
+
+          expect(el._elements.toggle.disabled).to.be.false;
+          expect(el._elements.toggle.getAttribute('tabindex')).to.equal('0');
+        });
       });
 
       describe('#displayFormat', function () {
@@ -348,6 +361,23 @@ describe('Datepicker', function () {
 
           expect(el.contains(document.activeElement)).to.be.false;
         });
+
+        it('should not be able to tab to calendar button with readOnly set to true', function () {
+          el.readOnly = true;
+
+          expect(el._elements.input.readOnly).to.be.true;
+          expect(el._elements.toggle.disabled).to.be.true;
+          expect(el._elements.toggle.getAttribute('tabindex')).to.equal('-1');
+        });
+
+        it('should be able to tab to calendar button with readOnly set to false', function () {
+          el.readOnly = false;
+
+          expect(el._elements.input.readOnly).to.be.false;
+          expect(el._elements.toggle.disabled).to.be.false;
+          expect(el._elements.toggle.getAttribute('tabindex')).to.equal('0');
+        });
+
       });
 
       describe('#required', function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A keyboard user is unable to tab to the calendar button.
A keyboard user should be able to tab to the calendar button, and the element should be announced as a button.
@review @Pareesh @RitwikSrivastava

## Description
<!--- Describe your changes in detail -->
Set the tabindex attribute of calendar button according to the disabled attribute value.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/ASSETS-6857

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A keyboard user should be able to tab to the calendar button, and the element should be announced as a button.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By tabbing through the asset manage publication page and by checking if tabindex attribute of calendar button is "-1" when disabled and "0" when is not disabled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
