### PR TITLE
fix(ASSETS-6863): Files: Asset information - IPTC tab - Certain ARIA roles must contain particular children

### DIFF
--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -570,10 +570,7 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     }
 
     // a11y
-    // add role list attribute if is not already added
-    if (self.getAttribute('role') !== 'list') {
-      self.setAttribute('role', 'list');
-    }
+    self._handleRoleList();
   }
 
   /** @private */
@@ -587,9 +584,19 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     }
 
     // a11y
-    // remove role list attribute if there is no item left
-    if (self.items.length === 0) {
-      this.removeAttribute('role');
+    self._handleRoleList();
+  }
+
+  /**
+   * handle role list of the multifield based on number of items
+   * @private
+   */
+  _handleRoleList() {
+    const self = this;
+    if (self.items.length > 0 && self.getAttribute('role') !== 'list') {
+      self.setAttribute('role', 'list');
+    } else if (self.items.length === 0 && self.getAttribute('role') === 'list') {
+      self.removeAttribute('role');
     }
   }
 
@@ -653,10 +660,7 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     this.classList.add(CLASSNAME, 'coral-Well');
 
     // a11y
-    // add role list attribute if there is at least one item
-    if (this.items.length > 0) {
-      this.setAttribute('role', 'list');
-    }
+    this._handleRoleList();
 
     // Assign the content zones, moving them into place in the process
     this.template = this._elements.template;

--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -568,6 +568,12 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     if(self.items.length === self.min + 1) {
       self._validateMinItems();
     }
+
+    // a11y
+    // add role list attribute if is not already added
+    if (self.getAttribute('role') !== 'list') {
+      self.setAttribute('role', 'list');
+    }
   }
 
   /** @private */
@@ -578,6 +584,12 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     // only validate when required
     if(self.items.length <= self.min) {
       self._validateMinItems();
+    }
+
+    // a11y
+    // remove role list attribute if there is no item left
+    if (self.items.length === 0) {
+      this.removeAttribute('role');
     }
   }
 
@@ -641,7 +653,10 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     this.classList.add(CLASSNAME, 'coral-Well');
 
     // a11y
-    this.setAttribute('role', 'list');
+    // add role list attribute if there is at least one item
+    if (this.items.length > 0) {
+      this.setAttribute('role', 'list');
+    }
 
     // Assign the content zones, moving them into place in the process
     this.template = this._elements.template;

--- a/coral-component-multifield/src/tests/test.Multifield.js
+++ b/coral-component-multifield/src/tests/test.Multifield.js
@@ -586,6 +586,38 @@ describe('Multifield', function () {
       });
     });
 
+    it('should not have role list attribute set initially', function () {
+      const el = helpers.build(window.__html__['Multifield.base.html']);
+      expect(el.items.getAll().length).to.equal(0);
+      expect(el.getAttribute('role')).to.be.null;
+    });
+
+    it('should have role list attribute set after adding item', function (done) {
+      const el = helpers.build(window.__html__['Multifield.base.html']);
+      el.items.add({});
+      helpers.next(() => {
+        expect(el.items.getAll().length).to.equal(1);
+        expect(el.getAttribute('role')).to.equal('list');
+        done();
+      });
+    });
+
+    it('should not have role list attribute set after removing all items', function (done) {
+      const el = helpers.build(window.__html__['Multifield.base.html']);
+      el.items.add({});
+      el.items.add({});
+      helpers.next(() => {
+        expect(el.items.getAll().length).to.equal(2);
+        expect(el.getAttribute('role')).to.equal('list');
+        el.items.clear();
+        helpers.next(() => {
+          expect(el.items.getAll().length).to.equal(0);
+          expect(el.getAttribute('role')).to.be.null;
+          done();
+        });
+      });
+    });
+
     describe('keyboard reordering', function () {
       it('should toggle aria-grabbed and force forms mode when move button is clicked', function () {
         const el = helpers.build(window.__html__['Multifield.base.html']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When the "Keywords" region does not contain any input fields, consider removing the role="list" attribute from the element.
As the "Add" button is pressed and the input fields (which contain the expected role="listitem") appear, consider using JavaScript to add role="list" back to the element.
@review @Pareesh @RitwikSrivastava 

## Description
<!--- Describe your changes in detail -->
Handle role list attribute according to the number of items.
When coral-multifield list of items is empty, the role should change.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/ASSETS-6863

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Only when the list of items is not empty should have the role list attribute added.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By adding and removing items.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
