### PR TITLE
fix: ActionBar overlay button does not work when has one child

### DIFF
--- a/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
+++ b/coral-component-actionbar/src/scripts/BaseActionBarContainer.js
@@ -185,7 +185,7 @@ const BaseActionBarContainer = (superClass) => class extends superClass {
     this._itemsInPopover.forEach((item) => {
       item.style.visibility = '';
       // Store the button and popover on the item
-      item._button = item.querySelector('button[is="coral-button"]') || item.querySelector('a[is="coral-anchorbutton"]');
+      item._button = item.querySelector(':scope > button[is="coral-button"]') || item.querySelector(':scope > a[is="coral-anchorbutton"]');
       item._popover = item.querySelector('coral-popover');
       if (item._popover) {
         item._popoverId = item._popover.id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add Rendition Button was not working when resolution is more then 1440px width when only "Add Rendition" option is in the dropdown option.
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
