### PR TITLE
fix(ASSETS-17347) - Text content lacks 4.5:1 contrast ratio.

### DIFF
--- a/coral-component-shell/src/styles/menubar/index.styl
+++ b/coral-component-shell/src/styles/menubar/index.styl
@@ -11,7 +11,7 @@
  */
 
 $shell-animation-time = 350ms;
-$shell-menubar-badge-background-color = rgb(235, 50, 45);
+$shell-menubar-badge-background-color = rgb(224, 50, 45);
 $shell-menubar-badge-text-color = white;
 
 coral-shell-menu {


### PR DESCRIPTION
Adjusted background colour of the notification icon so that it has the 4.5:1 ratio now with the white text

## Description
Adjusted background colour of the notification icon so that it has the 4.5:1 ratio now with the white text

## Related Issue
https://jira.corp.adobe.com/browse/ASSETS-17347

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested in my local AEM 6.6 instance

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/115532589/225856038-15af1c03-e55f-4404-8a42-179a65443d8c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
