### PR TITLE
fix(#244): [Masonry][Accessibility] add aria-multiselectable to parent element with role="grid"

### DIFF
--- a/coral-component-masonry/src/scripts/Masonry.js
+++ b/coral-component-masonry/src/scripts/Masonry.js
@@ -226,12 +226,18 @@ const Masonry = Decorator(class extends BaseComponent(HTMLElement) {
     this._selectionMode = validate.enumeration(selectionMode)(value) && value || selectionMode.NONE;
     this._reflectAttribute('selectionmode', this._selectionMode);
 
+    const isGrid = this.ariaGrid === ariaGrid.ON && this.parentElement;
+
     if (this._selectionMode === selectionMode.NONE) {
       this.classList.remove('is-selectable');
-      this.removeAttribute('aria-multiselectable');
+      if (isGrid) {
+        this.parentElement.removeAttribute('aria-multiselectable');
+      }
     } else {
       this.classList.add('is-selectable');
-      this.setAttribute('aria-multiselectable', this._selectionMode === selectionMode.MULTIPLE);
+      if (isGrid) {
+        this.parentElement.setAttribute('aria-multiselectable', this._selectionMode === selectionMode.MULTIPLE);
+      }
     }
 
     this._validateSelection();
@@ -543,6 +549,12 @@ const Masonry = Decorator(class extends BaseComponent(HTMLElement) {
         this._preservedParentAriaLabelledby = this.parentElement.getAttribute('aria-labelledby');
         this.parentElement.setAttribute('aria-labelledby', this.ariaLabelledby);
       }
+
+      if (this._selectionMode === selectionMode.NONE) {
+        this.parentElement.removeAttribute('aria-multiselectable');
+      } else {
+        this.parentElement.setAttribute('aria-multiselectable', this._selectionMode === selectionMode.MULTIPLE);
+      }
     } else {
       // Restore/remove role of the parent element
       if (this._preservedParentAriaRole) {
@@ -567,6 +579,9 @@ const Masonry = Decorator(class extends BaseComponent(HTMLElement) {
 
       // Remove aria-colcount
       this.parentElement.removeAttribute('aria-colcount');
+
+      // Remove aria-multiselectable
+      this.parentElement.removeAttribute('aria-multiselectable');
     }
   }
 

--- a/coral-component-masonry/src/tests/test.Masonry.js
+++ b/coral-component-masonry/src/tests/test.Masonry.js
@@ -484,11 +484,18 @@ describe('Masonry', function () {
     it('should have an aria attribute for single/multiple selection', function () {
       const el = helpers.build(new Masonry());
 
+      // aria-multiselectable should only apply when ariaGrid="on".
+      el.ariaGrid = 'on';
+      expect(el.parentElement.hasAttribute('aria-multiselectable')).to.be.false;
+
       el.selectionMode = 'single';
-      expect(el.getAttribute('aria-multiselectable')).to.equal('false');
+      expect(el.parentElement.getAttribute('aria-multiselectable')).to.equal('false');
 
       el.selectionMode = 'multiple';
-      expect(el.getAttribute('aria-multiselectable')).to.equal('true');
+      expect(el.parentElement.getAttribute('aria-multiselectable')).to.equal('true');
+
+      el.selectionMode = 'none';
+      expect(el.parentElement.hasAttribute('aria-multiselectable')).to.be.false;
     });
 
     it('should announce "checked" when item becomes selected', function(done) {


### PR DESCRIPTION
## Description
With `ariaGrid="on"`, when the `selectionMode` for `coral-masonry` is set to `"single"` or `"multiple"`, `aria-multiselectable` should be added to the `parentElement` of the `coral-masonry` element, which has `role="grid"`, rather than the `coral-masonry` element itself, which has `role="row"`.

## Related Issue
#244 

## Motivation and Context

### Steps to Reproduce
1. Open https://opensource.adobe.com/coral-spectrum/examples/#masonry example.
2. Click either of the Selection mode links labelled "single" or "multiple" to set the selection mode.
3. Use [aXe DevTools Chrome extension](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?utm_source=deque.com&utm_medium=referral&utm_campaign=axe-devtools_pricing_free) to scan page.
4. aXe reports following error: 

> [Elements must only use allowed ARIA attributes](https://dequeuniversity.com/rules/axe/4.4/aria-allowed-attr?application=AxeChrome)
> Element Location
> ```
> #example-preview #masonry
> ```
> Element Source
> ```
> <coral-masonry orderable="" id="masonry" layout="fixed-centered" columnwidth="250" aria-label="Masonry" ariagrid="on" role="row" class="_coral-Masonry is-loaded is-selectable" selectionmode="multiple" style="height: 600px;" aria-multiselectable="true">
> ```
> To solve this problem, you need to...
> 
> Fix the following:
> ARIA attribute is not allowed: aria-multiselectable="true"

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
