### PR TITLE
fix(Granite 37225): Autocomplete items containing HTML character references don't render when selected with arrow keys

### DIFF
--- a/coral-component-autocomplete/src/scripts/Autocomplete.js
+++ b/coral-component-autocomplete/src/scripts/Autocomplete.js
@@ -800,7 +800,15 @@ const Autocomplete = Decorator(class extends BaseFormField(BaseComponent(HTMLEle
 
       if (itemObj) {
         // Reflect the content in the input
-        content = itemObj.content;
+        /*
+          prefence would be first given to innerText instead of innerHtml
+          as special characters like '&' transformed as ;amp in case of innerHtml. 
+        */
+        if(itemObj.text && itemObj.text !== '') {
+          content = itemObj.text;
+        } else {
+          content = itemObj.content;
+        }
       } else {
         // Just use the provided value
         content = value;
@@ -1498,11 +1506,6 @@ const Autocomplete = Decorator(class extends BaseFormField(BaseComponent(HTMLEle
 
     if (!this.multiple) {
       this.value = selectListItem.value;
-
-      // Make sure the value is changed
-      // The setter won't run if we set the same value again
-      // This forces the DOM to update
-      this._setInputValues(this.value, selectListItem.content.textContent, false);
     } else {
       // Add to values
       this._addValue(selectListItem.value, selectListItem.content.innerHTML, true);

--- a/coral-component-autocomplete/src/scripts/Autocomplete.js
+++ b/coral-component-autocomplete/src/scripts/Autocomplete.js
@@ -804,11 +804,7 @@ const Autocomplete = Decorator(class extends BaseFormField(BaseComponent(HTMLEle
           prefence would be first given to innerText instead of innerHtml
           as special characters like '&' transformed as ;amp in case of innerHtml.
         */
-        if(itemObj.text && itemObj.text !== '') {
-          content = itemObj.text;
-        } else {
-          content = itemObj.content;
-        }
+        content = itemObj.text && itemObj.text !== '' ? itemObj.text : itemObj.content;
       } else {
         // Just use the provided value
         content = value;

--- a/coral-component-autocomplete/src/scripts/Autocomplete.js
+++ b/coral-component-autocomplete/src/scripts/Autocomplete.js
@@ -802,7 +802,7 @@ const Autocomplete = Decorator(class extends BaseFormField(BaseComponent(HTMLEle
         // Reflect the content in the input
         /*
           prefence would be first given to innerText instead of innerHtml
-          as special characters like '&' transformed as ;amp in case of innerHtml. 
+          as special characters like '&' transformed as ;amp in case of innerHtml.
         */
         if(itemObj.text && itemObj.text !== '') {
           content = itemObj.text;
@@ -1506,6 +1506,11 @@ const Autocomplete = Decorator(class extends BaseFormField(BaseComponent(HTMLEle
 
     if (!this.multiple) {
       this.value = selectListItem.value;
+
+      // Make sure the value is changed
+      // The setter won't run if we set the same value again
+      // This forces the DOM to update
+      this._setInputValues(this.value, selectListItem.content.textContent, false);
     } else {
       // Add to values
       this._addValue(selectListItem.value, selectListItem.content.innerHTML, true);


### PR DESCRIPTION
preference would be first given to innerText instead of innerHtml in case of reflectCurrentValues as special characters like '&' transformed as ;amp in case of innerHtml

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
