### PR TITLE
fix: Resources JS export

### DIFF
--- a/coral-gulp/plugins/rollup-plugin-resources.js
+++ b/coral-gulp/plugins/rollup-plugin-resources.js
@@ -43,10 +43,17 @@ function resources(opts) {
         fs.outputFile(path.join(process.cwd(), outputPath), code);
 
         // Export SVG as js file
+        const charMap = {
+          "'": "\\'",
+          '\\': '\\\\',
+          '\n': '\\n',
+          '\r': '\\r'
+        };
+        const literal = `'${code.split("").map(function(c){return charMap[c] || c}).join("")}'`;
         if (outputPath.endsWith('spectrum-icons-color.svg')) {
-          code = `document.body?document.body.insertAdjacentHTML('beforeend', '${code}'):document.addEventListener('DOMContentLoaded',function(){document.body.insertAdjacentHTML('beforeend', '${code}')})`;
+          code = `document.body?document.body.insertAdjacentHTML('beforeend', ${literal}):document.addEventListener('DOMContentLoaded',function(){document.body.insertAdjacentHTML('beforeend', ${literal})})`;
         } else {
-          code = `document.head.insertAdjacentHTML('beforeend', '${code}')`;
+          code = `document.head.insertAdjacentHTML('beforeend', ${literal})`;
         }
         fs.outputFile(path.join(process.cwd(), outputPath.replace('.svg', '.js')), code);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Escape code injected in exported resources

## Related Issue

https://github.com/adobe/coral-spectrum/issues/313

## Motivation and Context

The source of SVG injected in JS string literal was not escaped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
