### PR TITLE
fix(ASSETS-22047): Color picker improvement

### DIFF
--- a/coral-component-colorpicker/src/scripts/ColorPicker.js
+++ b/coral-component-colorpicker/src/scripts/ColorPicker.js
@@ -362,7 +362,7 @@ class ColorPicker extends BaseFormField(BaseComponent(HTMLElement)) {
   /**  @private */
   _onPropertyChange(event) {
     event.stopImmediatePropagation();
-    this._change(this._properties.color);
+    this._change(event.detail ? event.detail : this._properties.color);
   }
 }
 export default ColorPicker;

--- a/coral-component-colorpicker/src/scripts/ColorProperties.js
+++ b/coral-component-colorpicker/src/scripts/ColorProperties.js
@@ -206,15 +206,14 @@ class ColorProperties extends BaseComponent(HTMLElement) {
 
   /** @private */
   _onColorInputChange(event) {
-    var inputColorText = this._colorInput.value;
-    var color = new TinyColor(inputColorText);
+    let inputColorText = this._colorInput.value;
+    let color = new TinyColor(inputColorText);
     if (!color.isValid) {
       return;
     }
-    var cursorLoc = event.target.selectionStart;
+    let cursorLoc = event.target.selectionStart;
     event.stopImmediatePropagation();
     this.color = this._colorInput.value;
-    this.trigger('change');
     // trigger picker change event & send input color as event details to set it in picker input
     this.trigger('change', inputColorText);
     // restore user input color text in textfield

--- a/coral-component-colorpicker/src/scripts/ColorProperties.js
+++ b/coral-component-colorpicker/src/scripts/ColorProperties.js
@@ -207,12 +207,12 @@ class ColorProperties extends BaseComponent(HTMLElement) {
 
   /** @private */
   _onColorInputChange(event) {
-    let inputColorText = this._colorInput.value;
-    let color = new TinyColor(inputColorText);
+    const inputColorText = this._colorInput.value;
+    const color = new TinyColor(inputColorText);
     if (!color.isValid) {
       return;
     }
-    let cursorLoc = event.target.selectionStart;
+    const cursorLoc = event.target.selectionStart;
     event.stopImmediatePropagation();
     this.color = this._colorInput.value;
     // trigger picker change event & send input color as event details to set it in picker input

--- a/coral-component-colorpicker/src/scripts/ColorProperties.js
+++ b/coral-component-colorpicker/src/scripts/ColorProperties.js
@@ -35,7 +35,8 @@ class ColorProperties extends BaseComponent(HTMLElement) {
        'change [handle="propertyHue"]': '_onHueChange',
        'change [handle="propertySL"]': '_onSLChange',
        'change  [handle="formatSelector"]': '_onFormatChange',
-       'capture:change  [handle="colorInput"]': '_onColorInputChange'
+       'capture:change  [handle="colorInput"]': '_onColorInputChange',
+       'input  [handle="colorInput"]': "_onColorInputChange"
     }));
 
     // Templates
@@ -205,9 +206,21 @@ class ColorProperties extends BaseComponent(HTMLElement) {
 
   /** @private */
   _onColorInputChange(event) {
+    var inputColorText = this._colorInput.value;
+    var color = new TinyColor(inputColorText);
+    if (!color.isValid) {
+      return;
+    }
+    var cursorLoc = event.target.selectionStart;
     event.stopImmediatePropagation();
     this.color = this._colorInput.value;
     this.trigger('change');
+    // trigger picker change event & send input color as event details to set it in picker input
+    this.trigger('change', inputColorText);
+    // restore user input color text in textfield
+    this._colorInput.value = inputColorText;
+    // set cursor to last user input location
+    event.target.setSelectionRange(cursorLoc, cursorLoc);
   }
       
   /** @private */

--- a/coral-component-colorpicker/src/scripts/ColorProperties.js
+++ b/coral-component-colorpicker/src/scripts/ColorProperties.js
@@ -38,6 +38,7 @@ class ColorProperties extends BaseComponent(HTMLElement) {
        'capture:change  [handle="colorInput"]': '_onColorInputChange',
        'input  [handle="colorInput"]': "_onColorInputChange"
     }));
+    
 
     // Templates
     this._elements = {};

--- a/coral-component-colorpicker/src/tests/test.ColorProperties.js
+++ b/coral-component-colorpicker/src/tests/test.ColorProperties.js
@@ -213,7 +213,6 @@ describe('ColorPicker.ColorProperties', function () {
       el._elements.colorInput.value = "#3b3b81";
       el._elements.colorInput.trigger('change');
       validateColor(el, "#3b3b81");
-      
       });
 
     it("color text input should not change due to conversion", function() {

--- a/coral-component-colorpicker/src/tests/test.ColorProperties.js
+++ b/coral-component-colorpicker/src/tests/test.ColorProperties.js
@@ -214,6 +214,18 @@ describe('ColorPicker.ColorProperties', function () {
       el._elements.colorInput.trigger('change');
       validateColor(el, "#3b3b81");
       
+      });
+
+    it("color text input should not change due to conversion", function() {
+      el._elements.colorInput.value = "#000009";
+      el._elements.colorInput.trigger('change');
+      expect(el._elements.colorInput.value).to.equal("#000009",  "color input text should not change");
+    });
+
+    it("color text input trigger input event to change color", function() {
+      el._elements.colorInput.value = "#3b3b81";
+      el._elements.colorInput.trigger('input');
+      validateColor(el, "#3b3b81");
     });
   }); 
   


### PR DESCRIPTION
1. color text change after input due to conversion - it seem to happen due to change event [triggered](https://github.com/adobe/coral-spectrum/blob/master/coral-component-colorpicker/src/scripts/ColorProperties.js#L210) after text change. colors in coral-picker lib are stored in hsl format as color-area support hsl only & then converted back to selected format which result in text change due to rounding double values. possible solution is to not update text-field if event is triggered from text-field.
2. color area should update as input text change - currently there is only [event](https://github.com/adobe/coral-spectrum/blob/master/coral-component-colorpicker/src/scripts/ColorProperties.js#L38) for change on text-field which trigger on focus close. possible solution is add [input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) event to update color area as text change.



## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
