### PR TITLE
fix(ASSETS-17241): Focus indicator is missing.

### DIFF
--- a/coral-component-calendar/src/styles/index.styl
+++ b/coral-component-calendar/src/styles/index.styl
@@ -74,3 +74,7 @@
   border-color: var(--spectrum-darkest-calendar-day-border-color-key-focus);
 }
 
+.coral--light ._coral-Calendar-date.is-selected:not(.is-range-selection) {
+    background: #326ec8;
+    color: #fff
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
https://jira.corp.adobe.com/browse/ASSETS-17241
In AEM 6.6 calendar, the background color of selected date does not have enough contrast against the white calendar background.
Added darker blue background color and white text color to selected date and increased ration to 5:1

![Screen Shot 2023-04-07 at 15 01 56](https://user-images.githubusercontent.com/74657799/230606132-6239bf1b-4842-4fec-b4d5-409c0c5f129a.jpg)


## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
