### PR TITLE
fix(ASSETS-17252): Informative (static) content is not readable by a screen reader

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewPreview.js
+++ b/coral-component-columnview/src/scripts/ColumnViewPreview.js
@@ -96,20 +96,13 @@ const ColumnViewPreview = Decorator(class extends BaseComponent(HTMLElement) {
     let element;
     let elementLabel;
 
-    // @a11y If the previous column has selected items,
-    // do not include item values in the tab order,
-    // so that a keyboard user can quickly advance to a subsequent toolbar.
-    const tabIndex = (this.parentElement &&
-      this.parentElement.tagName === 'CORAL-COLUMNVIEW' &&
-      this.parentElement.selectedItems.length) ? -1 : 0;
-
     for (i = 0 ; i < length ; i++) {
       element = elements[i];
       elementLabel = element.previousElementSibling;
       elementLabel.id = elementLabel.id || commons.getUID();
       element.setAttribute('aria-labelledby', elementLabel.id);
       element.setAttribute('role', 'textbox');
-      element.setAttribute('tabindex', tabIndex);
+      element.setAttribute('tabindex', 0);
       element.setAttribute('aria-readonly', 'true');
 
       // force ChromeVox to read value of textbox


### PR DESCRIPTION
Allowed the ColumnViewPreview element's values to be tab-able. Previously this was prevented

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
