### PR TITLE
fix(Accessibility) : Info alert not getting announced

### DIFF
--- a/coral-component-toast/src/scripts/Toast.js
+++ b/coral-component-toast/src/scripts/Toast.js
@@ -310,7 +310,7 @@ const Toast = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
 
     // Set the role attribute to alert or status depending on
     // the variant so that the element turns into a live region
-    this.setAttribute('role', (this.variant === variant.ERROR || this.variant === variant.WARNING || this.variant === variant.SUCCESS) ? 'alert' : 'status');
+    this.setAttribute('role', (this.variant === variant.ERROR || this.variant === variant.WARNING || this.variant === variant.SUCCESS || this.variant === variant.INFO) ? 'alert' : 'status');
     this.setAttribute('aria-live', 'polite');
   }
 

--- a/coral-component-toast/src/tests/test.Toast.js
+++ b/coral-component-toast/src/tests/test.Toast.js
@@ -176,6 +176,14 @@ describe('Toast', function () {
           done();
         });
       });
+
+      it('should have role alert when variant is info', function(done) {
+        el.variant = Toast.variant.INFO;
+        helpers.next(function() {
+          expect(el.getAttribute('role')).to.equal('alert');
+          done();
+        });
+      });
     });
 
     describe('#variant', function () {


### PR DESCRIPTION
ticket: [SITES-27143](https://jira.corp.adobe.com/browse/SITES-27143)

Changing the role to alert to make sure that screen reader announce it once it is displayed, with status it might get undetected. 