### PR TITLE
fix(Accessibility): Focus is not visible on dropdown elements in high contrast

### DIFF
--- a/coral-component-list/src/styles/index.styl
+++ b/coral-component-list/src/styles/index.styl
@@ -101,6 +101,14 @@
   height: var(--spectrum-medium-circleloader-medium-height);
 }
 
+@media (forced-colors: active) {
+  ._coral-Menu-item.focus-ring,
+  ._coral-Menu-item.is-focused {
+      border: 1px solid #000000;
+      box-sizing: border-box;
+    }
+}
+
 @require 'light';
 @require 'lightest';
 @require 'dark';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

https://jira.corp.adobe.com/browse/ASSETS-25759

Added border around `_coral-Menu-item`s when in focus to fix visibility when used in Windows high contrast mode
Screenshots:
![contrast_nightSky](https://github.com/adobe/coral-spectrum/assets/74657799/5e982db6-0a54-4539-a8fa-9541dbdc7fde)
![contrast_dusk](https://github.com/adobe/coral-spectrum/assets/74657799/a73c61e5-3914-48de-9ebe-d4534f18462e)
![contrast_desert](https://github.com/adobe/coral-spectrum/assets/74657799/b9bf6ac7-04ea-4a42-a1bd-8fdbdf9e5065)


## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
