### PR TITLE
SITES-2864: Accessibility - Drag and Drop feature is not keyboard accessible.

### DIFF
--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -132,7 +132,13 @@ const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
       'coral-dragaction:dragstart tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragStart',
       'coral-dragaction:drag tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDrag',
       'coral-dragaction:dragover tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragOver',
-      'coral-dragaction:dragend tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragEnd',
+      'coral-dragaction:dragend tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragEnd',    
+      // a11y dnd
+      'key:space tbody[is="coral-table-body"] [coral-table-roworder]:not([disabled])': '_onKeyboardDrag',
+      'coral-dragaction:dragonkeyspace tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragOnKeySpace',
+      'coral-dragaction:dragoveronkeyarrowdown tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragOverOnKeyArrowDown',
+      'coral-dragaction:dragoveronkeyarrowup tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragOverOnKeyArrowUp',
+      'coral-dragaction:dragendonkey tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowDragOverOnKeyEnter',
       // a11y
       'mousedown tbody[is="coral-table-body"] [coral-table-rowselect]': '_onRowDown',
       'key:enter tbody[is="coral-table-body"] tr[is="coral-table-row"]': '_onRowSelect',

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -1218,6 +1218,20 @@ const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
   }  
 
   /** @private */
+  _onRowDragOnKeySpace(event) {
+    const dragElement = event.detail.dragElement;
+    const dragData = dragElement.dragAction._dragData;
+
+    dragData.style.cells = [];
+    getCells(dragElement).forEach((cell) => {
+      // Backup styles to restore them later
+      dragData.style.cells.push(cell.getAttribute('style'));
+      // Cells will shrink otherwise
+      cell.style.width = window.getComputedStyle(cell).width;
+    });
+  }  
+
+  /** @private */
   _onRowMultipleChanged(event) {
     event.stopImmediatePropagation();
 

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -1180,6 +1180,43 @@ const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
     });
   }
 
+  /** @private */  
+  _onKeyboardDrag(event) {
+    const table = this;
+    const row = event.target.closest('tr[is="coral-table-row"]');
+    
+    if (row && table.orderable) {
+      const body = table.body;
+      const style = row.getAttribute('style');
+      const index = getIndexOf(row);
+      const oldBefore = row.nextElementSibling;
+      const dragAction = new DragAction(row);
+      const items = getRows([body]);
+
+      dragAction.axis = 'vertical';
+      // Handle the scroll in table
+      dragAction.scroll = false;
+      // Specify selection handle directly on the row if none found
+      dragAction.handle = row.querySelector('[coral-table-roworder]');
+
+      // The row placeholder indicating where the dragged element will be dropped
+      const placeholder = row.cloneNode(true);
+      placeholder.classList.add('_coral-Table-row--placeholder');
+
+      // Store the data to avoid re-reading the layout on drag events
+      const dragData = {
+        placeholder: placeholder,
+        index: index,
+        oldBefore: oldBefore,
+        // Backup styles to restore them later
+        style: {
+          row: style
+        }
+      };
+      row.dragAction._dragData = dragData;
+    }
+  }  
+
   /** @private */
   _onRowMultipleChanged(event) {
     event.stopImmediatePropagation();

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -1232,6 +1232,62 @@ const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
   }  
 
   /** @private */
+  _onRowDragOverOnKeyArrowDown(event) {
+    const table = this;
+    const body = table.body;
+    const dragElement = event.detail.dragElement;
+    const items = getRows([body]);
+    const index = getIndexOf(dragElement);
+    const dragData = dragElement.dragAction._dragData;
+
+    // We cannot rely on :focus since the row is being moved in the dom while dnd
+    dragElement.classList.add('is-focused');
+
+    if (dragElement === items[items.length - 1]) {
+      for (let position = 0; position < items.length - 1; position++) {
+        body.appendChild(items[position]);
+      }
+      body.insertBefore(items[0], items[items.length - 2].nextElementSibling);
+    } else {
+      body.insertBefore(items[index + 1], items[index]);
+    }
+
+    // Restore specific styling
+    dragElement.setAttribute('style', dragData.style.row || '');
+    getCells(dragElement).forEach((cell, i) => {
+      cell.setAttribute('style', dragData.style.cells[i] || '');
+    });  
+  }
+
+  /** @private */
+  _onRowDragOverOnKeyArrowUp(event) {
+    const table = this;
+    const body = table.body;
+    const dragElement = event.detail.dragElement;
+    const items = getRows([body]);
+    const index = getIndexOf(dragElement);
+    const dragData = dragElement.dragAction._dragData;
+
+    // We cannot rely on :focus since the row is being moved in the dom while dnd
+    dragElement.classList.add('is-focused');
+
+    if (dragElement === items[0]) {
+      for (let position = 0; position < items.length - 2; position++) {
+        body.insertBefore(items[position + 1], items[0]);
+      }
+      body.insertBefore(items[items.length - 1], items[1]);
+    } else {
+      body.insertBefore(items[index - 1], items[index].nextElementSibling);
+    }
+
+    // Restore specific styling
+    dragElement.setAttribute('style', dragData.style.row || '');
+    getCells(dragElement).forEach((cell, i) => {
+      cell.setAttribute('style', dragData.style.cells[i] || '');
+    });  
+  }  
+
+  /** @private */
   _onRowMultipleChanged(event) {
     event.stopImmediatePropagation();
 

--- a/coral-component-table/src/scripts/Table.js
+++ b/coral-component-table/src/scripts/Table.js
@@ -1285,6 +1285,19 @@ const Table = Decorator(class extends BaseComponent(HTMLTableElement) {
     getCells(dragElement).forEach((cell, i) => {
       cell.setAttribute('style', dragData.style.cells[i] || '');
     });  
+  }
+  
+  /** @private */
+  _onRowDragOverOnKeyEnter(event) {
+    const table = this;
+    const dragElement = event.detail.dragElement;
+    dragElement.dragAction.destroy();
+
+    // Refocus the dragged element manually
+    window.requestAnimationFrame(() => {
+      dragElement.classList.remove('is-focused');
+      table._focusItem(dragElement, true);
+    });
   }  
 
   /** @private */

--- a/coral-dragaction/src/scripts/DragAction.js
+++ b/coral-dragaction/src/scripts/DragAction.js
@@ -682,6 +682,36 @@ class DragAction {
     }
   }
 
+  /** @private */
+  _dragOnKey(event) {
+    switch (event.code) {
+      case 'Space':
+        this._dragEvents.dispatch('coral-dragaction:dragonkeyspace', {
+          detail: {
+            dragElement: this._dragElement
+          }
+        });
+        break;
+      case 'ArrowDown':
+        this._dragEvents.dispatch('coral-dragaction:dragoveronkeyarrowdown', {
+          detail: {
+            dragElement: this._dragElement
+          }
+        });
+        break;
+      case 'ArrowUp':
+        this._dragEvents.dispatch('coral-dragaction:dragoveronkeyarrowup', {
+          detail: {
+            dragElement: this._dragElement
+          }
+        });
+        break;
+      case 'Enter':
+        this._dragOnKeyEnd(event);
+        break;
+    }
+  }  
+
   /**
    Remove draggable actions
 

--- a/coral-dragaction/src/scripts/DragAction.js
+++ b/coral-dragaction/src/scripts/DragAction.js
@@ -888,6 +888,51 @@ class DragAction {
    @property {Number} pageY
    The mouse position relative to the top edge of the document.
    */
+
+  /**
+   Triggered when the {@link DragAction#dragElement} is selected to be dragged.
+
+   @typedef {CustomEvent} coral-dragaction:dragonkeyspace
+
+   @property {HTMLElement} dragElement
+   The dragged element
+   */
+
+  /**
+   Triggered when the {@link DragAction#dragElement} is moved on arrow down pressed.
+
+   @typedef {CustomEvent} coral-dragaction:dragoveronkeyarrowdown
+
+   @property {HTMLElement} dragElement
+   The dragged element
+   */
+
+  /**
+   Triggered when the {@link DragAction#dragElement} is moved on arrow up pressed.
+
+   @typedef {CustomEvent} coral-dragaction:dragoveronkeyarrowup
+
+   @property {HTMLElement} dragElement
+   The dragged element
+   */
+
+  /**
+   Triggered when the {@link DragAction#dragElement} is losing focus.
+
+   @typedef {CustomEvent} coral-dragaction:dragonkeyfocusout
+
+   @property {HTMLElement} dragElement
+   The dragged element
+   */
+
+  /**
+   Triggered when the {@link DragAction#dragElement} is dropped on key.
+
+   @typedef {CustomEvent} coral-dragaction:dragendonkey
+
+   @property {HTMLElement} dragElement
+   The dragged element
+   */      
 }
 
 export default DragAction;

--- a/coral-dragaction/src/scripts/DragAction.js
+++ b/coral-dragaction/src/scripts/DragAction.js
@@ -712,6 +712,15 @@ class DragAction {
     }
   }  
 
+  /** @private */
+  _dragOnKeyEnd(event) {
+    this._dragEvents.dispatch('coral-dragaction:dragendonkey', {
+      detail: {
+        dragElement: this._dragElement
+      }
+    });
+  }  
+
   /**
    Remove draggable actions
 

--- a/coral-dragaction/src/scripts/DragAction.js
+++ b/coral-dragaction/src/scripts/DragAction.js
@@ -244,11 +244,13 @@ class DragAction {
 
     this._drag = this._drag.bind(this);
     this._dragEnd = this._dragEnd.bind(this);
+    this._dragOnKeyEnd = this._dragOnKeyEnd.bind(this);
 
     events.on(`touchmove.DragAction${this._id}`, this._drag);
     events.on(`mousemove.DragAction${this._id}`, this._drag);
     events.on(`touchend.DragAction${this._id}`, this._dragEnd);
     events.on(`mouseup.DragAction${this._id}`, this._dragEnd);
+    events.on(`focusout.DragAction${this._id}`, this._dragOnKeyEnd);
 
     // Store reference on dragElement
     this._dragElement.dragAction = this;
@@ -307,11 +309,13 @@ class DragAction {
           handle._dragEvents = handle._dragEvents || new Vent(handle);
           handle._dragEvents.on('mousedown.DragAction', this._dragStart.bind(this));
           handle._dragEvents.on('touchstart.DragAction', this._dragStart.bind(this));
+          handle._dragEvents.on('keyup.DragAction', this._dragOnKey.bind(this));
           handle.classList.add(OPEN_HAND_CLASS);
         });
       } else {
         this._dragEvents.on('touchstart.DragAction', this._dragStart.bind(this));
         this._dragEvents.on('mousedown.DragAction', this._dragStart.bind(this));
+        this._dragEvents.on('keyup.DragAction', this._dragOnKey.bind(this));
         this._dragElement.classList.add(OPEN_HAND_CLASS);
       }
     } else {
@@ -319,6 +323,7 @@ class DragAction {
       this._handles = [];
       this._dragEvents.on('touchstart.DragAction', this._dragStart.bind(this));
       this._dragEvents.on('mousedown.DragAction', this._dragStart.bind(this));
+      this._dragEvents.on('keyup.DragAction', this._dragOnKey.bind(this));
       this._dragElement.classList.add(OPEN_HAND_CLASS);
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Jira Ticket: https://jira.corp.adobe.com/browse/SITES-2864

Fixing this issue with the following approach:

- capturing key space event 
- treating each relevant event code in order to dispatch the proper event for it
`space` key - capture the element and opens keyboard drag&drop functionality 
`arrowUp` and `arrowDown` keys - swaps the element (more exactly the draggable row) with previous or next element
`enter` key - stops the drag&drop functionality (also this is possible when losing focus from the element)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No overview regarding this.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
