### PR TITLE
ASSETS-6819: Make content of the calendar widget scrollable when the …

### DIFF
--- a/coral-component-datepicker/src/templates/base.html
+++ b/coral-component-datepicker/src/templates/base.html
@@ -1,4 +1,4 @@
-<coral-popover tracking="off" smart class="_coral-Datepicker-overlay" handle="overlay" id="{{data.commons.getUID()}}" breadthoffset="50%r - 50%p" placement="bottom"></coral-popover>
+<coral-popover tracking="off" smart class="_coral-Datepicker-overlay" handle="overlay" id="{{data.commons.getUID()}}" breadthoffset="50%r - 50%p" placement="bottom" style="max-height: 75vh;"></coral-popover>
 <input type="hidden" handle="hiddenInput">
 <input tracking="off" is="coral-textfield" type="text" handle="input" class="_coral-InputGroup-field" role="textbox">
 <button tracking="off" is="coral-button" variant="_custom" class="_coral-InputGroup-button _coral-FieldButton" type="button" handle="toggle" aria-haspopup="dialog" aria-label="{{data.i18n.get('Calendar')}}" title="{{data.i18n.get('Calendar')}}">


### PR DESCRIPTION
…page is zoomed to 200%

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The calendar pop-up dialog box gets cut from below when rendered at zoom level 200%. Adding a max-height of 75vh ensures that it becomes scrollable at 200%.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
