### PR TITLE
fix(ASSETS-17263) - The decorative image is not hidden from screen readers

### DIFF
--- a/coral-component-shell/src/templates/user.html
+++ b/coral-component-shell/src/templates/user.html
@@ -1,5 +1,5 @@
 <div class="_coral-Shell-user-container" handle="container">
   <div class="_coral-Shell-user-image" handle="image">
-    <coral-icon icon="{{data.icon}}" class="_coral-Shell-user-avatar" size="XL" handle="avatar"></coral-icon>
+    <coral-icon icon="{{data.icon}}" class="_coral-Shell-user-avatar" aria-hidden="true" alt="" size="XL" handle="avatar"></coral-icon>
   </div>
 </div>

--- a/coral-component-shell/src/templates/user.html
+++ b/coral-component-shell/src/templates/user.html
@@ -1,5 +1,5 @@
 <div class="_coral-Shell-user-container" handle="container">
   <div class="_coral-Shell-user-image" handle="image">
-    <coral-icon icon="{{data.icon}}" class="_coral-Shell-user-avatar" aria-hidden="true" alt="" size="XL" handle="avatar"></coral-icon>
+    <coral-icon icon="{{data.icon}}" class="_coral-Shell-user-avatar" alt="" size="XL" handle="avatar"></coral-icon>
   </div>
 </div>

--- a/coral-component-shell/src/tests/test.Shell.User.js
+++ b/coral-component-shell/src/tests/test.Shell.User.js
@@ -163,6 +163,7 @@ describe('Shell.User', function () {
         var user = helpers.build('<coral-shell-user></coral-shell-user>');
         expect(user.avatar).to.equal(Shell.User.avatar.DEFAULT);
         expect(user._elements.avatar.classList.contains('_coral-Shell-user-avatar')).to.be.true;
+        expect(user._elements.avatar.hasAttribute("alt"));
       });
 
       it('should set the new avatar', function () {


### PR DESCRIPTION
added "alt" attribute on user icon

https://jira.corp.adobe.com/browse/ASSETS-17263

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
