### PR TITLE
fix: Tooltip should be visible when mouse hover over tooltip

### DIFF
--- a/coral-component-tooltip/src/scripts/Tooltip.js
+++ b/coral-component-tooltip/src/scripts/Tooltip.js
@@ -105,7 +105,9 @@ const Tooltip = Decorator(class extends ExtensibleOverlay {
     this._id = commons.getUID();
     this._delegateEvents({
       'coral-overlay:positioned': '_onPositioned',
-      'coral-overlay:_animate': '_onAnimate'
+      'coral-overlay:_animate': '_onAnimate',
+      'mouseenter': '_onMouseEnter',
+      'mouseleave': '_onMouseLeave'
     });
   }
 
@@ -250,6 +252,20 @@ const Tooltip = Decorator(class extends ExtensibleOverlay {
     }
   }
 
+  _onMouseEnter() {
+    if (this.interaction === this.constructor.interaction.ON && this.open) {
+      // on automatic interaction and tooltip still open and mouse enters the tooltip, cancel hide.
+      this._cancelHide();
+    }
+  }
+
+  _onMouseLeave() {
+    if (this.interaction === this.constructor.interaction.ON) {
+      // on automatic interaction and mouse leave tooltip and execute same flow when mouse leaves target.
+      this._startHide();
+    }
+  }
+
   /** @ignore */
   _handleFocusOut() {
     // The item that should have focus will get it on the next frame
@@ -306,27 +322,6 @@ const Tooltip = Decorator(class extends ExtensibleOverlay {
 
     // Use Vent to bind events on the target
     this._targetEvents = new Vent(target);
-
-    const handleEventToShow = () => {
-      // Don't let the tooltip hide
-      this._cancelHide();
-
-      if (!this.open) {
-        this._cancelShow();
-
-        if (this.delay === 0) {
-          // Show immediately
-          this.show();
-        } else {
-          this._showTimeout = window.setTimeout(() => {
-            this.show();
-          }, this.delay);
-        }
-      }
-    };
-
-    this._targetEvents.on(`mouseenter.Tooltip${this._id}`, handleEventToShow);
-    this._targetEvents.on(`focusin.Tooltip${this._id}`, handleEventToShow);
 
     this._targetEvents.on(`mouseenter.Tooltip${this._id}`, this._handleOpenTooltip.bind(this));
     this._targetEvents.on(`focusin.Tooltip${this._id}`, this._handleOpenTooltip.bind(this));


### PR DESCRIPTION
As per MDN docs : `Tooltip must stay open when the mouse moves over the tooltip itself, and should also close when the user presses the Escape key.`
The above statement is implemented. 

## Description
Added code to cancel hide when mouse enter tooltip and hide when mouse leave tooltip only when target is not focused.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
