### PR TITLE
fix: SITES-24495 Button label contains state

### DIFF
--- a/coral-component-cyclebutton/src/scripts/CycleButton.js
+++ b/coral-component-cyclebutton/src/scripts/CycleButton.js
@@ -813,7 +813,6 @@ const CycleButton = Decorator(class extends BaseComponent(HTMLElement) {
     // The id reference for an HTML element that labels the button element accessibility name for the button element
     else if (name === 'aria-labelledby') {
       if (value || !this.getAttribute('aria-label')) {
-        this._elements.button.setAttribute('aria-labelledby', `${value} ${this._elements.button.id}`);
         this._elements.overlay.setAttribute('aria-labelledby', value || this._elements.button.id);
         this._elements.selectList[this._hasMenuItemRadioGroup() ? 'setAttribute' : 'removeAttribute']('aria-labelledby', value || this._elements.button.id);
       }

--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -379,6 +379,12 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
     this._fullscreen = transform.booleanAttr(value);
     this._reflectAttribute('fullscreen', this._fullscreen);
 
+    var icons = this._elements.header.querySelectorAll('coral-Icon');
+
+    icons.forEach(function (icon) {
+      icon.setAttribute("aria-hidden", true);
+    });
+
     if (this._fullscreen) {
       // Full screen and movable are not compatible
       this.movable = false;

--- a/coral-component-dialog/src/scripts/Dialog.js
+++ b/coral-component-dialog/src/scripts/Dialog.js
@@ -379,12 +379,6 @@ const Dialog = Decorator(class extends BaseOverlay(BaseComponent(HTMLElement)) {
     this._fullscreen = transform.booleanAttr(value);
     this._reflectAttribute('fullscreen', this._fullscreen);
 
-    var icons = this._elements.header.querySelectorAll('coral-Icon');
-
-    icons.forEach(function (icon) {
-      icon.setAttribute("aria-hidden", true);
-    });
-
     if (this._fullscreen) {
       // Full screen and movable are not compatible
       this.movable = false;


### PR DESCRIPTION


## Description
Information is being announced twice for the same element when focusing

## Related Issue

Ticket: https://jira.corp.adobe.com/browse/SITES-24495

## Motivation and Context
Prevent verbosity be removing duplicated information

## How Has This Been Tested?


## Screenshots (if appropriate):

Before

https://github.com/user-attachments/assets/ff58f71b-a2ef-40f2-b2ab-ca0d68d45efe

After

https://github.com/user-attachments/assets/878131d6-2b9a-464e-aca0-773f559a2ff9


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
