### PR TITLE
fix: Add coral tabs item background color

### DIFF
--- a/coral-theme-spectrum/src/styles/vars.css
+++ b/coral-theme-spectrum/src/styles/vars.css
@@ -21779,4 +21779,5 @@
   --spectrum-gray-300: rgb(84, 84, 84);
   --spectrum-white: rgb(255, 255, 255);
   --spectrum-disabled-background-color: rgb(230, 230, 230);
+  --spectrum-coral-tabs-item-background-color: rgb(142, 142, 142)
 }


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-10906

In this PR I added a new variable that contains the right color for the background so that the issue mentioned in the ticket will not be reproduced.
In the PR mentioned below you can see the difference in the images:
https://git.corp.adobe.com/Granite/com.adobe.granite.ui.coral-spectrum/pull/167

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
