### PR TITLE
fix: Datepicker required functionality is incorrect.

### DIFF
--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -511,10 +511,9 @@ const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLEleme
   set required(value) {
     this._required = transform.booleanAttr(value);
     this._reflectAttribute('required', this._required);
-
-    this._elements.toggle.classList.toggle('is-invalid', this._required);
-
-    this._elements.input.required = this._required;
+    // this._elements.toggle.classList.toggle('is-invalid', this._required);
+    // this._elements.input.required = this._required;
+    this._elements.input.setAttribute("aria-required", this._required);
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With required attribute, at first :invalid selector of coral-textfield triggered and showed input as red.

## Description
<!--- Describe your changes in detail -->
using aria-required attribute instead of required.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
