### PR TITLE
fix(ASSETS-6862): Files: Filter - Required ARIA child role is missing

### DIFF
--- a/coral-component-taglist/src/scripts/TagList.js
+++ b/coral-component-taglist/src/scripts/TagList.js
@@ -295,8 +295,8 @@ const TagList = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)
     attachedItem.setAttribute('role', 'row');
 
     // adds role to parent to support accessibility, if it doesn't already have it
-    if (attachedItem.parentElement.getAttribute('role') === null) {
-      attachedItem.parentElement.setAttribute('role', 'grid');
+    if (this.getAttribute('role') === null) {
+      this.setAttribute('role', 'grid');
     }
 
     if (!this.disabled) {
@@ -327,7 +327,7 @@ const TagList = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)
     detachedItem.removeAttribute('role');
 
     // Removes role from taglist if it has no tag elements
-    if (this.childNodes.length <= 0) {
+    if (this.items.length <= 0) {
       this.removeAttribute('role');
     }
 

--- a/coral-component-taglist/src/scripts/TagList.js
+++ b/coral-component-taglist/src/scripts/TagList.js
@@ -293,6 +293,12 @@ const TagList = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)
 
     // adds the role to support accessibility
     attachedItem.setAttribute('role', 'row');
+
+    // adds role to parent to support accessibility, if it doesn't already have it
+    if (attachedItem.parentElement.getAttribute('role') === null) {
+      attachedItem.parentElement.setAttribute('role', 'grid');
+    }
+
     if (!this.disabled) {
       attachedItem.setAttribute('tabindex', '-1');
     }
@@ -319,6 +325,12 @@ const TagList = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)
   _onItemDisconnected(detachedItem) {
     // Cleans the tag from TagList specific values
     detachedItem.removeAttribute('role');
+
+    // Removes role from taglist if it has no tag elements
+    if (this.childNodes.length <= 0) {
+      this.removeAttribute('role');
+    }
+
     detachedItem.removeAttribute('tabindex');
     detachedItem._host = undefined;
 
@@ -535,7 +547,11 @@ const TagList = Decorator(class extends BaseFormField(BaseComponent(HTMLElement)
     this.classList.add(CLASSNAME);
 
     // adds the role to support accessibility
-    this.setAttribute('role', 'grid');
+    if (this.items.length > 0) {
+      this.setAttribute('role', 'grid');
+    } else {
+      this.removeAttribute('role');
+    };
 
     this.setAttribute('aria-live', 'off');
     this.setAttribute('aria-atomic', 'false');

--- a/coral-component-taglist/src/tests/test.TagList.js
+++ b/coral-component-taglist/src/tests/test.TagList.js
@@ -429,6 +429,11 @@ describe('TagList', function () {
       expect(tagList.getAttribute('role')).to.equal('grid');
     });
 
+    it('should not have a role of grid when having no children', function () {
+      var tagList = helpers.build(window.__html__['TagList.empty.html']);
+      expect(tagList.getAttribute('role')).not.to.equal('grid');
+    });
+
     it('should remove a focused tag on backspace', function () {
       var eventSpy = sinon.spy();
       var tagList = helpers.build(window.__html__['TagList.base.html']);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
- adding `role=grid` attribute to `coral-taglist` elements when they have a child with `role=row` attribute 
- removing the `role=grid` attribute from `coral-taglist` when it has no child

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/ASSETS-6862
https://jira.corp.adobe.com/browse/ASSETS-6858

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves accessibility issue that affects user population: Without Vision, With Limited Vision, With Limited Manipulation, With Limited Reach and Strength, With Limited Language, Cognitive, and Learning Abilities

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- tested manually by adding/removing `coral-tag` elements on `coral-taglist` items and observing that the `role` attributes are added/removed accordingly

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
