### PR TITLE
fix(Accessibility) Decorative image missing empty alt attribute.

### DIFF
--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -363,6 +363,15 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
     this._fullscreen = transform.booleanAttr(value);
     this._reflectAttribute('fullscreen', this._fullscreen);
 
+    var icons = this._elements.header.querySelectorAll('coral-Icon');
+
+    icons.forEach(function (icon) {
+      if (icon.parentElement.hasAttribute("title")) {
+        icon.setAttribute("alt", icon.parentElement.title);
+        icon.parentElement.removeAttribute("title");
+      }
+    });
+
     if (this._fullscreen) {
       // Full screen and movable are not compatible
       this.movable = false;


### PR DESCRIPTION
Ticket: [SITES-2934](https://jira.corp.adobe.com/browse/SITES-2934)

Requirements changed. Had to set the alt attribute with the value of title and remove title attribute after