### PR TITLE
SITES-10887 Modal is closed, focus is not returned to trigger element.

### DIFF
--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -542,9 +542,11 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
   /** @ignore */
   _handleEscape(event) {
     // When escape is pressed, hide ourselves
+    const triggerButton = document.querySelector('a[title="Select another mode"]');
     if (this.interaction === interaction.ON && this.open && this._isTopOverlay()) {
       event.stopPropagation();
       this.open = false;
+      triggerButton.focus();
     }
   }
 
@@ -555,20 +557,24 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
   _handleCloseClick(event) {
     const dismissTarget = event.matchedTarget;
     const dismissValue = dismissTarget.getAttribute('coral-close');
+    const triggerButton = document.querySelector('a[title="Select another mode"]');
     if (!dismissValue || this.matches(dismissValue)) {
       this.open = false;
       event.stopPropagation();
 
       this._trackEvent('close', 'coral-dialog', event);
+      triggerButton.focus();
     }
   }
 
   _handleClick(event) {
     // When we're modal, we close when our outer area (over the backdrop) is clicked
+    const triggerButton = document.querySelector('a[title="Select another mode"]');
     if (event.target === this && this.backdrop === backdrop.MODAL && this._isTopOverlay()) {
       this.open = false;
 
       this._trackEvent('close', 'coral-dialog', event);
+      triggerButton.focus();
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
[SITES-10887](https://jira.corp.adobe.com/browse/SITES-10887)
## Description
<!--- Describe your changes in detail -->
Added focus to the trigger element when closing the modal
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
