### PR TITLE
fix(ASSETS-6864): Set aria-expanded of the button to true when timeline cycle button item is selected on annotate asset page

### DIFF
--- a/coral-component-cyclebutton/src/scripts/CycleButton.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButton.js
@@ -51,6 +51,9 @@ const ACTION_TAG_NAME = 'coral-cyclebutton-action';
 
 const CLASSNAME = '_coral-CycleSelect';
 
+const TIMELINE_CYCLE_BUTTON_ITEM = "coral-cyclebutton-item[data-granite-toggleable-control-name='timeline']";
+const CONTENT_ONLY_CYCLE_BUTTON_ITEM = "coral-cyclebutton-item[data-granite-toggleable-control-name='content-only']";
+
 /**
  @class Coral.CycleButton
  @classdesc A CycleButton component is a simple multi-state toggle button that toggles between the possible items below
@@ -391,6 +394,19 @@ const CycleButton = Decorator(class extends BaseComponent(HTMLElement) {
     }
   }
 
+  /** @private */
+  _isAnnotateAssetPage() {
+    const loc = window.location.pathname;
+    const assetAnnotatePage = "/annotate.html/";
+    return loc.includes(assetAnnotatePage);
+  }
+
+  /** @private */
+  _isAnnotateAssetItemSelected(selector) {
+    const cycleButtonItem = $(selector);
+    return this._isAnnotateAssetPage() && cycleButtonItem && cycleButtonItem.attr("selected");
+  }
+
   /**
    Render the provided item as selected according to resolved icon and displayMode properties.
 
@@ -442,6 +458,21 @@ const CycleButton = Decorator(class extends BaseComponent(HTMLElement) {
       // @a11y we do not require aria attributes since we already show text
       this._elements.button.removeAttribute('aria-label');
       this._elements.button.removeAttribute('title');
+    }
+
+    // @a11y
+    // on annotate asset page
+    // if timeline cycle button item is selected
+    // the aria-expanded attribute of the button should be true
+    const isAnnotateAssetTimelineSelected = this._isAnnotateAssetItemSelected(TIMELINE_CYCLE_BUTTON_ITEM);
+    if (isAnnotateAssetTimelineSelected) {
+      this._elements.button.setAttribute('aria-expanded', true);
+    }
+    // if timeline cycle button item is selected
+    // the aria-expanded attribute of the button should be false
+    const isAnnotateAssetContentOnlySelected = this._isAnnotateAssetItemSelected(CONTENT_ONLY_CYCLE_BUTTON_ITEM);
+    if (isAnnotateAssetContentOnlySelected) {
+      this._elements.button.setAttribute("aria-expanded", false);
     }
   }
 
@@ -625,7 +656,12 @@ const CycleButton = Decorator(class extends BaseComponent(HTMLElement) {
 
   _onOverlayClose() {
     // @a11y
-    this._elements.button.setAttribute('aria-expanded', false);
+    // when annotation asset page initially loads and timeline cycle button item is selected
+    // prevent changing the aria-expanded attribute of the button to false
+    const isAnnotateAssetTimelineSelected = this._isAnnotateAssetItemSelected(TIMELINE_CYCLE_BUTTON_ITEM);
+    if (!isAnnotateAssetTimelineSelected) {
+      this._elements.button.setAttribute('aria-expanded', false);
+    }
   }
 
   _onOverlayOpen() {

--- a/coral-component-cyclebutton/src/scripts/CycleButton.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButton.js
@@ -51,8 +51,8 @@ const ACTION_TAG_NAME = 'coral-cyclebutton-action';
 
 const CLASSNAME = '_coral-CycleSelect';
 
-const TIMELINE_CYCLE_BUTTON_ITEM = "coral-cyclebutton-item[data-granite-toggleable-control-name='timeline']";
 const CONTENT_ONLY_CYCLE_BUTTON_ITEM = "coral-cyclebutton-item[data-granite-toggleable-control-name='content-only']";
+const TIMELINE_CYCLE_BUTTON_ITEM = "coral-cyclebutton-item[data-granite-toggleable-control-name='timeline']";
 
 /**
  @class Coral.CycleButton
@@ -395,16 +395,16 @@ const CycleButton = Decorator(class extends BaseComponent(HTMLElement) {
   }
 
   /** @private */
+  _isAnnotateAssetItemSelected(selector) {
+    const cycleButtonItem = $(selector);
+    return this._isAnnotateAssetPage() && cycleButtonItem && cycleButtonItem.attr("selected");
+  }
+
+  /** @private */
   _isAnnotateAssetPage() {
     const loc = window.location.pathname;
     const assetAnnotatePage = "/annotate.html/";
     return loc.includes(assetAnnotatePage);
-  }
-
-  /** @private */
-  _isAnnotateAssetItemSelected(selector) {
-    const cycleButtonItem = $(selector);
-    return this._isAnnotateAssetPage() && cycleButtonItem && cycleButtonItem.attr("selected");
   }
 
   /**
@@ -468,7 +468,7 @@ const CycleButton = Decorator(class extends BaseComponent(HTMLElement) {
     if (isAnnotateAssetTimelineSelected) {
       this._elements.button.setAttribute('aria-expanded', true);
     }
-    // if timeline cycle button item is selected
+    // if content only cycle button item is selected
     // the aria-expanded attribute of the button should be false
     const isAnnotateAssetContentOnlySelected = this._isAnnotateAssetItemSelected(CONTENT_ONLY_CYCLE_BUTTON_ITEM);
     if (isAnnotateAssetContentOnlySelected) {


### PR DESCRIPTION
The screen reader announces that the control is collapsed, when in fact the 'Timeline' column is expanded.
The screen reader should announce that the control is expanded.
@review @Pareesh @RitwikSrivastava

## Description
Set aria-expanded of the button to true when timeline cycle button item is selected on annotate asset page.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/ASSETS-6864

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The screen reader should announce that the control is expanded when the 'Timeline' column is expanded.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By selecting timeline cycle button item on annotate asset page and by checking if the aria-expanded of the button is set to true.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
