### PR TITLE
fix: SITES-25263 Date field in Timewarp modal has aria-haspopup="dialog"

### DIFF
--- a/coral-component-datepicker/src/scripts/Datepicker.js
+++ b/coral-component-datepicker/src/scripts/Datepicker.js
@@ -607,7 +607,6 @@ const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLEleme
       // Input attributes per ARIA Autocomplete
       this._elements.input.setAttribute('role', 'combobox');
       this._elements.input.setAttribute('aria-autocomplete', 'none');
-      this._elements.input.setAttribute('aria-haspopup', 'dialog');
       this._elements.input.setAttribute('aria-expanded', this._elements.overlay.open);
       this._elements.input.setAttribute('aria-controls', this._elements.overlay.id);
 
@@ -831,7 +830,6 @@ const Datepicker = Decorator(class extends BaseFormField(BaseComponent(HTMLEleme
     // Input attributes per ARIA Autocomplete
     this._elements.input.setAttribute('role', 'combobox');
     this._elements.input.setAttribute('aria-autocomplete', 'none');
-    this._elements.input.setAttribute('aria-haspopup', 'dialog');
     this._elements.input.setAttribute('aria-expanded', 'false');
     this._elements.input.setAttribute('aria-controls', this._elements.overlay.id);
 

--- a/coral-component-datepicker/src/tests/test.Datepicker.js
+++ b/coral-component-datepicker/src/tests/test.Datepicker.js
@@ -957,7 +957,6 @@ describe('Datepicker', function () {
 
           expect(el.getAttribute('role')).to.equal('group');
           expect(el._elements.input.getAttribute('role')).to.equal('combobox');
-          expect(el._elements.input.getAttribute('aria-haspopup')).to.equal('dialog');
           expect(el._elements.input.getAttribute('aria-expanded')).to.equal('false');
           expect(el._elements.toggle.getAttribute('aria-haspopup')).to.equal('dialog');
           expect(el._elements.toggle.getAttribute('aria-expanded')).to.equal('false');


### PR DESCRIPTION
## Description
JIRA Ticket: https://jira.corp.adobe.com/browse/SITES-25263

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
