### PR TITLE
fix(CQ-4273759): Added aria-label to multifield add new item button

### DIFF
--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -752,7 +752,7 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     this._handleRoleList();
 
     // a11y Add aria-label to the add button to give context to screen reader users
-    $("[coral-multifield-add]").attr("aria-label","Add a new item to the options list");
+    document.querySelector('[coral-multifield-add]').setAttribute("aria-label","Add");
 
     // Assign the content zones, moving them into place in the process
     this.template = this._elements.template;

--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -752,7 +752,7 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     this._handleRoleList();
 
     // a11y Add aria-label to the add button to give context to screen reader users
-    document.querySelector('[coral-multifield-add]').setAttribute("aria-label","Add");
+    this.querySelector('[coral-multifield-add]').setAttribute("aria-label","Add");
 
     // Assign the content zones, moving them into place in the process
     this.template = this._elements.template;

--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -751,8 +751,11 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     // a11y
     this._handleRoleList();
 
-    // a11y Add aria-label to the add button to give context to screen reader users
-    this.querySelector('[coral-multifield-add]').setAttribute("aria-label","Add");
+    // a11y Add aria-label to the add button if exists to give context to screen reader users
+    const coralMultifieldAddBtn = this.querySelector('[coral-multifield-add]');
+    if (coralMultifieldAddBtn){
+      coralMultifieldAddBtn.setAttribute("aria-label","Add");
+    }
 
     // Assign the content zones, moving them into place in the process
     this.template = this._elements.template;

--- a/coral-component-multifield/src/scripts/Multifield.js
+++ b/coral-component-multifield/src/scripts/Multifield.js
@@ -751,6 +751,9 @@ const Multifield = Decorator(class extends BaseComponent(HTMLElement) {
     // a11y
     this._handleRoleList();
 
+    // a11y Add aria-label to the add button to give context to screen reader users
+    $("[coral-multifield-add]").attr("aria-label","Add a new item to the options list");
+
     // Assign the content zones, moving them into place in the process
     this.template = this._elements.template;
 


### PR DESCRIPTION
This PR is adding aria-label="Add a new item to the options list" on multifield add button as was requested by the CQ-4273759 ticket. This adds necessary context for screen reader users. @Pareesh 