### PR TITLE
fix (SITES-26913): Microsoft AEMaaCS Accessibility Bug - While using Keyboard, "Adobe experience manager" link focus is not clearly visible

### DIFF
--- a/coral-component-shell/src/styles/header/index.styl
+++ b/coral-component-shell/src/styles/header/index.styl
@@ -125,6 +125,7 @@ coral-shell-header-content {
     &:focus,
     &.is-focused {
       color: $shell-homeanchor-focus-color;
+      color:red;
     }
 
     // active overrides focus

--- a/coral-component-shell/src/styles/header/index.styl
+++ b/coral-component-shell/src/styles/header/index.styl
@@ -125,7 +125,6 @@ coral-shell-header-content {
     &:focus,
     &.is-focused {
       color: $shell-homeanchor-focus-color;
-      color:red;
     }
 
     // active overrides focus

--- a/coral-component-shell/src/styles/header/index.styl
+++ b/coral-component-shell/src/styles/header/index.styl
@@ -125,7 +125,6 @@ coral-shell-header-content {
     &:focus,
     &.is-focused {
       color: $shell-homeanchor-focus-color;
-      outline: none;
     }
 
     // active overrides focus


### PR DESCRIPTION
Ticket: [SITES-26913](https://jira.corp.adobe.com/browse/SITES-26913)

<img width="532" alt="Screenshot 2024-11-25 at 11 20 20" src="https://github.com/user-attachments/assets/b0bd1ecf-2a8c-45c8-a31a-6408c1560aa5">
