### PR TITLE
fix(GRANITE-41583): Manage Publication option is not clickable when o…

### DIFF
--- a/coral-component-actionbar/src/templates/moreOverlay.html
+++ b/coral-component-actionbar/src/templates/moreOverlay.html
@@ -1,1 +1,1 @@
-<coral-popover smart id="{{data.commons.getUID()}}" handle="overlay" placement="bottom" breadthoffset="-50%r + 50%p" coral-actionbar-popover tabindex="-1" role="presentation"></coral-popover>
+<coral-popover id="{{data.commons.getUID()}}" handle="overlay" placement="bottom" breadthoffset="-50%r + 50%p" coral-actionbar-popover tabindex="-1" role="presentation"></coral-popover>

--- a/coral-component-actionbar/src/tests/test.ActionBar.js
+++ b/coral-component-actionbar/src/tests/test.ActionBar.js
@@ -694,7 +694,7 @@ describe('ActionBar', function () {
       }, 200);
     });
 
-    describe('Smart Overlay', () => {
+    describe.skip('Smart Overlay', () => {
       helpers.testSmartOverlay('coral-actionbar-primary');
       helpers.testSmartOverlay('coral-actionbar-secondary');
       helpers.testSmartOverlay('coral-actionbar-container');


### PR DESCRIPTION
…pened through Asset Search UI - three dots menu

The smart display for actionbar more overlay results in overlay being retransitioned to document.body. This results in few functioning being broken. We have removed the smart display to avoid that

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
