### PR TITLE
fix(FORMS-6979): Coral-Icon receives alt attribute value from wrapping Button title or icon attributes

### DIFF
--- a/coral-base-button/src/scripts/BaseButton.js
+++ b/coral-base-button/src/scripts/BaseButton.js
@@ -457,6 +457,11 @@ const BaseButton = (superClass) => class extends BaseLabellable(superClass) {
     // Update autoAriaLabel as well
     iconElement.autoAriaLabel = iconAutoAriaLabelValue;
 
+    // Accessibility fix
+    // If the wrapping <button> has either a "title=" or an "icon=" attribute
+    // passes the value down to the <coral-icon> as "alt="
+    (this.title || this.icon) && (iconElement.alt = this.title || this.icon);
+
     // removes the icon element from the DOM.
     if (this.icon === '') {
       iconElement.remove();


### PR DESCRIPTION
Accessibility fix for
[https://jira.corp.adobe.com/browse/FORMS-6979](url)
[https://jira.corp.adobe.com/browse/FORMS-7013](url)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Accessibility fix for <coral-icon> wrapped inside a <button> - the "title" or the "icon" attribute values of the button are passed down to the icon as "alt" attribute.

## Related Issue
Accessibility fix for
[https://jira.corp.adobe.com/browse/FORMS-6979](url)
[https://jira.corp.adobe.com/browse/FORMS-7013](url)

## Motivation and Context
Accessibility fix for
[https://jira.corp.adobe.com/browse/FORMS-6979](url)
[https://jira.corp.adobe.com/browse/FORMS-7013](url)

## How Has This Been Tested?
Manual test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
