### PR TITLE
fix(accessibility): Remove heading role that contains interactive elements

### DIFF
--- a/coral-component-dialog/examples/index.html
+++ b/coral-component-dialog/examples/index.html
@@ -421,6 +421,27 @@
 
       </div>
 
+      <h2 class="coral--Heading--S">Dialog with buttons in header</h2>
+      <div class="markup">
+        <coral-dialog id="buttonsInHeader" aria-labelledby="buttonsInHeader--heading">
+          <coral-dialog-header>
+            <span id="buttonsInHeader--heading" role="heading" aria-level="2">Dialog with buttons in header</span>
+            <div class="u-coral-pullRight">
+              <button is="coral-button" icon="helpCircle" variant="quietaction" title="Help" size="M" iconautoarialabel="off"></button>
+              <button is="coral-button" icon="fullScreen" variant="quietaction" title="Toggle Fullscreen" size="M" iconautoarialabel="off"></button>
+              <button is="coral-button" icon="close" variant="quietaction" title="Cancel" size="M" iconautoarialabel="off"></button>
+              <button is="coral-button" icon="check" variant="quietaction" title="Done" size="M" iconautoarialabel="off"></button>
+            </div>
+          </coral-dialog-header>
+          <coral-dialog-content>This dialog was created from markup with child elements.</coral-dialog-content>
+          <coral-dialog-footer>
+            <button is="coral-button" coral-close>Cancel</button>
+            <button is="coral-button" variant="primary" coral-close>Done</button>
+          </coral-dialog-footer>
+        </coral-dialog>
+        <button is="coral-button" onclick="showDialog('buttonsInHeader')">Dialog with buttons in header</button>
+      </div>
+
     </main>
 
     <script>

--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -189,9 +189,6 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
       tagName: 'coral-dialog-header',
       insert: function (header) {
         header.classList.add(`${CLASSNAME}-title`);
-        // Providing the ARIA attributes to coral dialog header
-        header.setAttribute('role', 'heading');
-        header.setAttribute('aria-level', '2');
         // Position the header between the drag zone and the type icon
         this._elements.headerWrapper.insertBefore(header, this._elements.dragZone.nextElementSibling);
       },
@@ -316,6 +313,18 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
 
       // label the dialog with a reference to the header
       this.setAttribute('aria-labelledby', this.header.id);
+    }
+
+    // Provide the ARIA heading role to coral dialog header
+    // depending on whether the header contains focusable elements
+    if (hasHeader) {
+      if (this.header.querySelector(commons.FOCUSABLE_ELEMENT_SELECTOR) !== null) {
+        this.header.removeAttribute('role');
+        this.header.removeAttribute('aria-level');
+      } else if (!this.header.hasAttribute('role')) {
+        this.header.setAttribute('role', 'heading');
+        this.header.setAttribute('aria-level', '2');
+      }
     }
 
     // If the dialog has no content, or the content is empty, do nothing further.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/coral-spectrum",
-  "version": "4.18.0",
+  "version": "4.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/coral-spectrum",
-      "version": "4.18.0",
+      "version": "4.19.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Description
- Ensure that headings are not nested
- Verify that header does not contain interactive elements before adding role="heading" and aria-level="2"
- Provide example for properly labelling the dialog and providing a header when the header element contains interactive controls.

## Related Issue
SITES-27152

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
