### PR TITLE
SITES-2852 Accessibility - Decorative image missing empty alt attribute

### DIFF
--- a/coral-component-columnview/src/scripts/ColumnViewItem.js
+++ b/coral-component-columnview/src/scripts/ColumnViewItem.js
@@ -418,8 +418,14 @@ const ColumnViewItem = Decorator(class extends BaseLabellable(BaseComponent(HTML
 
     // @a11y thumbnail img element should have alt attribute
     const thumbnailImg = thumbnail.querySelector('img:not([alt])');
+    const folderImg = this.thumbnail.querySelector('coral-icon[icon="folder"]');
+
     if (thumbnailImg) {
       thumbnailImg.setAttribute('alt', '');
+    }
+
+    if (folderImg) {
+      folderImg.setAttribute('alt', '');
     }
 
     // @ally add aria-labelledby so that JAWS/IE announces item correctly


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Ticket: [SITES-2852](https://jira.corp.adobe.com/browse/SITES-2852)
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
